### PR TITLE
Measure and display installation time

### DIFF
--- a/prospero-cli/src/main/java/org/wildfly/prospero/cli/CliMessages.java
+++ b/prospero-cli/src/main/java/org/wildfly/prospero/cli/CliMessages.java
@@ -132,6 +132,12 @@ public interface CliMessages {
     @Message("Path `%s` does not contain a server installation provisioned by prospero.")
     IllegalArgumentException invalidInstallationDir(Path path);
 
-    @Message("Add required channels using [%s] argument")
+    @Message("Add required channels using [%s] argument.")
     String addChannels(String channel);
+
+    @Message("Installation completed in %.2f seconds.")
+    String installationCompleted(float time);
+
+    @Message("Update completed in %.2f seconds.")
+    String updateCompleted(float time);
 }

--- a/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/InstallCommand.java
+++ b/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/InstallCommand.java
@@ -113,6 +113,8 @@ public class InstallCommand extends AbstractCommand {
 
     @Override
     public Integer call() throws Exception {
+        final long startTime = System.currentTimeMillis();
+
         // following is checked by picocli, adding this to avoid IDE warnings
         assert featurePackOrDefinition.definition.isPresent() || featurePackOrDefinition.fpl.isPresent();
         if (featurePackOrDefinition.definition.isEmpty() && isStandardFpl(featurePackOrDefinition.fpl.get()) && provisionConfig.isEmpty()) {
@@ -135,6 +137,9 @@ public class InstallCommand extends AbstractCommand {
         ProvisioningAction provisioningAction = actionFactory.install(directory.toAbsolutePath(), mavenSessionManager,
                 console);
         provisioningAction.provision(provisioningDefinition);
+
+        final float totalTime = (System.currentTimeMillis() - startTime) / 1000f;
+        console.println(CliMessages.MESSAGES.installationCompleted(totalTime));
 
         return ReturnCodes.SUCCESS;
     }

--- a/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/UpdateCommand.java
+++ b/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/UpdateCommand.java
@@ -72,6 +72,7 @@ public class UpdateCommand extends AbstractCommand {
 
     @Override
     public Integer call() throws Exception {
+        final long startTime = System.currentTimeMillis();
         final Path installationDir;
 
         if (self) {
@@ -99,6 +100,10 @@ public class UpdateCommand extends AbstractCommand {
             logger.error(CliMessages.MESSAGES.errorWhileExecutingOperation(CliConstants.Commands.INSTALL, e.getMessage()), e);
             return ReturnCodes.PROCESSING_ERROR;
         }
+
+        final float totalTime = (System.currentTimeMillis() - startTime) / 1000f;
+        console.println(CliMessages.MESSAGES.updateCompleted(totalTime));
+
         return ReturnCodes.SUCCESS;
     }
 


### PR DESCRIPTION
I used this to measure performance difference when testing parallel stream for version resolution, but maybe we would like to have that it main?

```
$ ./prospero install --dir tmp/wf-core --provision-config tmp/wildfly-core-config-patterns.yaml --fpl "wildfly-core@maven(org.jboss.universe:community-universe):19.0" 
Installing wildfly-core@maven(org.jboss.universe:community-universe):19.0
Feature-packs resolved.0%
Packages installed. 100%
JBoss modules installed. 1%
Configurations generated.
Installation completed in 36.44 seconds
```