### PR TITLE
Make --dir command optional, assume "." default value

### DIFF
--- a/prospero-cli/src/main/java/org/wildfly/prospero/cli/CliMain.java
+++ b/prospero-cli/src/main/java/org/wildfly/prospero/cli/CliMain.java
@@ -34,11 +34,9 @@ import picocli.CommandLine;
 
 public class CliMain {
 
-
     static {
         enableJBossLogManager();
     }
-
 
     private static void enableJBossLogManager() {
         if (System.getProperty("java.util.logging.manager") == null) {
@@ -47,9 +45,6 @@ public class CliMain {
     }
 
     private static final Logger logger = Logger.getLogger(CliMain.class);
-
-    public static final String TARGET_PATH_ARG = "dir";
-    public static final String PROVISION_CONFIG_ARG = "provision-config";
 
     public static void main(String[] args) {
         try {
@@ -85,6 +80,7 @@ public class CliMain {
 
         commandLine.setHelpFactory(new CustomHelp.CustomHelpFactory());
         commandLine.setUsageHelpAutoWidth(true);
+        commandLine.setExecutionExceptionHandler(new ExecutionExceptionHandler(console));
 
         return commandLine;
     }

--- a/prospero-cli/src/main/java/org/wildfly/prospero/cli/CliMessages.java
+++ b/prospero-cli/src/main/java/org/wildfly/prospero/cli/CliMessages.java
@@ -94,13 +94,10 @@ public interface CliMessages {
     String unexpectedPackageInSelfUpdate(String path);
 
     @Message("Unable to locate the installation folder to perform self-update.")
-    String unableToLocateInstallation();
+    String unableToLocateProsperoInstallation();
 
     @Message("Unable to perform self-update - unable to determine installed feature packs.")
     String unableToParseSelfUpdateData();
-
-    @Message("Using offline mode requires a local-repo parameter present.")
-    String offlineModeRequiresLocalRepo();
 
     @Message("Provisioning config argument (" + CliConstants.PROVISION_CONFIG + ") need to be set when using custom fpl")
     String prosperoConfigMandatoryWhenCustomFpl();
@@ -125,4 +122,7 @@ public interface CliMessages {
 
     @Message("File referenced by [%s] doesn't exist: %s")
     String fileDoesntExist(String optionName, Path patchArchive);
+
+    @Message("Path `%s` does not contain a server installation provisioned by prospero.")
+    IllegalArgumentException invalidInstallationDir(Path path);
 }

--- a/prospero-cli/src/main/java/org/wildfly/prospero/cli/ExecutionExceptionHandler.java
+++ b/prospero-cli/src/main/java/org/wildfly/prospero/cli/ExecutionExceptionHandler.java
@@ -1,0 +1,39 @@
+package org.wildfly.prospero.cli;
+
+import org.jboss.galleon.ProvisioningException;
+import org.jboss.logging.Logger;
+import org.wildfly.prospero.actions.Console;
+import org.wildfly.prospero.api.exceptions.OperationException;
+import org.wildfly.prospero.cli.commands.CliConstants;
+import picocli.CommandLine;
+
+/**
+ * Handles exceptions that happen during command executions.
+ */
+public class ExecutionExceptionHandler implements CommandLine.IExecutionExceptionHandler {
+
+    private final Logger logger = Logger.getLogger(this.getClass());
+    private final Console console;
+
+    public ExecutionExceptionHandler(Console console) {
+        this.console = console;
+    }
+
+    @Override
+    public int handleExecutionException(Exception ex, CommandLine commandLine, CommandLine.ParseResult parseResult)
+            throws Exception {
+        if (ex instanceof IllegalArgumentException || ex instanceof ArgumentParsingException) {
+            // used to indicate invalid arguments
+            console.error(ex.getMessage());
+            return ReturnCodes.INVALID_ARGUMENTS;
+        } else if (ex instanceof ProvisioningException || ex instanceof OperationException) {
+            // provisioning error
+            console.error(CliMessages.MESSAGES.errorWhileExecutingOperation(CliConstants.REVERT, ex.getMessage()));
+            logger.error(CliMessages.MESSAGES.errorWhileExecutingOperation(CliConstants.INSTALL, ex.getMessage()), ex);
+            return ReturnCodes.PROCESSING_ERROR;
+        }
+
+        // re-throw other exceptions
+        throw ex;
+    }
+}

--- a/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/AbstractCommand.java
+++ b/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/AbstractCommand.java
@@ -1,9 +1,15 @@
 package org.wildfly.prospero.cli.commands;
 
+import java.io.File;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Optional;
 import java.util.concurrent.Callable;
 
 import org.wildfly.prospero.actions.Console;
+import org.wildfly.prospero.api.InstallationMetadata;
 import org.wildfly.prospero.cli.ActionFactory;
+import org.wildfly.prospero.cli.CliMessages;
 import picocli.CommandLine;
 
 public abstract class AbstractCommand implements Callable<Integer> {
@@ -23,4 +29,24 @@ public abstract class AbstractCommand implements Callable<Integer> {
         this.console = console;
         this.actionFactory = actionFactory;
     }
+
+    static Path determineInstallationDirectory(Optional<Path> directoryOption) {
+        Path installationDirectory = directoryOption.orElse(currentDir()).toAbsolutePath();
+        verifyInstallationDirectory(installationDirectory);
+        return installationDirectory;
+    }
+
+    static void verifyInstallationDirectory(Path path) {
+        File dotGalleonDir = path.resolve(InstallationMetadata.GALLEON_INSTALLATION_DIR).toFile();
+        File prosperoConfigFile = path.resolve(InstallationMetadata.METADATA_DIR)
+                .resolve(InstallationMetadata.PROSPERO_CONFIG_FILE_NAME).toFile();
+        if (!dotGalleonDir.isDirectory() || !prosperoConfigFile.isFile()) {
+            throw CliMessages.MESSAGES.invalidInstallationDir(path);
+        }
+    }
+
+    static Path currentDir() {
+        return Paths.get(".").toAbsolutePath();
+    }
+
 }

--- a/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/ApplyPatchCommand.java
+++ b/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/ApplyPatchCommand.java
@@ -35,8 +35,8 @@ import java.util.Optional;
 )
 public class ApplyPatchCommand extends AbstractCommand {
 
-    @CommandLine.Option(names = CliConstants.DIR, required = true, order = 1)
-    Path directory;
+    @CommandLine.Option(names = CliConstants.DIR, order = 1)
+    Optional<Path> directory;
 
     @CommandLine.Option(names = CliConstants.PATCH_FILE, required = true, order = 2)
     Path patchArchive;
@@ -59,6 +59,7 @@ public class ApplyPatchCommand extends AbstractCommand {
 
     @Override
     public Integer call() throws Exception {
+        Path installationDirectory = determineInstallationDirectory(directory);
 
         if (!Files.exists(patchArchive)) {
             console.error(CliMessages.MESSAGES.fileDoesntExist(CliConstants.PATCH_FILE, patchArchive));
@@ -67,7 +68,7 @@ public class ApplyPatchCommand extends AbstractCommand {
 
         final MavenSessionManager mavenSessionManager = new MavenSessionManager(localRepo, offline);
 
-        final ApplyPatchAction applyPatchAction = actionFactory.applyPatch(directory, mavenSessionManager, console);
+        final ApplyPatchAction applyPatchAction = actionFactory.applyPatch(installationDirectory, mavenSessionManager, console);
         applyPatchAction.apply(patchArchive);
 
         return ReturnCodes.SUCCESS;

--- a/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/HistoryCommand.java
+++ b/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/HistoryCommand.java
@@ -19,8 +19,8 @@ import picocli.CommandLine;
 )
 public class HistoryCommand extends AbstractCommand {
 
-    @CommandLine.Option(names = CliConstants.DIR, required = true)
-    Path directory;
+    @CommandLine.Option(names = CliConstants.DIR)
+    Optional<Path> directory;
 
     @CommandLine.Option(names = CliConstants.REVISION)
     Optional<String> revision;
@@ -31,7 +31,8 @@ public class HistoryCommand extends AbstractCommand {
 
     @Override
     public Integer call() throws Exception {
-        InstallationHistoryAction historyAction = actionFactory.history(directory.toAbsolutePath(), console);
+        Path installationDirectory = determineInstallationDirectory(directory);
+        InstallationHistoryAction historyAction = actionFactory.history(installationDirectory, console);
 
         if (revision.isEmpty()) {
             List<SavedState> revisions = historyAction.getRevisions();

--- a/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/RepositoryAddCommand.java
+++ b/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/RepositoryAddCommand.java
@@ -2,6 +2,7 @@ package org.wildfly.prospero.cli.commands;
 
 import java.net.URL;
 import java.nio.file.Path;
+import java.util.Optional;
 
 import org.wildfly.prospero.actions.Console;
 import org.wildfly.prospero.actions.MetadataAction;
@@ -19,8 +20,8 @@ public class RepositoryAddCommand extends AbstractCommand {
     @CommandLine.Parameters(index = "1")
     URL url;
 
-    @CommandLine.Option(names = CliConstants.DIR, required = true)
-    Path directory;
+    @CommandLine.Option(names = CliConstants.DIR)
+    Optional<Path> directory;
 
     public RepositoryAddCommand(Console console, ActionFactory actionFactory) {
         super(console, actionFactory);
@@ -28,14 +29,10 @@ public class RepositoryAddCommand extends AbstractCommand {
 
     @Override
     public Integer call() throws Exception {
-        try {
-            MetadataAction metadataAction = actionFactory.metadataActions(directory);
-            metadataAction.addRepository(repoId, url);
-            console.println(CliMessages.MESSAGES.repositoryAdded(repoId));
-            return ReturnCodes.SUCCESS;
-        } catch (IllegalArgumentException e) {
-            console.error(e.getMessage());
-            return ReturnCodes.INVALID_ARGUMENTS;
-        }
+        Path installationDirectory = determineInstallationDirectory(directory);
+        MetadataAction metadataAction = actionFactory.metadataActions(installationDirectory);
+        metadataAction.addRepository(repoId, url);
+        console.println(CliMessages.MESSAGES.repositoryAdded(repoId));
+        return ReturnCodes.SUCCESS;
     }
 }

--- a/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/RepositoryListCommand.java
+++ b/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/RepositoryListCommand.java
@@ -2,6 +2,7 @@ package org.wildfly.prospero.cli.commands;
 
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Optional;
 
 import org.apache.commons.lang3.StringUtils;
 import org.wildfly.prospero.actions.Console;
@@ -14,8 +15,8 @@ import picocli.CommandLine;
 @CommandLine.Command(name = CliConstants.LIST)
 public class RepositoryListCommand extends AbstractCommand {
 
-    @CommandLine.Option(names = CliConstants.DIR, required = true)
-    Path directory;
+    @CommandLine.Option(names = CliConstants.DIR)
+    Optional<Path> directory;
 
     public RepositoryListCommand(Console console, ActionFactory actionFactory) {
         super(console, actionFactory);
@@ -23,7 +24,8 @@ public class RepositoryListCommand extends AbstractCommand {
 
     @Override
     public Integer call() throws Exception {
-        MetadataAction metadataAction = actionFactory.metadataActions(directory);
+        Path installationDirectory = determineInstallationDirectory(directory);
+        MetadataAction metadataAction = actionFactory.metadataActions(installationDirectory);
         List<RepositoryRef> repositories = metadataAction.getRepositories();
 
         // calculate maximum length of repository id strings, to make the list nicely alligned

--- a/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/RepositoryRemoveCommand.java
+++ b/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/RepositoryRemoveCommand.java
@@ -1,6 +1,7 @@
 package org.wildfly.prospero.cli.commands;
 
 import java.nio.file.Path;
+import java.util.Optional;
 
 import org.wildfly.prospero.actions.Console;
 import org.wildfly.prospero.actions.MetadataAction;
@@ -15,8 +16,8 @@ public class RepositoryRemoveCommand extends AbstractCommand {
     @CommandLine.Parameters(index = "0")
     String repoId;
 
-    @CommandLine.Option(names = CliConstants.DIR, required = true)
-    Path directory;
+    @CommandLine.Option(names = CliConstants.DIR)
+    Optional<Path> directory;
 
     public RepositoryRemoveCommand(Console console, ActionFactory actionFactory) {
         super(console, actionFactory);
@@ -24,14 +25,10 @@ public class RepositoryRemoveCommand extends AbstractCommand {
 
     @Override
     public Integer call() throws Exception {
-        try {
-            MetadataAction metadataAction = actionFactory.metadataActions(directory);
-            metadataAction.removeRepository(repoId);
-            console.println(CliMessages.MESSAGES.repositoryRemoved(repoId));
-            return ReturnCodes.SUCCESS;
-        } catch (IllegalArgumentException e) {
-            console.error(e.getMessage());
-            return ReturnCodes.INVALID_ARGUMENTS;
-        }
+        Path installationDirectory = determineInstallationDirectory(directory);
+        MetadataAction metadataAction = actionFactory.metadataActions(installationDirectory);
+        metadataAction.removeRepository(repoId);
+        console.println(CliMessages.MESSAGES.repositoryRemoved(repoId));
+        return ReturnCodes.SUCCESS;
     }
 }

--- a/prospero-cli/src/test/java/org/wildfly/prospero/cli/commands/ApplyPatchCommandTest.java
+++ b/prospero-cli/src/test/java/org/wildfly/prospero/cli/commands/ApplyPatchCommandTest.java
@@ -1,5 +1,6 @@
 package org.wildfly.prospero.cli.commands;
 
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -13,6 +14,7 @@ import org.wildfly.prospero.cli.AbstractConsoleTest;
 import org.wildfly.prospero.cli.ActionFactory;
 import org.wildfly.prospero.cli.CliMessages;
 import org.wildfly.prospero.cli.ReturnCodes;
+import org.wildfly.prospero.test.MetadataTestUtils;
 import org.wildfly.prospero.wfchannel.MavenSessionManager;
 
 import java.nio.file.Path;
@@ -29,6 +31,8 @@ public class ApplyPatchCommandTest extends AbstractConsoleTest {
     @Rule
     public TemporaryFolder temp = new TemporaryFolder();
 
+    private Path installationDir;
+
     @Override
     protected ActionFactory createActionFactory() {
         return new ActionFactory() {
@@ -39,15 +43,24 @@ public class ApplyPatchCommandTest extends AbstractConsoleTest {
         };
     }
 
-    @Test
-    public void requireDirFolder() throws Exception {
-        int exitCode = commandLine.execute(CliConstants.APPLY_PATCH, CliConstants.PATCH_FILE, "foo");
-        assertEquals(ReturnCodes.INVALID_ARGUMENTS, exitCode);
-        assertTrue(getErrorOutput().contains(String.format("Missing required option: '%s=<directory>'", CliConstants.DIR)));
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        installationDir = temp.newFolder().toPath();
+        MetadataTestUtils.createInstallationMetadata(installationDir);
+        MetadataTestUtils.createGalleonProvisionedState(installationDir);
     }
 
     @Test
-    public void requirePatchFile() throws Exception {
+    public void invalidInstallationDir() {
+        int exitCode = commandLine.execute(CliConstants.APPLY_PATCH, CliConstants.PATCH_FILE, "foo");
+        assertEquals(ReturnCodes.INVALID_ARGUMENTS, exitCode);
+        assertTrue(getErrorOutput().contains(CliMessages.MESSAGES.invalidInstallationDir(ApplyPatchCommand.currentDir())
+                .getMessage()));
+    }
+
+    @Test
+    public void requirePatchFile() {
         int exitCode = commandLine.execute(CliConstants.APPLY_PATCH, CliConstants.DIR, "foo");
         assertEquals(ReturnCodes.INVALID_ARGUMENTS, exitCode);
         assertTrue(getErrorOutput().contains(String.format("Missing required option: '%s=<patchArchive>'", CliConstants.PATCH_FILE)));
@@ -56,15 +69,15 @@ public class ApplyPatchCommandTest extends AbstractConsoleTest {
     @Test
     public void callApplyPatchAction() throws Exception {
         final Path testArchive = temp.newFile().toPath();
-        int exitCode = commandLine.execute(CliConstants.APPLY_PATCH, CliConstants.DIR, "test",
+        int exitCode = commandLine.execute(CliConstants.APPLY_PATCH, CliConstants.DIR, installationDir.toString(),
                 CliConstants.PATCH_FILE, testArchive.toString());
         Mockito.verify(applyPatchAction).apply(testArchive);
         assertEquals(ReturnCodes.SUCCESS, exitCode);
     }
 
     @Test
-    public void dontAllowNonExistingPatchFile() throws Exception {
-        int exitCode = commandLine.execute(CliConstants.APPLY_PATCH, CliConstants.DIR, "test",
+    public void dontAllowNonExistingPatchFile() {
+        int exitCode = commandLine.execute(CliConstants.APPLY_PATCH, CliConstants.DIR, installationDir.toString(),
                 CliConstants.PATCH_FILE, "doesnt-exist.zip");
         assertEquals(ReturnCodes.INVALID_ARGUMENTS, exitCode);
         assertTrue(getErrorOutput().contains(CliMessages.MESSAGES.fileDoesntExist(CliConstants.PATCH_FILE, Paths.get("doesnt-exist.zip"))));

--- a/prospero-cli/src/test/java/org/wildfly/prospero/cli/commands/RepositoryCommandTest.java
+++ b/prospero-cli/src/test/java/org/wildfly/prospero/cli/commands/RepositoryCommandTest.java
@@ -15,19 +15,22 @@
  * limitations under the License.
  */
 
-package org.wildfly.prospero.cli;
+package org.wildfly.prospero.cli.commands;
 
 import java.nio.file.Path;
 import java.util.Collections;
 
 import org.eclipse.aether.repository.RemoteRepository;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.wildfly.prospero.api.InstallationMetadata;
 import org.wildfly.prospero.api.exceptions.MetadataException;
-import org.wildfly.prospero.cli.commands.CliConstants;
+import org.wildfly.prospero.cli.AbstractConsoleTest;
+import org.wildfly.prospero.cli.CliMessages;
+import org.wildfly.prospero.cli.ReturnCodes;
 import org.wildfly.prospero.model.RepositoryRef;
 import org.wildfly.prospero.test.MetadataTestUtils;
 
@@ -52,15 +55,34 @@ public class RepositoryCommandTest extends AbstractConsoleTest {
         this.dir = tempDir.newFolder().toPath();
         RemoteRepository repo = new RemoteRepository.Builder(REPO_ID, "default", REPO_URL).build();
         MetadataTestUtils.createInstallationMetadata(dir, Collections.emptyList(), Collections.singletonList(repo));
+        MetadataTestUtils.createGalleonProvisionedState(dir);
     }
 
     @Test
-    public void testListDirRequired() {
+    public void testListInvalidInstallationDir() {
         int exitCode = commandLine.execute(CliConstants.REPO, CliConstants.LIST);
 
-        assertEquals(ReturnCodes.INVALID_ARGUMENTS, exitCode);
-        assertTrue(getErrorOutput().contains(String.format("Missing required option: '%s=<directory>'",
-                CliConstants.DIR)));
+        Assert.assertEquals(ReturnCodes.INVALID_ARGUMENTS, exitCode);
+        assertTrue(getErrorOutput().contains(CliMessages.MESSAGES.invalidInstallationDir(RepositoryListCommand.currentDir())
+                .getMessage()));
+    }
+
+    @Test
+    public void testAddInvalidInstallationDir() {
+        int exitCode = commandLine.execute(CliConstants.REPO, CliConstants.ADD, "repo2", "file:/tmp/repo2");
+
+        Assert.assertEquals(ReturnCodes.INVALID_ARGUMENTS, exitCode);
+        assertTrue(getErrorOutput().contains(CliMessages.MESSAGES.invalidInstallationDir(RepositoryListCommand.currentDir())
+                .getMessage()));
+    }
+
+    @Test
+    public void testRemoveInvalidInstallationDir() {
+        int exitCode = commandLine.execute(CliConstants.REPO, CliConstants.REMOVE, REPO_ID);
+
+        Assert.assertEquals(ReturnCodes.INVALID_ARGUMENTS, exitCode);
+        assertTrue(getErrorOutput().contains(CliMessages.MESSAGES.invalidInstallationDir(RepositoryListCommand.currentDir())
+                .getMessage()));
     }
 
     @Test

--- a/prospero-common/src/main/java/org/wildfly/prospero/test/MetadataTestUtils.java
+++ b/prospero-common/src/main/java/org/wildfly/prospero/test/MetadataTestUtils.java
@@ -12,8 +12,15 @@ import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import javax.xml.stream.XMLStreamException;
+
 import org.apache.commons.io.FileUtils;
 import org.eclipse.aether.repository.RemoteRepository;
+import org.jboss.galleon.Constants;
+import org.jboss.galleon.state.ProvisionedFeaturePack;
+import org.jboss.galleon.state.ProvisionedState;
+import org.jboss.galleon.universe.FeaturePackLocation;
+import org.jboss.galleon.xml.ProvisionedStateXmlWriter;
 import org.wildfly.channel.Channel;
 import org.wildfly.channel.Stream;
 import org.wildfly.prospero.api.InstallationMetadata;
@@ -51,6 +58,18 @@ public final class MetadataTestUtils {
         final InstallationMetadata metadata = new InstallationMetadata(installation, manifest, channels, repositories);
         metadata.writeFiles();
         return metadata;
+    }
+
+    public static ProvisionedState createGalleonProvisionedState(Path installation, String... featurePacks)
+            throws XMLStreamException, IOException {
+        final ProvisionedState.Builder builder = ProvisionedState.builder();
+        for (String fp : featurePacks) {
+            builder.addFeaturePack(ProvisionedFeaturePack.builder(FeaturePackLocation.fromString(fp).getFPID()).build());
+        }
+        ProvisionedState state = builder.build();
+        ProvisionedStateXmlWriter.getInstance().write(state,
+                installation.resolve(Constants.PROVISIONED_STATE_DIR).resolve(Constants.PROVISIONED_STATE_XML));
+        return state;
     }
 
     public static URL prepareProvisionConfigAsUrl(String channelDescriptor) throws IOException {


### PR DESCRIPTION
Resolves https://github.com/wildfly-extras/prospero/issues/87.

The `install` command remains as it was - `--dir` is mandatory and must be an empty dir.