### PR TITLE
Suppress non-conflict user changes reports

### DIFF
--- a/prospero-common/src/main/java/org/wildfly/prospero/actions/ApplyPatchAction.java
+++ b/prospero-common/src/main/java/org/wildfly/prospero/actions/ApplyPatchAction.java
@@ -93,6 +93,6 @@ public class ApplyPatchAction {
 
         metadata.setChannel(galleonEnv.getRepositoryManager().resolvedChannel());
 
-        metadata.recordProvision();
+        metadata.recordProvision(false);
     }
 }

--- a/prospero-common/src/main/java/org/wildfly/prospero/actions/InstallationRestoreAction.java
+++ b/prospero-common/src/main/java/org/wildfly/prospero/actions/InstallationRestoreAction.java
@@ -68,6 +68,6 @@ public class InstallationRestoreAction {
 
     private void writeProsperoMetadata(ChannelMavenArtifactRepositoryManager maven, List<ChannelRef> channelRefs, List<RemoteRepository> repositories)
             throws MetadataException {
-        new InstallationMetadata(installDir, maven.resolvedChannel(), channelRefs, repositories).recordProvision();
+        new InstallationMetadata(installDir, maven.resolvedChannel(), channelRefs, repositories).recordProvision(true);
     }
 }

--- a/prospero-common/src/main/java/org/wildfly/prospero/actions/ProvisioningAction.java
+++ b/prospero-common/src/main/java/org/wildfly/prospero/actions/ProvisioningAction.java
@@ -127,7 +127,7 @@ public class ProvisioningAction {
                                        List<RemoteRepository> repositories) throws MetadataException {
         final Channel channel = maven.resolvedChannel();
 
-        new InstallationMetadata(home, channel, channelRefs, repositories).recordProvision();
+        new InstallationMetadata(home, channel, channelRefs, repositories).recordProvision(true);
     }
 
     private static void verifyInstallDir(Path directory) {

--- a/prospero-common/src/main/java/org/wildfly/prospero/actions/UpdateAction.java
+++ b/prospero-common/src/main/java/org/wildfly/prospero/actions/UpdateAction.java
@@ -63,7 +63,7 @@ public class UpdateAction {
 
         applyUpdates();
 
-        metadata.recordProvision();
+        metadata.recordProvision(false);
 
         console.updatesComplete();
     }

--- a/prospero-common/src/main/java/org/wildfly/prospero/api/InstallationMetadata.java
+++ b/prospero-common/src/main/java/org/wildfly/prospero/api/InstallationMetadata.java
@@ -198,13 +198,14 @@ public class InstallationMetadata {
         return galleonProvisioningConfig;
     }
 
-    public void recordProvision() throws MetadataException {
+    public void recordProvision(boolean overrideProsperoConfig) throws MetadataException {
         try {
             ManifestYamlSupport.write(this.manifest, this.manifestFile);
         } catch (IOException e) {
             throw new MetadataException("Unable to save manifest in installation", e);
         }
-        if (!Files.exists(this.prosperoConfigFile)) {
+
+        if (overrideProsperoConfig || !Files.exists(this.prosperoConfigFile)) {
             writeProsperoConfig();
         }
 

--- a/prospero-common/src/main/java/org/wildfly/prospero/galleon/GalleonUtils.java
+++ b/prospero-common/src/main/java/org/wildfly/prospero/galleon/GalleonUtils.java
@@ -39,6 +39,8 @@ public class GalleonUtils {
     public static final String JBOSS_BULK_RESOLVE_PROPERTY = "jboss-bulk-resolve-artifacts";
     public static final String JBOSS_BULK_RESOLVE_VALUE = "true";
     public static final String MODULE_PATH_PROPERTY = "module.path";
+    public static final String PRINT_ONLY_CONFLICTS_PROPERTY = "print-only-conflicts";
+    public static final String PRINT_ONLY_CONFLICTS_VALUE = "true";
 
     public static void executeGalleon(GalleonExecution execution, Path localRepository) throws ProvisioningException {
         final String modulePathProperty = System.getProperty(MODULE_PATH_PROPERTY);
@@ -50,6 +52,7 @@ public class GalleonUtils {
             final Map<String, String> options = new HashMap<>();
             options.put(GalleonUtils.JBOSS_FORK_EMBEDDED_PROPERTY, GalleonUtils.JBOSS_FORK_EMBEDDED_VALUE);
             options.put(GalleonUtils.JBOSS_BULK_RESOLVE_PROPERTY, GalleonUtils.JBOSS_BULK_RESOLVE_VALUE);
+            options.put(GalleonUtils.PRINT_ONLY_CONFLICTS_PROPERTY, GalleonUtils.PRINT_ONLY_CONFLICTS_VALUE);
             execution.execute(options);
         } finally {
             System.clearProperty(MAVEN_REPO_LOCAL);

--- a/prospero-common/src/main/java/org/wildfly/prospero/test/MetadataTestUtils.java
+++ b/prospero-common/src/main/java/org/wildfly/prospero/test/MetadataTestUtils.java
@@ -73,7 +73,7 @@ public final class MetadataTestUtils {
             List<RemoteRepository> repositories) throws MetadataException {
         Runtime.getRuntime().addShutdownHook(new Thread(() -> FileUtils.deleteQuietly(installation.toFile())));
         final InstallationMetadata metadata = new InstallationMetadata(installation, manifest, channels, repositories);
-        metadata.recordProvision();
+        metadata.recordProvision(true);
         return metadata;
     }
 

--- a/prospero-common/src/test/java/org/wildfly/prospero/installation/LocalInstallationHistoryTest.java
+++ b/prospero-common/src/test/java/org/wildfly/prospero/installation/LocalInstallationHistoryTest.java
@@ -129,7 +129,7 @@ public class LocalInstallationHistoryTest {
         final Channel channel = new Channel("test", "", null, null,
                 Arrays.asList(new Stream("foo", "bar", "1.1.2", null)));
         metadata.setChannel(channel);
-        metadata.recordProvision();
+        metadata.recordProvision(true);
     }
 
     private InstallationMetadata mockInstallation() throws Exception {


### PR DESCRIPTION
enable GAL-337 and override prospero-config on initial install (#119)