### PR TITLE
Fix java.lang.ClassCastException

### DIFF
--- a/prospero-common/src/main/java/org/wildfly/prospero/Messages.java
+++ b/prospero-common/src/main/java/org/wildfly/prospero/Messages.java
@@ -25,6 +25,7 @@ import org.jboss.logging.annotations.Cause;
 import org.jboss.logging.annotations.Message;
 import org.jboss.logging.annotations.MessageBundle;
 import org.wildfly.channel.InvalidChannelException;
+import org.wildfly.channel.UnresolvedMavenArtifactException;
 import org.wildfly.prospero.api.exceptions.ArtifactResolutionException;
 import org.wildfly.prospero.api.exceptions.ChannelDefinitionException;
 import org.wildfly.prospero.api.exceptions.MetadataException;
@@ -54,7 +55,7 @@ public interface Messages {
     String installingFpl(String fpl);
 
     @Message("Artifact [%s:%s] not found")
-    ArtifactResolutionException artifactNotFound(String g, String a, @Cause Exception e);
+    ArtifactResolutionException artifactNotFound(String g, String a, @Cause UnresolvedMavenArtifactException e);
 
     @Message("At least one channel reference must be given.")
     NoChannelException noChannelReference();

--- a/prospero-common/src/main/java/org/wildfly/prospero/api/ProvisioningDefinition.java
+++ b/prospero-common/src/main/java/org/wildfly/prospero/api/ProvisioningDefinition.java
@@ -40,7 +40,7 @@ import org.wildfly.channel.Channel;
 import org.wildfly.channel.ChannelManifestCoordinate;
 import org.wildfly.channel.Repository;
 import org.wildfly.prospero.Messages;
-import org.wildfly.prospero.api.exceptions.ArtifactResolutionException;
+import org.wildfly.prospero.api.exceptions.MetadataException;
 import org.wildfly.prospero.api.exceptions.NoChannelException;
 import org.wildfly.prospero.galleon.FeaturePackLocationParser;
 import org.wildfly.prospero.galleon.GalleonUtils;
@@ -57,7 +57,7 @@ public class ProvisioningDefinition {
     private final List<RemoteRepository> repositories = new ArrayList<>();
     private final URI definition;
 
-    private ProvisioningDefinition(Builder builder) throws ArtifactResolutionException, NoChannelException {
+    private ProvisioningDefinition(Builder builder) throws MetadataException, NoChannelException {
         final Optional<String> fpl = Optional.ofNullable(builder.fpl);
         final Optional<URI> definition = Optional.ofNullable(builder.definitionFile);
         final List<Repository> overrideRepos = builder.overrideRepositories;
@@ -88,7 +88,7 @@ public class ProvisioningDefinition {
                                 String.join(", ", KnownFeaturePacks.getNames())));
             }
         } catch (IOException e) {
-            throw new ArtifactResolutionException("Unable to resolve channel definition: " + e.getMessage(), e);
+            throw new MetadataException("Unable to resolve channel definition: " + e.getMessage(), e);
         }
 
         if (channels.isEmpty() || channelsMissingManifest()) {
@@ -172,7 +172,7 @@ public class ProvisioningDefinition {
         private Set<String> includedPackages;
         private ChannelManifestCoordinate manifest;
 
-        public ProvisioningDefinition build() throws ArtifactResolutionException, NoChannelException {
+        public ProvisioningDefinition build() throws MetadataException, NoChannelException {
             return new ProvisioningDefinition(this);
         }
 

--- a/prospero-common/src/main/java/org/wildfly/prospero/api/exceptions/ArtifactResolutionException.java
+++ b/prospero-common/src/main/java/org/wildfly/prospero/api/exceptions/ArtifactResolutionException.java
@@ -35,7 +35,7 @@ public class ArtifactResolutionException extends OperationException {
     private Collection<RemoteRepository> repositories;
     private boolean offline;
 
-    public ArtifactResolutionException(String msg, Throwable e) {
+    public ArtifactResolutionException(String msg, UnresolvedMavenArtifactException e) {
         super(msg, e);
     }
 
@@ -43,7 +43,7 @@ public class ArtifactResolutionException extends OperationException {
         super(msg);
     }
 
-    public ArtifactResolutionException(Throwable e) {
+    public ArtifactResolutionException(UnresolvedMavenArtifactException e) {
         super(e);
     }
 


### PR DESCRIPTION
```
java.lang.ClassCastException: class com.fasterxml.jackson.databind.exc.MismatchedInputException cannot be cast to class org.wildfly.channel.UnresolvedMavenArtifactException (com.fasterxml.jackson.databind.exc.MismatchedInputException and org.wildfly.channel.UnresolvedMavenArtifactException are in unnamed module of loader 'app')
	at org.wildfly.prospero.api.exceptions.ArtifactResolutionException.failedArtifacts(ArtifactResolutionException.java:81)
	at org.wildfly.prospero.cli.ExecutionExceptionHandler.handleExecutionException(ExecutionExceptionHandler.java:64)
	at picocli.CommandLine.execute(CommandLine.java:2088)
	at org.wildfly.prospero.cli.CliMain.main(CliMain.java:54)
```


Fix `java.lang.ClassCastException`. It's not necessarily an `UnresolvedMavenArtifactException` e.g.  The exception has been thrown from https://github.com/wildfly-extras/prospero/blob/1.0.0.Beta4/prospero-common/src/main/java/org/wildfly/prospero/api/ProvisioningDefinition.java#L86