### PR TITLE
Rework maven settings CLI parameters

### DIFF
--- a/integration-tests/src/test/java/org/wildfly/prospero/it/cli/InstallTest.java
+++ b/integration-tests/src/test/java/org/wildfly/prospero/it/cli/InstallTest.java
@@ -37,7 +37,7 @@ public class InstallTest {
         int returnCode = commandLine.execute(CliConstants.INSTALL,
                 CliConstants.PROVISION_CONFIG, provisionConfig.getPath(),
                 CliConstants.FPL, "wildfly-core@maven(org.jboss.universe:community-universe):19.0",
-                CliConstants.CHANNEL_REPO,
+                CliConstants.REMOTE_REPOSITORIES,
                 "https://repo1.maven.org/maven2/,https://repository.jboss.org/nexus/content/groups/public-jboss",
                 CliConstants.DIR, targetDir.getAbsolutePath());
 

--- a/integration-tests/src/test/java/org/wildfly/prospero/it/commonapi/WfCoreTestBase.java
+++ b/integration-tests/src/test/java/org/wildfly/prospero/it/commonapi/WfCoreTestBase.java
@@ -34,7 +34,6 @@ import org.eclipse.aether.resolution.ArtifactResult;
 import org.junit.BeforeClass;
 
 import java.io.File;
-import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.List;
 
@@ -50,11 +49,11 @@ public class WfCoreTestBase {
     protected static Artifact resolvedUpgradeArtifact;
 
     protected final List<RemoteRepository> repositories = defaultRemoteRepositories();
-    protected MavenSessionManager mavenSessionManager = new MavenSessionManager(Paths.get(MavenSessionManager.LOCAL_MAVEN_REPO));
+    protected MavenSessionManager mavenSessionManager = new MavenSessionManager(MavenSessionManager.LOCAL_MAVEN_REPO);
 
     @BeforeClass
     public static void deployUpgrade() throws InstallationException, ArtifactResolutionException {
-        final MavenSessionManager msm = new MavenSessionManager(Paths.get(MavenSessionManager.LOCAL_MAVEN_REPO));
+        final MavenSessionManager msm = new MavenSessionManager(MavenSessionManager.LOCAL_MAVEN_REPO);
         final RepositorySystem system = msm.newRepositorySystem();
         final DefaultRepositorySystemSession session = msm.newRepositorySystemSession(system, false);
 
@@ -92,7 +91,7 @@ public class WfCoreTestBase {
     }
 
     protected Artifact resolveArtifact(String groupId, String artifactId, String version) throws ArtifactResolutionException {
-        final MavenSessionManager msm = new MavenSessionManager(Paths.get(MavenSessionManager.LOCAL_MAVEN_REPO));
+        final MavenSessionManager msm = new MavenSessionManager(MavenSessionManager.LOCAL_MAVEN_REPO);
         final RepositorySystem system = msm.newRepositorySystem();
         final DefaultRepositorySystemSession session = msm.newRepositorySystemSession(system, false);
 

--- a/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/ApplyPatchCommand.java
+++ b/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/ApplyPatchCommand.java
@@ -60,11 +60,6 @@ public class ApplyPatchCommand extends AbstractCommand {
     @Override
     public Integer call() throws Exception {
 
-        if (offline && localRepo.isEmpty()) {
-            console.error(CliMessages.MESSAGES.offlineModeRequiresLocalRepo());
-            return ReturnCodes.INVALID_ARGUMENTS;
-        }
-
         if (!Files.exists(patchArchive)) {
             console.error(CliMessages.MESSAGES.fileDoesntExist(CliConstants.PATCH_FILE, patchArchive));
             return ReturnCodes.INVALID_ARGUMENTS;

--- a/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/CliConstants.java
+++ b/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/CliConstants.java
@@ -34,6 +34,7 @@ public final class CliConstants {
     public static final String H = "-h"; // shortcut for --help
     public static final String HELP = "--help";
     public static final String LOCAL_REPO = "--local-repo";
+    public static final String NO_LOCAL_MAVEN_CACHE = "--no-resolve-local-cache";
     public static final String OFFLINE = "--offline";
     public static final String PATCH_FILE = "--patch-file";
     public static final String PROVISION_CONFIG = "--provision-config";

--- a/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/CliConstants.java
+++ b/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/CliConstants.java
@@ -26,7 +26,7 @@ public final class CliConstants {
     // Options:
 
     public static final String CHANNEL = "--channel";
-    public static final String CHANNEL_REPO = "--channel-repo";
+    public static final String REMOTE_REPOSITORIES = "--remote-repositories";
     public static final String DEFINITION = "--definition";
     public static final String DIR = "--dir";
     public static final String DRY_RUN = "--dry-run";

--- a/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/InstallCommand.java
+++ b/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/InstallCommand.java
@@ -2,7 +2,6 @@ package org.wildfly.prospero.cli.commands;
 
 import java.net.URL;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -111,13 +110,8 @@ public class InstallCommand extends AbstractCommand {
 
         if (localRepo.isPresent()) {
             if (localRepo.get().getFileName().toString().equals(DEFAULT_REPO_KEY)) {
-                localRepo = Optional.of(Paths.get(MavenSessionManager.LOCAL_MAVEN_REPO));
+                localRepo = Optional.of(MavenSessionManager.LOCAL_MAVEN_REPO);
             }
-        }
-
-        if (offline && localRepo.isEmpty()) {
-            console.error(CliMessages.MESSAGES.offlineModeRequiresLocalRepo());
-            return ReturnCodes.INVALID_ARGUMENTS;
         }
 
         try {

--- a/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/InstallCommand.java
+++ b/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/InstallCommand.java
@@ -2,6 +2,7 @@ package org.wildfly.prospero.cli.commands;
 
 import java.net.URL;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -62,8 +63,12 @@ public class InstallCommand extends AbstractCommand {
     )
     List<URL> remoteRepositories;
 
+    public static final String DEFAULT_REPO_KEY = "__LOCAL_REPO__";
+
     @CommandLine.Option(
             names = CliConstants.LOCAL_REPO,
+            arity = "0..1",
+            fallbackValue = DEFAULT_REPO_KEY,
             order = 6
     )
     Optional<Path> localRepo;
@@ -102,6 +107,12 @@ public class InstallCommand extends AbstractCommand {
         if (featurePackOrDefinition.definition.isEmpty() && isStandardFpl(featurePackOrDefinition.fpl.get()) && provisionConfig.isEmpty()) {
             console.error(CliMessages.MESSAGES.prosperoConfigMandatoryWhenCustomFpl(), CliMain.PROVISION_CONFIG_ARG);
             return ReturnCodes.INVALID_ARGUMENTS;
+        }
+
+        if (localRepo.isPresent()) {
+            if (localRepo.get().getFileName().toString().equals(DEFAULT_REPO_KEY)) {
+                localRepo = Optional.of(Paths.get(MavenSessionManager.LOCAL_MAVEN_REPO));
+            }
         }
 
         if (offline && localRepo.isEmpty()) {

--- a/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/InstallCommand.java
+++ b/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/InstallCommand.java
@@ -4,6 +4,7 @@ import java.net.URL;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import org.jboss.galleon.ProvisioningException;
 import org.jboss.logging.Logger;
@@ -54,10 +55,12 @@ public class InstallCommand extends AbstractCommand {
     Optional<String> channel;
 
     @CommandLine.Option(
-            names = CliConstants.CHANNEL_REPO,
+            names = CliConstants.REMOTE_REPOSITORIES,
+            paramLabel = "url",
+            split = ",",
             order = 5
     )
-    List<URL> channelRepositories;
+    List<URL> remoteRepositories;
 
     @CommandLine.Option(
             names = CliConstants.LOCAL_REPO,
@@ -113,8 +116,7 @@ public class InstallCommand extends AbstractCommand {
                     .setFpl(featurePackOrDefinition.fpl.orElse(null))
                     .setChannel(channel.orElse(null))
                     .setProvisionConfig(provisionConfig.orElse(null))
-                    .setChannelRepo(channelRepositories == null || channelRepositories.isEmpty() ?
-                            null : channelRepositories.get(0).toString())
+                    .setRemoteRepositories(remoteRepositories ==null?null: remoteRepositories.stream().map(URL::toString).collect(Collectors.toList()))
                     .setDefinitionFile(featurePackOrDefinition.definition.orElse(null))
                     .build();
 

--- a/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/InstallCommand.java
+++ b/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/InstallCommand.java
@@ -2,6 +2,7 @@ package org.wildfly.prospero.cli.commands;
 
 import java.net.URL;
 import java.nio.file.Path;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -17,6 +18,7 @@ import org.wildfly.prospero.cli.ActionFactory;
 import org.wildfly.prospero.cli.CliMain;
 import org.wildfly.prospero.cli.CliMessages;
 import org.wildfly.prospero.cli.ReturnCodes;
+import org.wildfly.prospero.cli.commands.options.LocalRepoOptions;
 import org.wildfly.prospero.wfchannel.MavenSessionManager;
 import picocli.CommandLine;
 
@@ -62,19 +64,12 @@ public class InstallCommand extends AbstractCommand {
     )
     List<URL> remoteRepositories;
 
-    public static final String DEFAULT_REPO_KEY = "__LOCAL_REPO__";
-
-    @CommandLine.Option(
-            names = CliConstants.LOCAL_REPO,
-            arity = "0..1",
-            fallbackValue = DEFAULT_REPO_KEY,
-            order = 6
-    )
-    Optional<Path> localRepo;
+    @CommandLine.ArgGroup(exclusive = true)
+    LocalRepoOptions localRepoOptions;
 
     @CommandLine.Option(
             names = CliConstants.OFFLINE,
-            order = 7
+            order = 8
     )
     boolean offline;
 
@@ -108,11 +103,7 @@ public class InstallCommand extends AbstractCommand {
             return ReturnCodes.INVALID_ARGUMENTS;
         }
 
-        if (localRepo.isPresent()) {
-            if (localRepo.get().getFileName().toString().equals(DEFAULT_REPO_KEY)) {
-                localRepo = Optional.of(MavenSessionManager.LOCAL_MAVEN_REPO);
-            }
-        }
+        final Optional<Path> localRepo = LocalRepoOptions.getLocalRepo(localRepoOptions);
 
         try {
             final MavenSessionManager mavenSessionManager = new MavenSessionManager(localRepo, offline);
@@ -121,7 +112,7 @@ public class InstallCommand extends AbstractCommand {
                     .setFpl(featurePackOrDefinition.fpl.orElse(null))
                     .setChannel(channel.orElse(null))
                     .setProvisionConfig(provisionConfig.orElse(null))
-                    .setRemoteRepositories(remoteRepositories ==null?null: remoteRepositories.stream().map(URL::toString).collect(Collectors.toList()))
+                    .setRemoteRepositories(remoteRepositories ==null? Collections.emptyList() : remoteRepositories.stream().map(URL::toString).collect(Collectors.toList()))
                     .setDefinitionFile(featurePackOrDefinition.definition.orElse(null))
                     .build();
 

--- a/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/RevertCommand.java
+++ b/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/RevertCommand.java
@@ -1,7 +1,6 @@
 package org.wildfly.prospero.cli.commands;
 
 import java.nio.file.Path;
-import java.util.Optional;
 
 import org.jboss.galleon.ProvisioningException;
 import org.jboss.logging.Logger;
@@ -11,6 +10,7 @@ import org.wildfly.prospero.api.SavedState;
 import org.wildfly.prospero.cli.ActionFactory;
 import org.wildfly.prospero.cli.CliMessages;
 import org.wildfly.prospero.cli.ReturnCodes;
+import org.wildfly.prospero.cli.commands.options.LocalRepoOptions;
 import org.wildfly.prospero.wfchannel.MavenSessionManager;
 import picocli.CommandLine;
 
@@ -28,8 +28,8 @@ public class RevertCommand extends AbstractCommand {
     @CommandLine.Option(names = CliConstants.REVISION, required = true)
     String revision;
 
-    @CommandLine.Option(names = CliConstants.LOCAL_REPO)
-    Optional<Path> localRepo;
+    @CommandLine.ArgGroup(exclusive = true)
+    LocalRepoOptions localRepoOptions;
 
     @CommandLine.Option(names = CliConstants.OFFLINE)
     boolean offline;
@@ -42,7 +42,7 @@ public class RevertCommand extends AbstractCommand {
     public Integer call() throws Exception {
 
         try {
-            final MavenSessionManager mavenSessionManager = new MavenSessionManager(localRepo, offline);
+            final MavenSessionManager mavenSessionManager = new MavenSessionManager(LocalRepoOptions.getLocalRepo(localRepoOptions), offline);
 
             InstallationHistoryAction historyAction = actionFactory.history(directory.toAbsolutePath(), console);
             historyAction.rollback(new SavedState(revision), mavenSessionManager);

--- a/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/RevertCommand.java
+++ b/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/RevertCommand.java
@@ -40,10 +40,6 @@ public class RevertCommand extends AbstractCommand {
 
     @Override
     public Integer call() throws Exception {
-        if (offline && localRepo.isEmpty()) {
-            console.error(CliMessages.MESSAGES.offlineModeRequiresLocalRepo());
-            return ReturnCodes.INVALID_ARGUMENTS;
-        }
 
         try {
             final MavenSessionManager mavenSessionManager = new MavenSessionManager(localRepo, offline);

--- a/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/UpdateCommand.java
+++ b/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/UpdateCommand.java
@@ -15,6 +15,7 @@ import org.wildfly.prospero.cli.ArgumentParsingException;
 import org.wildfly.prospero.cli.CliMain;
 import org.wildfly.prospero.cli.CliMessages;
 import org.wildfly.prospero.cli.ReturnCodes;
+import org.wildfly.prospero.cli.commands.options.LocalRepoOptions;
 import org.wildfly.prospero.galleon.GalleonUtils;
 import org.wildfly.prospero.wfchannel.MavenSessionManager;
 import picocli.CommandLine;
@@ -42,8 +43,8 @@ public class UpdateCommand extends AbstractCommand {
     @CommandLine.Option(names = CliConstants.SELF)
     boolean self;
 
-    @CommandLine.Option(names = CliConstants.LOCAL_REPO)
-    Optional<Path> localRepo;
+    @CommandLine.ArgGroup(exclusive = true)
+    LocalRepoOptions localRepoOptions;
 
     @CommandLine.Option(names = CliConstants.OFFLINE)
     boolean offline;
@@ -71,7 +72,7 @@ public class UpdateCommand extends AbstractCommand {
         }
 
         try {
-            final MavenSessionManager mavenSessionManager = new MavenSessionManager(localRepo, offline);
+            final MavenSessionManager mavenSessionManager = new MavenSessionManager(LocalRepoOptions.getLocalRepo(localRepoOptions), offline);
 
             final Path targetPath = directory.get().toAbsolutePath();
             UpdateAction updateAction = actionFactory.update(targetPath, mavenSessionManager, console);

--- a/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/UpdateCommand.java
+++ b/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/UpdateCommand.java
@@ -70,11 +70,6 @@ public class UpdateCommand extends AbstractCommand {
             return ReturnCodes.INVALID_ARGUMENTS;
         }
 
-        if (offline && localRepo.isEmpty()) {
-            console.error(CliMessages.MESSAGES.offlineModeRequiresLocalRepo());
-            return ReturnCodes.INVALID_ARGUMENTS;
-        }
-
         try {
             final MavenSessionManager mavenSessionManager = new MavenSessionManager(localRepo, offline);
 

--- a/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/options/LocalRepoOptions.java
+++ b/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/options/LocalRepoOptions.java
@@ -1,0 +1,49 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.prospero.cli.commands.options;
+
+import org.wildfly.prospero.cli.commands.CliConstants;
+import org.wildfly.prospero.wfchannel.MavenSessionManager;
+import picocli.CommandLine;
+
+import java.nio.file.Path;
+import java.util.Optional;
+
+public class LocalRepoOptions {
+    @CommandLine.Option(
+            names = CliConstants.LOCAL_REPO,
+            order = 6
+    )
+    Path localRepo;
+
+    @CommandLine.Option(
+            names = CliConstants.NO_LOCAL_MAVEN_CACHE,
+            order = 7
+    )
+    boolean noLocalCache;
+
+    public static Optional<Path> getLocalRepo(LocalRepoOptions localRepoParam) {
+        if (localRepoParam == null) {
+            return Optional.of(MavenSessionManager.LOCAL_MAVEN_REPO);
+        } else if (localRepoParam.noLocalCache) {
+            return Optional.empty();
+        } else {
+            return Optional.of(localRepoParam.localRepo);
+        }
+    }
+}

--- a/prospero-cli/src/main/resources/UsageMessages.properties
+++ b/prospero-cli/src/main/resources/UsageMessages.properties
@@ -28,8 +28,9 @@ dry-run = Print components that can be upgraded, but do not perform the upgrades
 fpl = Feature pack location. This can be a feature pack "GA" like "org.jboss.eap:wildfly-ee-galleon-pack", or one of \
   pre-defined feature pack names:%n  "eap", "eap-7.4", "eap-8.0", "xp", "xp-5.0".
 help = Display this help message.
-local-repo = Path to the local Maven repository. If the parameter is provided without value, it defaults to ~/.m2/repository.
-offline = Perform installation from local Maven repository only. Offline installation requires --local-repo to be configured.
+local-repo = Path to the local Maven repository. It overrides the default Maven repository at ~/.m2/repository.
+no-resolve-local-cache = Perform the operation without resolving or installing artifacts from/into local maven cache.
+offline = Perform installation from local or file-system Maven repositories only.
 provision-config = Provisioning configuration file path. This is special JSON configuration file that contains list \
   of channel file references and list of remote Maven repositories.
 revision = Hash of an installation state.

--- a/prospero-cli/src/main/resources/UsageMessages.properties
+++ b/prospero-cli/src/main/resources/UsageMessages.properties
@@ -21,7 +21,7 @@ prospero.repository.remove.usage.header = Remove a maven repository from an inst
 usage.optionListHeading = %nOptions:%n
 
 channel = Channel file URL.
-channel-repo = URL of a remote Maven repository that contains artifacts required to build an application container.
+remote-repositories = URLs of remote Maven repositories that contains the artifacts required to install the application server ( multiple URLs are separated by comma).
 definition = Galleon provisioning XML definition file path.
 dir = Target directory where the application server is going to be provisioned.
 dry-run = Print components that can be upgraded, but do not perform the upgrades.

--- a/prospero-cli/src/main/resources/UsageMessages.properties
+++ b/prospero-cli/src/main/resources/UsageMessages.properties
@@ -28,7 +28,7 @@ dry-run = Print components that can be upgraded, but do not perform the upgrades
 fpl = Feature pack location. This can be a feature pack "GA" like "org.jboss.eap:wildfly-ee-galleon-pack", or one of \
   pre-defined feature pack names:%n  "eap", "eap-7.4", "eap-8.0", "xp", "xp-5.0".
 help = Display this help message.
-local-repo = Path to a local Maven repository.
+local-repo = Path to the local Maven repository. If the parameter is provided without value, it defaults to ~/.m2/repository.
 offline = Perform installation from local Maven repository only. Offline installation requires --local-repo to be configured.
 provision-config = Provisioning configuration file path. This is a YAML configuration file that contains list \
   of channel file references and list of remote Maven repositories.

--- a/prospero-cli/src/main/resources/UsageMessages.properties
+++ b/prospero-cli/src/main/resources/UsageMessages.properties
@@ -30,7 +30,7 @@ fpl = Feature pack location. This can be a feature pack "GA" like "org.jboss.eap
 help = Display this help message.
 local-repo = Path to the local Maven repository. If the parameter is provided without value, it defaults to ~/.m2/repository.
 offline = Perform installation from local Maven repository only. Offline installation requires --local-repo to be configured.
-provision-config = Provisioning configuration file path. This is a YAML configuration file that contains list \
+provision-config = Provisioning configuration file path. This is special JSON configuration file that contains list \
   of channel file references and list of remote Maven repositories.
 revision = Hash of an installation state.
 self = Server instance to work with is determined via the JBOSS_MODULE env variable. Alternative to --dir.

--- a/prospero-cli/src/test/java/org/wildfly/prospero/cli/commands/AbstractMavenCommandTest.java
+++ b/prospero-cli/src/test/java/org/wildfly/prospero/cli/commands/AbstractMavenCommandTest.java
@@ -1,0 +1,82 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.prospero.cli.commands;
+
+import org.junit.Test;
+import org.wildfly.prospero.cli.AbstractConsoleTest;
+import org.wildfly.prospero.cli.ReturnCodes;
+import org.wildfly.prospero.wfchannel.MavenSessionManager;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public abstract class AbstractMavenCommandTest extends AbstractConsoleTest {
+
+    @Test
+    public void defaultMavenRepoIsUsedIfLocalRepoParameterNotUsed() throws Exception {
+        int exitCode = commandLine.execute(getArgs());
+
+        assertEquals(ReturnCodes.SUCCESS, exitCode);
+        MavenSessionManager msm = getCapturedSessionManager();
+        assertEquals(MavenSessionManager.LOCAL_MAVEN_REPO, msm.getProvisioningRepo());
+    }
+
+    @Test
+    public void overrideMavenRepoIfLocalRepoParameterPresent() throws Exception {
+        int exitCode = commandLine.execute(getArgs(CliConstants.LOCAL_REPO, "test-path"));
+
+        assertEquals(ReturnCodes.SUCCESS, exitCode);
+        MavenSessionManager msm = getCapturedSessionManager();
+        assertEquals(Paths.get("test-path").toAbsolutePath(), msm.getProvisioningRepo());
+    }
+
+    private String[] getArgs(String... additional) {
+        final List<String> args = new ArrayList<>();
+        args.addAll(Arrays.asList(getDefaultArguments()));
+        args.addAll(Arrays.asList(additional));
+        return args.toArray(new String[]{});
+    }
+
+    @Test
+    public void useTemporaryMavenRepoIfNoLocalCacheParameterPresent() throws Exception {
+        int exitCode = commandLine.execute(getArgs(CliConstants.NO_LOCAL_MAVEN_CACHE));
+
+        assertEquals(ReturnCodes.SUCCESS, exitCode);
+        MavenSessionManager msm = getCapturedSessionManager();
+        final Path provisioningRepo = msm.getProvisioningRepo();
+        final Path defaultTempPath = Paths.get(System.getProperty("java.io.tmpdir"));
+        assertTrue(provisioningRepo.toString(), provisioningRepo.startsWith(defaultTempPath));
+    }
+
+    @Test
+    public void noLocalCacheAndLocalRepoAreMutuallyExclusive() throws Exception {
+        int exitCode = commandLine.execute(getArgs(CliConstants.LOCAL_REPO, "test-path", CliConstants.NO_LOCAL_MAVEN_CACHE));
+
+        assertEquals(ReturnCodes.INVALID_ARGUMENTS, exitCode);
+    }
+
+    protected abstract MavenSessionManager getCapturedSessionManager() throws Exception;
+
+    protected abstract String[] getDefaultArguments();
+}

--- a/prospero-cli/src/test/java/org/wildfly/prospero/cli/commands/ApplyPatchCommandTest.java
+++ b/prospero-cli/src/test/java/org/wildfly/prospero/cli/commands/ApplyPatchCommandTest.java
@@ -54,14 +54,6 @@ public class ApplyPatchCommandTest extends AbstractConsoleTest {
     }
 
     @Test
-    public void offlineModeRequiresLocalRepoOption() {
-        int exitCode = commandLine.execute(CliConstants.APPLY_PATCH, CliConstants.DIR, "test",
-                CliConstants.PATCH_FILE, "eap", CliConstants.OFFLINE);
-        assertEquals(ReturnCodes.INVALID_ARGUMENTS, exitCode);
-        assertTrue(getErrorOutput().contains(CliMessages.MESSAGES.offlineModeRequiresLocalRepo()));
-    }
-
-    @Test
     public void callApplyPatchAction() throws Exception {
         final Path testArchive = temp.newFile().toPath();
         int exitCode = commandLine.execute(CliConstants.APPLY_PATCH, CliConstants.DIR, "test",

--- a/prospero-cli/src/test/java/org/wildfly/prospero/cli/commands/InstallCommandTest.java
+++ b/prospero-cli/src/test/java/org/wildfly/prospero/cli/commands/InstallCommandTest.java
@@ -24,6 +24,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
+import org.eclipse.aether.repository.RemoteRepository;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
@@ -46,6 +47,7 @@ import org.wildfly.prospero.model.ProsperoConfig;
 import org.wildfly.prospero.model.RepositoryRef;
 import org.wildfly.prospero.wfchannel.MavenSessionManager;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
@@ -176,5 +178,18 @@ public class InstallCommandTest extends AbstractConsoleTest {
                 CliConstants.FPL, "test");
 
         assertEquals(ReturnCodes.INVALID_ARGUMENTS, exitCode);
+    }
+
+    @Test
+    public void passChannelReposToProvisionDef() throws Exception {
+        int exitCode = commandLine.execute(CliConstants.INSTALL, CliConstants.DIR, "test",
+                CliConstants.FPL, "eap", CliConstants.REMOTE_REPOSITORIES, "http://test.repo1,http://test.repo2");
+
+        assertEquals(ReturnCodes.SUCCESS, exitCode);
+        Mockito.verify(provisionAction).provision(serverDefiniton.capture());
+        assertThat(serverDefiniton.getValue().getRepositories().stream().map(RemoteRepository::getUrl)).contains(
+                "http://test.repo1",
+                "http://test.repo2"
+        );
     }
 }

--- a/prospero-cli/src/test/java/org/wildfly/prospero/cli/commands/InstallCommandTest.java
+++ b/prospero-cli/src/test/java/org/wildfly/prospero/cli/commands/InstallCommandTest.java
@@ -92,14 +92,6 @@ public class InstallCommandTest extends AbstractConsoleTest {
     }
 
     @Test
-    public void offlineModeRequiresLocalRepoOption() {
-        int exitCode = commandLine.execute(CliConstants.INSTALL, CliConstants.DIR, "test",
-                CliConstants.FPL, "eap", CliConstants.OFFLINE);
-        assertEquals(ReturnCodes.INVALID_ARGUMENTS, exitCode);
-        assertTrue(getErrorOutput().contains(CliMessages.MESSAGES.offlineModeRequiresLocalRepo()));
-    }
-
-    @Test
     public void errorIfChannelsIsNotPresentAndUsingCustomFplOnInstall() {
         int exitCode = commandLine.execute(CliConstants.INSTALL, CliConstants.DIR, "test",
                 CliConstants.FPL, "foo:bar");

--- a/prospero-cli/src/test/java/org/wildfly/prospero/cli/commands/RevertCommandTest.java
+++ b/prospero-cli/src/test/java/org/wildfly/prospero/cli/commands/RevertCommandTest.java
@@ -15,7 +15,6 @@ import org.wildfly.prospero.actions.InstallationHistoryAction;
 import org.wildfly.prospero.api.SavedState;
 import org.wildfly.prospero.cli.AbstractConsoleTest;
 import org.wildfly.prospero.cli.ActionFactory;
-import org.wildfly.prospero.cli.CliMessages;
 import org.wildfly.prospero.cli.ReturnCodes;
 import org.wildfly.prospero.wfchannel.MavenSessionManager;
 
@@ -68,15 +67,6 @@ public class RevertCommandTest extends AbstractConsoleTest {
 
         assertEquals(ReturnCodes.SUCCESS, exitCode);
         verify(historyAction).rollback(eq(new SavedState("abcd")), any());
-    }
-
-    @Test
-    public void offlineModeRequiresLocalRepoOption() {
-        int exitCode = commandLine.execute(CliConstants.REVERT, CliConstants.DIR, "test", CliConstants.REVISION, "abcd",
-                CliConstants.OFFLINE);
-
-        assertEquals(ReturnCodes.INVALID_ARGUMENTS, exitCode);
-        assertTrue(getErrorOutput().contains(CliMessages.MESSAGES.offlineModeRequiresLocalRepo()));
     }
 
     @Test

--- a/prospero-cli/src/test/java/org/wildfly/prospero/cli/commands/RevertCommandTest.java
+++ b/prospero-cli/src/test/java/org/wildfly/prospero/cli/commands/RevertCommandTest.java
@@ -1,7 +1,6 @@
 package org.wildfly.prospero.cli.commands;
 
 import java.nio.file.Path;
-import java.nio.file.Paths;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -13,7 +12,6 @@ import org.mockito.junit.MockitoJUnitRunner;
 import org.wildfly.prospero.actions.Console;
 import org.wildfly.prospero.actions.InstallationHistoryAction;
 import org.wildfly.prospero.api.SavedState;
-import org.wildfly.prospero.cli.AbstractConsoleTest;
 import org.wildfly.prospero.cli.ActionFactory;
 import org.wildfly.prospero.cli.ReturnCodes;
 import org.wildfly.prospero.wfchannel.MavenSessionManager;
@@ -25,7 +23,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 
 @RunWith(MockitoJUnitRunner.class)
-public class RevertCommandTest extends AbstractConsoleTest {
+public class RevertCommandTest extends AbstractMavenCommandTest {
 
     @Mock
     private InstallationHistoryAction historyAction;
@@ -79,13 +77,14 @@ public class RevertCommandTest extends AbstractConsoleTest {
         assertTrue(mavenSessionManager.getValue().isOffline());
     }
 
-    @Test
-    public void useLocalMavenRepoIfParameterSet() throws Exception {
-        int exitCode = commandLine.execute(CliConstants.REVERT, CliConstants.DIR, "test", CliConstants.REVISION, "abcd",
-                CliConstants.LOCAL_REPO, "local-repo");
-
-        assertEquals(ReturnCodes.SUCCESS, exitCode);
+    @Override
+    protected MavenSessionManager getCapturedSessionManager() throws Exception {
         verify(historyAction).rollback(eq(new SavedState("abcd")), mavenSessionManager.capture());
-        assertEquals(Paths.get("local-repo").toAbsolutePath(), mavenSessionManager.getValue().getProvisioningRepo());
+        return mavenSessionManager.getValue();
+    }
+
+    @Override
+    protected String[] getDefaultArguments() {
+        return new String[]{CliConstants.REVERT, CliConstants.DIR, "test", CliConstants.REVISION, "abcd"};
     }
 }

--- a/prospero-cli/src/test/java/org/wildfly/prospero/cli/commands/UpdateCommandTest.java
+++ b/prospero-cli/src/test/java/org/wildfly/prospero/cli/commands/UpdateCommandTest.java
@@ -151,16 +151,6 @@ public class UpdateCommandTest extends AbstractConsoleTest {
                 CliMessages.MESSAGES.unexpectedPackageInSelfUpdate(baseDir.toAbsolutePath().toString())));
     }
 
-    @Test
-    public void offlineModeRequiresLocalRepoOption() throws Exception {
-        final Path baseDir = mockGalleonInstallation(A_PROSPERO_FP);
-        int exitCode = commandLine.execute(CliConstants.UPDATE, CliConstants.SELF,
-                CliConstants.DIR, baseDir.toAbsolutePath().toString(), CliConstants.OFFLINE);
-
-        assertEquals(ReturnCodes.INVALID_ARGUMENTS, exitCode);
-        assertTrue(getErrorOutput().contains(CliMessages.MESSAGES.offlineModeRequiresLocalRepo()));
-    }
-
     private Path mockGalleonInstallation(String... fps) throws IOException, javax.xml.stream.XMLStreamException {
         final ProvisionedState.Builder builder = ProvisionedState.builder();
         for (String fp : fps) {

--- a/prospero-cli/src/test/java/org/wildfly/prospero/cli/commands/options/LocalRepoOptionsTest.java
+++ b/prospero-cli/src/test/java/org/wildfly/prospero/cli/commands/options/LocalRepoOptionsTest.java
@@ -1,0 +1,34 @@
+package org.wildfly.prospero.cli.commands.options;
+
+import org.junit.Test;
+import org.wildfly.prospero.wfchannel.MavenSessionManager;
+
+import java.nio.file.Paths;
+import java.util.Optional;
+
+import static org.junit.Assert.assertEquals;
+
+public class LocalRepoOptionsTest {
+
+    @Test
+    public void defaultLocalPathIfNoOptionsSpecified() throws Exception {
+        assertEquals(Optional.of(MavenSessionManager.LOCAL_MAVEN_REPO), LocalRepoOptions.getLocalRepo(null));
+    }
+
+    @Test
+    public void emptyLocalPathIfNoLocalCacheSpecified() throws Exception {
+        final LocalRepoOptions localRepoParam = new LocalRepoOptions();
+        localRepoParam.noLocalCache = true;
+
+        assertEquals(Optional.empty(), LocalRepoOptions.getLocalRepo(localRepoParam));
+    }
+
+    @Test
+    public void customLocalPathIfLocalRepoSpecified() throws Exception {
+        final LocalRepoOptions localRepoParam = new LocalRepoOptions();
+        localRepoParam.localRepo = Paths.get("test");
+
+        assertEquals(Optional.of(Paths.get("test")), LocalRepoOptions.getLocalRepo(localRepoParam));
+    }
+
+}

--- a/prospero-common/src/main/java/org/wildfly/prospero/api/ProvisioningDefinition.java
+++ b/prospero-common/src/main/java/org/wildfly/prospero/api/ProvisioningDefinition.java
@@ -168,11 +168,7 @@ public class ProvisioningDefinition {
         }
 
         public Builder setRemoteRepositories(List<String> remoteRepositories) {
-            if (remoteRepositories == null) {
-                this.remoteRepositories = Collections.emptyList();
-            } else {
-                this.remoteRepositories = remoteRepositories;
-            }
+            this.remoteRepositories = remoteRepositories;
             return this;
         }
 

--- a/prospero-common/src/main/java/org/wildfly/prospero/wfchannel/MavenSessionManager.java
+++ b/prospero-common/src/main/java/org/wildfly/prospero/wfchannel/MavenSessionManager.java
@@ -45,7 +45,7 @@ public class MavenSessionManager {
 
     private static final Logger logger = Logger.getLogger(MavenSessionManager.class);
 
-    public static String LOCAL_MAVEN_REPO = System.getProperty("user.home") + "/.m2/repository";
+    public static final String LOCAL_MAVEN_REPO = System.getProperty("user.home") + "/.m2/repository";
     private final Path provisioningRepo;
     private boolean offline;
 

--- a/prospero-common/src/test/java/org/wildfly/prospero/api/ProvisioningDefinitionTest.java
+++ b/prospero-common/src/test/java/org/wildfly/prospero/api/ProvisioningDefinitionTest.java
@@ -1,9 +1,12 @@
 package org.wildfly.prospero.api;
 
+import org.eclipse.aether.repository.RemoteRepository;
 import org.junit.Test;
 
 import java.nio.file.Paths;
+import java.util.Arrays;
 
+import static org.assertj.core.api.Assertions.*;
 import static org.junit.Assert.*;
 
 public class ProvisioningDefinitionTest {
@@ -33,5 +36,19 @@ public class ProvisioningDefinitionTest {
         builder.setChannel("tmp/foo.bar");
 
         assertEquals("file:" + Paths.get("tmp/foo.bar").toAbsolutePath(), builder.build().getChannelRefs().get(0).getUrl());
+    }
+
+    @Test
+    public void overrideRemoteRepos() throws Exception {
+        final ProvisioningDefinition.Builder builder = new ProvisioningDefinition.Builder()
+                .setFpl("eap")
+                .setRemoteRepositories(Arrays.asList("http://test.repo1", "http://test.repo2"));
+
+        final ProvisioningDefinition def = builder.build();
+
+        assertThat(def.getRepositories().stream().map(RemoteRepository::getUrl)).containsExactlyInAnyOrder(
+                "http://test.repo1",
+                "http://test.repo2"
+        );
     }
 }

--- a/prospero-common/src/test/java/org/wildfly/prospero/api/ProvisioningDefinitionTest.java
+++ b/prospero-common/src/test/java/org/wildfly/prospero/api/ProvisioningDefinitionTest.java
@@ -6,8 +6,8 @@ import org.junit.Test;
 import java.nio.file.Paths;
 import java.util.Arrays;
 
-import static org.assertj.core.api.Assertions.*;
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
 
 public class ProvisioningDefinitionTest {
 


### PR DESCRIPTION
Fixes #94 and #95

* rename channel-repo->remote-repositories
* allow multiple values for remote-repositories
* default local-repo to ~/.m2/repository (if specified without value)
* in offline mode allow resolving artifacts from file-system maven reposistoried