### PR TITLE
Unify remote-repositories parameter

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,6 +9,8 @@ on:
       - 'examples'
       - 'README.md'
   pull_request:
+    branches-ignore:
+      - 'future'
     paths-ignore:
       - '.gitignore'
       - 'examples'

--- a/integration-tests/src/test/java/org/wildfly/prospero/it/cli/PatchingTest.java
+++ b/integration-tests/src/test/java/org/wildfly/prospero/it/cli/PatchingTest.java
@@ -138,7 +138,7 @@ public class PatchingTest {
             ExecutionUtils.prosperoExecution(CliConstants.Commands.CHANNEL, CliConstants.Commands.CUSTOMIZATION_INIT_CHANNEL,
                             CliConstants.DIR, targetDir.getAbsolutePath(),
                             CliConstants.CUSTOMIZATION_REPOSITORY_URL, repositoryUrl,
-                            CliConstants.CUSTOMIZATION_CHANNEL_NAME, TEST_CUSTOM_CHANNEL)
+                            CliConstants.CHANNEL_MANIFEST, TEST_CUSTOM_CHANNEL)
                     .execute()
                     .assertReturnCode(ReturnCodes.SUCCESS);
 
@@ -150,7 +150,7 @@ public class PatchingTest {
                             CliConstants.Y,
                             CliConstants.CUSTOMIZATION_ARCHIVE, customizationArchive.toString(),
                             CliConstants.CUSTOMIZATION_REPOSITORY_URL, repositoryPath.toUri().toURL().toString(),
-                            CliConstants.CUSTOMIZATION_CHANNEL_NAME, TEST_CUSTOM_CHANNEL)
+                            CliConstants.CHANNEL_MANIFEST, TEST_CUSTOM_CHANNEL)
                     .execute()
                     .assertReturnCode(ReturnCodes.SUCCESS);
 

--- a/integration-tests/src/test/java/org/wildfly/prospero/it/cli/UpdateWithAdditionalRepositoryTest.java
+++ b/integration-tests/src/test/java/org/wildfly/prospero/it/cli/UpdateWithAdditionalRepositoryTest.java
@@ -65,7 +65,7 @@ public class UpdateWithAdditionalRepositoryTest extends WfCoreTestBase {
         final URL temporaryRepo = mockTemporaryRepo();
 
         ExecutionUtils.prosperoExecution(CliConstants.Commands.UPDATE,
-                        CliConstants.REMOTE_REPOSITORIES, temporaryRepo.toString(),
+                        CliConstants.REPOSITORIES, temporaryRepo.toString(),
                         CliConstants.Y,
                         CliConstants.NO_LOCAL_MAVEN_CACHE,
                         CliConstants.DIR, targetDir.getAbsolutePath())

--- a/integration-tests/src/test/java/org/wildfly/prospero/it/commonapi/InstallationHistoryActionTest.java
+++ b/integration-tests/src/test/java/org/wildfly/prospero/it/commonapi/InstallationHistoryActionTest.java
@@ -142,7 +142,7 @@ public class InstallationHistoryActionTest extends WfCoreTestBase {
         // perform the rollback using temporary repository only. Offline mode disables other repositories
         final URL temporaryRepo = mockTemporaryRepo();
         final MavenSessionManager offlineSessionManager = new MavenSessionManager(Optional.empty(), true);
-        historyAction.rollback(savedState, offlineSessionManager, List.of(temporaryRepo));
+        historyAction.rollback(savedState, offlineSessionManager, List.of(new Repository("temp-repo", temporaryRepo.toExternalForm())));
 
         wildflyCliArtifact = readArtifactFromManifest("org.wildfly.core", "wildfly-cli");
         assertEquals(BASE_VERSION, wildflyCliArtifact.get().getVersion());

--- a/integration-tests/src/test/java/org/wildfly/prospero/it/commonapi/InstallationHistoryActionTest.java
+++ b/integration-tests/src/test/java/org/wildfly/prospero/it/commonapi/InstallationHistoryActionTest.java
@@ -19,6 +19,8 @@ package org.wildfly.prospero.it.commonapi;
 
 import org.jboss.galleon.ProvisioningException;
 import org.junit.Assert;
+import org.wildfly.channel.Channel;
+import org.wildfly.channel.Repository;
 import org.wildfly.prospero.api.ArtifactChange;
 import org.wildfly.prospero.actions.InstallationHistoryAction;
 import org.wildfly.prospero.api.SavedState;
@@ -31,10 +33,13 @@ import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.artifact.DefaultArtifact;
 import org.junit.After;
 import org.junit.Test;
+import org.wildfly.prospero.model.ProsperoConfig;
 import org.wildfly.prospero.test.MetadataTestUtils;
+import org.wildfly.prospero.wfchannel.MavenSessionManager;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -44,6 +49,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -100,11 +106,52 @@ public class InstallationHistoryActionTest extends WfCoreTestBase {
         final List<SavedState> revisions = historyAction.getRevisions();
 
         final SavedState savedState = revisions.get(1);
-        historyAction.rollback(savedState, mavenSessionManager);
+        historyAction.rollback(savedState, mavenSessionManager, Collections.emptyList());
 
         wildflyCliArtifact = readArtifactFromManifest("org.wildfly.core", "wildfly-cli");
         assertEquals(BASE_VERSION, wildflyCliArtifact.get().getVersion());
         assertTrue("Reverted jar should be present in module", wildflyCliModulePath.resolve(BASE_JAR).toFile().exists());
+    }
+
+    @Test
+    public void rollbackChangesWithTemporaryRepo() throws Exception {
+        // install server
+        final Path manifestPath = temp.newFile().toPath();
+        provisionConfigFile = temp.newFile().toPath();
+        MetadataTestUtils.copyManifest("channels/wfcore-19-base.yaml", manifestPath);
+        MetadataTestUtils.prepareProvisionConfig(provisionConfigFile, List.of(manifestPath.toUri().toURL()));
+
+        final Path modulesPaths = outputPath.resolve(Paths.get("modules", "system", "layers", "base"));
+        final Path wildflyCliModulePath = modulesPaths.resolve(Paths.get("org", "jboss", "as", "cli", "main"));
+
+        final ProvisioningDefinition provisioningDefinition = defaultWfCoreDefinition()
+                .setProvisionConfig(provisionConfigFile)
+                .build();
+        installation.provision(provisioningDefinition.toProvisioningConfig(), provisioningDefinition.getChannels());
+
+        MetadataTestUtils.upgradeStreamInManifest(manifestPath, resolvedUpgradeArtifact);
+        updateAction().performUpdate();
+        Optional<Artifact> wildflyCliArtifact = readArtifactFromManifest("org.wildfly.core", "wildfly-cli");
+        assertEquals(UPGRADE_VERSION, wildflyCliArtifact.get().getVersion());
+        assertTrue("Updated jar should be present in module", wildflyCliModulePath.resolve(UPGRADE_JAR).toFile().exists());
+
+        final InstallationHistoryAction historyAction = new InstallationHistoryAction(outputPath, new AcceptingConsole());
+        final List<SavedState> revisions = historyAction.getRevisions();
+        final SavedState savedState = revisions.get(1);
+
+        // perform the rollback using temporary repository only. Offline mode disables other repositories
+        final URL temporaryRepo = mockTemporaryRepo();
+        final MavenSessionManager offlineSessionManager = new MavenSessionManager(Optional.empty(), true);
+        historyAction.rollback(savedState, offlineSessionManager, List.of(temporaryRepo));
+
+        wildflyCliArtifact = readArtifactFromManifest("org.wildfly.core", "wildfly-cli");
+        assertEquals(BASE_VERSION, wildflyCliArtifact.get().getVersion());
+        assertTrue("Reverted jar should be present in module", wildflyCliModulePath.resolve(BASE_JAR).toFile().exists());
+        assertThat(ProsperoConfig.readConfig(outputPath.resolve(MetadataTestUtils.PROVISION_CONFIG_FILE_PATH)).getChannels())
+                .withFailMessage("Temporary repository should not be listed")
+                .flatMap(Channel::getRepositories)
+                .map(Repository::getUrl)
+                .doesNotContain(temporaryRepo.toExternalForm());
     }
 
     @Test

--- a/integration-tests/src/test/java/org/wildfly/prospero/it/commonapi/WfCoreTestBase.java
+++ b/integration-tests/src/test/java/org/wildfly/prospero/it/commonapi/WfCoreTestBase.java
@@ -123,7 +123,7 @@ public class WfCoreTestBase {
     protected ProvisioningDefinition.Builder defaultWfCoreDefinition() {
         return ProvisioningDefinition.builder()
                 .setFpl("wildfly-core@maven(org.jboss.universe:community-universe):19.0")
-                .setOverrideRepositories(repositories.stream().map(Repository::getUrl).collect(Collectors.toList()));
+                .setOverrideRepositories(repositories);
     }
 
     protected Artifact resolveArtifact(String groupId, String artifactId, String version) throws ArtifactResolutionException {

--- a/integration-tests/src/test/java/org/wildfly/prospero/it/commonapi/WfCoreTestBase.java
+++ b/integration-tests/src/test/java/org/wildfly/prospero/it/commonapi/WfCoreTestBase.java
@@ -123,7 +123,7 @@ public class WfCoreTestBase {
     protected ProvisioningDefinition.Builder defaultWfCoreDefinition() {
         return ProvisioningDefinition.builder()
                 .setFpl("wildfly-core@maven(org.jboss.universe:community-universe):19.0")
-                .setAdditionalRepositories(repositories.stream().map(Repository::getUrl).collect(Collectors.toList()));
+                .setOverrideRepositories(repositories.stream().map(Repository::getUrl).collect(Collectors.toList()));
     }
 
     protected Artifact resolveArtifact(String groupId, String artifactId, String version) throws ArtifactResolutionException {

--- a/prospero-cli/src/main/java/org/wildfly/prospero/cli/ActionFactory.java
+++ b/prospero-cli/src/main/java/org/wildfly/prospero/cli/ActionFactory.java
@@ -17,12 +17,11 @@
 
 package org.wildfly.prospero.cli;
 
-
-import java.net.URL;
 import java.nio.file.Path;
 import java.util.List;
 
 import org.jboss.galleon.ProvisioningException;
+import org.wildfly.channel.Repository;
 import org.wildfly.prospero.actions.Console;
 import org.wildfly.prospero.actions.InstallationHistoryAction;
 import org.wildfly.prospero.actions.MetadataAction;
@@ -41,7 +40,7 @@ public class ActionFactory {
 
     // Option for BETA update support
     // TODO: evaluate in GA - replace by repository:add / custom channels?
-    public UpdateAction update(Path targetPath, MavenSessionManager mavenSessionManager, Console console, List<URL> additionalRepositories)
+    public UpdateAction update(Path targetPath, MavenSessionManager mavenSessionManager, Console console, List<Repository> additionalRepositories)
             throws OperationException,
             ProvisioningException {
         return new UpdateAction(targetPath, mavenSessionManager, console, additionalRepositories);

--- a/prospero-cli/src/main/java/org/wildfly/prospero/cli/ExecutionExceptionHandler.java
+++ b/prospero-cli/src/main/java/org/wildfly/prospero/cli/ExecutionExceptionHandler.java
@@ -46,7 +46,7 @@ public class ExecutionExceptionHandler implements CommandLine.IExecutionExceptio
             throws Exception {
         if (ex instanceof NoChannelException) {
             console.error("ERROR: " + ex.getMessage());
-            console.error(CliMessages.MESSAGES.addChannels(CliConstants.CHANNEL));
+            console.error(CliMessages.MESSAGES.addChannels(CliConstants.CHANNEL_MANIFEST));
             return ReturnCodes.INVALID_ARGUMENTS;
         }
         if (ex instanceof IllegalArgumentException || ex instanceof ArgumentParsingException) {

--- a/prospero-cli/src/main/java/org/wildfly/prospero/cli/RepositoryDefinition.java
+++ b/prospero-cli/src/main/java/org/wildfly/prospero/cli/RepositoryDefinition.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.prospero.cli;
+
+import org.wildfly.channel.Repository;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+
+public class RepositoryDefinition {
+
+    public static List<Repository> from(List<String> repos) throws ArgumentParsingException {
+        ArrayList<Repository> repositories = new ArrayList<>(repos.size());
+        for (int i = 0; i < repos.size(); i++) {
+            final String text = repos.get(i);
+            if(text.contains("::")) {
+                final String[] parts = text.split("::");
+                if (parts.length != 2 || parts[0].isEmpty() || parts[1].isEmpty() || !isValidUrl(parts[1])) {
+                    throw CliMessages.MESSAGES.invalidRepositoryDefinition(text);
+                }
+
+                repositories.add(new Repository(parts[0], parts[1]));
+            } else {
+                if (!isValidUrl(text)) {
+                    throw CliMessages.MESSAGES.invalidRepositoryDefinition(text);
+                }
+
+                repositories.add(new Repository("temp-repo-" + i, text));
+            }
+        }
+        return repositories;
+    }
+
+    private static boolean isValidUrl(String text) {
+        try {
+            new URL(text);
+            return true;
+        } catch (MalformedURLException e) {
+            return false;
+        }
+    }
+}

--- a/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/ChannelCommand.java
+++ b/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/ChannelCommand.java
@@ -45,7 +45,6 @@ public class ChannelCommand extends AbstractCommand {
         return ReturnCodes.INVALID_ARGUMENTS;
     }
 
-
     @CommandLine.Command(name = CliConstants.Commands.LIST)
     public static class ChannelListCommand extends AbstractCommand {
 
@@ -64,10 +63,9 @@ public class ChannelCommand extends AbstractCommand {
                 channels = metadataAction.getChannels();
             }
 
-            int i=0;
             console.println("-------");
             for (Channel channel: channels) {
-                console.println("#" + i++);
+                console.println("#" + channel.getName());
                 final String manifest = channel.getManifestRef().getGav() == null
                         ?channel.getManifestRef().getUrl().toExternalForm():channel.getManifestRef().getGav();
                 console.println("  " + "manifest: " + manifest);

--- a/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/CliConstants.java
+++ b/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/CliConstants.java
@@ -59,7 +59,7 @@ public final class CliConstants {
     // Option names:
 
     public static final String CHANNEL_MANIFEST = "--manifest";
-    public static final String REMOTE_REPOSITORIES = "--remote-repositories";
+    public static final String REPOSITORIES = "--repositories";
     public static final String DEFINITION = "--definition";
     public static final String DIR = "--dir";
     public static final String DRY_RUN = "--dry-run";
@@ -77,11 +77,7 @@ public final class CliConstants {
     public static final String Y = "-y";
     public static final String YES = "--yes";
 
-    public static final String CUSTOMIZATION_CHANNEL_NAME = "--channel-name";
+    public static final String CHANNEL_NAME = "--channel-name";
     public static final String CUSTOMIZATION_REPOSITORY_URL = "--repository-url";
     public static final String CUSTOMIZATION_ARCHIVE = "--archive";
-
-    public static final String REPOSITORY = "repository";
-
-    public static final String MANIFEST = "manifest";
 }

--- a/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/CliConstants.java
+++ b/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/CliConstants.java
@@ -66,7 +66,7 @@ public final class CliConstants {
     public static final String FPL = "--fpl";
     public static final String H = "-h";
     public static final String HELP = "--help";
-    public static final String LOCAL_REPO = "--local-repo";
+    public static final String LOCAL_CACHE = "--local-cache";
     public static final String NO_LOCAL_MAVEN_CACHE = "--no-resolve-local-cache";
     public static final String OFFLINE = "--offline";
     public static final String PROVISION_CONFIG = "--provision-config";

--- a/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/CliConstants.java
+++ b/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/CliConstants.java
@@ -51,14 +51,14 @@ public final class CliConstants {
 
     // Parameter and option labels:
 
-    public static final String CHANNEL_REFERENCE = "<channel-reference>";
+    public static final String CHANNEL_MANIFEST_REFERENCE = "<manifest-reference>";
     public static final String FEATURE_PACK_REFERENCE = "<feature-pack-reference>";
     public static final String PATH = "<path>";
     public static final String REPO_URL = "<repo-url>";
 
     // Option names:
 
-    public static final String CHANNEL = "--channel";
+    public static final String CHANNEL_MANIFEST = "--manifest";
     public static final String REMOTE_REPOSITORIES = "--remote-repositories";
     public static final String DEFINITION = "--definition";
     public static final String DIR = "--dir";

--- a/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/InstallCommand.java
+++ b/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/InstallCommand.java
@@ -63,8 +63,8 @@ public class InstallCommand extends AbstractCommand {
         Optional<Path> provisionConfig;
 
         @CommandLine.Option(
-                names = CliConstants.CHANNEL,
-                paramLabel = CliConstants.CHANNEL_REFERENCE,
+                names = CliConstants.CHANNEL_MANIFEST,
+                paramLabel = CliConstants.CHANNEL_MANIFEST_REFERENCE,
                 order = 4
         )
         Optional<String> channel;
@@ -120,7 +120,7 @@ public class InstallCommand extends AbstractCommand {
         }
 
         if (provisionConfig.isPresent() && channel.isPresent()) {
-            throw CliMessages.MESSAGES.exclusiveOptions(CliConstants.PROVISION_CONFIG, CliConstants.CHANNEL);
+            throw CliMessages.MESSAGES.exclusiveOptions(CliConstants.PROVISION_CONFIG, CliConstants.CHANNEL_MANIFEST);
         }
 
         if (provisionConfig.isPresent() && !remoteRepositories.isEmpty()) {

--- a/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/InstallCommand.java
+++ b/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/InstallCommand.java
@@ -17,12 +17,10 @@
 
 package org.wildfly.prospero.cli.commands;
 
-import java.net.URL;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 import org.wildfly.prospero.actions.Console;
 import org.wildfly.prospero.actions.ProvisioningAction;
@@ -77,7 +75,7 @@ public class InstallCommand extends AbstractCommand {
                 split = ",",
                 order = 5
         )
-        List<URL> remoteRepositories = new ArrayList<>();
+        List<String> remoteRepositories = new ArrayList<>();
 
         @CommandLine.ArgGroup(exclusive = true, order = 6, headingKey = "localRepoOptions.heading")
         LocalRepoOptions localRepoOptions;
@@ -137,7 +135,7 @@ public class InstallCommand extends AbstractCommand {
                 .setFpl(featurePackOrDefinition.fpl.orElse(null))
                 .setManifest(channel.orElse(null))
                 .setProvisionConfig(provisionConfig.orElse(null))
-                .setAdditionalRepositories(remoteRepositories.stream().map(URL::toString).collect(Collectors.toList()))
+                .setOverrideRepositories(remoteRepositories)
                 .setDefinitionFile(featurePackOrDefinition.definition.map(Path::toUri).orElse(null))
                 .build();
 

--- a/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/InstallCommand.java
+++ b/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/InstallCommand.java
@@ -129,15 +129,15 @@ public class InstallCommand extends AbstractCommand {
             throw CliMessages.MESSAGES.exclusiveOptions(CliConstants.PROVISION_CONFIG, CliConstants.REMOTE_REPOSITORIES);
         }
 
-        final Optional<Path> localRepo = LocalRepoOptions.getLocalRepo(localRepoOptions);
+        final Optional<Path> localMavenCache = LocalRepoOptions.getLocalMavenCache(localRepoOptions);
 
-        final MavenSessionManager mavenSessionManager = new MavenSessionManager(localRepo, offline);
+        final MavenSessionManager mavenSessionManager = new MavenSessionManager(localMavenCache, offline);
 
         final ProvisioningDefinition provisioningDefinition = ProvisioningDefinition.builder()
                 .setFpl(featurePackOrDefinition.fpl.orElse(null))
                 .setManifest(channel.orElse(null))
                 .setProvisionConfig(provisionConfig.orElse(null))
-                .setRemoteRepositories(remoteRepositories.stream().map(URL::toString).collect(Collectors.toList()))
+                .setAdditionalRepositories(remoteRepositories.stream().map(URL::toString).collect(Collectors.toList()))
                 .setDefinitionFile(featurePackOrDefinition.definition.map(Path::toUri).orElse(null))
                 .build();
 

--- a/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/InstallCommand.java
+++ b/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/InstallCommand.java
@@ -28,6 +28,7 @@ import org.wildfly.prospero.api.ProvisioningDefinition;
 import org.wildfly.prospero.api.KnownFeaturePacks;
 import org.wildfly.prospero.cli.ActionFactory;
 import org.wildfly.prospero.cli.CliMessages;
+import org.wildfly.prospero.cli.RepositoryDefinition;
 import org.wildfly.prospero.cli.ReturnCodes;
 import org.wildfly.prospero.cli.commands.options.LocalRepoOptions;
 import org.wildfly.prospero.cli.commands.options.FeaturePackCandidates;
@@ -70,7 +71,7 @@ public class InstallCommand extends AbstractCommand {
         Optional<String> channel;
 
         @CommandLine.Option(
-                names = CliConstants.REMOTE_REPOSITORIES,
+                names = CliConstants.REPOSITORIES,
                 paramLabel = CliConstants.REPO_URL,
                 split = ",",
                 order = 5
@@ -124,7 +125,7 @@ public class InstallCommand extends AbstractCommand {
         }
 
         if (provisionConfig.isPresent() && !remoteRepositories.isEmpty()) {
-            throw CliMessages.MESSAGES.exclusiveOptions(CliConstants.PROVISION_CONFIG, CliConstants.REMOTE_REPOSITORIES);
+            throw CliMessages.MESSAGES.exclusiveOptions(CliConstants.PROVISION_CONFIG, CliConstants.REPOSITORIES);
         }
 
         final Optional<Path> localMavenCache = LocalRepoOptions.getLocalMavenCache(localRepoOptions);
@@ -135,7 +136,7 @@ public class InstallCommand extends AbstractCommand {
                 .setFpl(featurePackOrDefinition.fpl.orElse(null))
                 .setManifest(channel.orElse(null))
                 .setProvisionConfig(provisionConfig.orElse(null))
-                .setOverrideRepositories(remoteRepositories)
+                .setOverrideRepositories(RepositoryDefinition.from(remoteRepositories))
                 .setDefinitionFile(featurePackOrDefinition.definition.map(Path::toUri).orElse(null))
                 .build();
 

--- a/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/RevertCommand.java
+++ b/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/RevertCommand.java
@@ -17,15 +17,16 @@
 
 package org.wildfly.prospero.cli.commands;
 
-import java.net.URL;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
+import org.wildfly.channel.Repository;
 import org.wildfly.prospero.actions.Console;
 import org.wildfly.prospero.actions.InstallationHistoryAction;
 import org.wildfly.prospero.api.SavedState;
+import org.wildfly.prospero.api.TemporaryRepositoriesHandler;
 import org.wildfly.prospero.cli.ActionFactory;
 import org.wildfly.prospero.cli.ReturnCodes;
 import org.wildfly.prospero.cli.commands.options.LocalRepoOptions;
@@ -45,7 +46,7 @@ public class RevertCommand extends AbstractCommand {
     String revision;
 
     @CommandLine.Option(names = CliConstants.REMOTE_REPOSITORIES)
-    List<URL> remoteRepositories = new ArrayList<>();
+    List<String> temporaryRepositories = new ArrayList<>();
 
     @CommandLine.ArgGroup(exclusive = true, headingKey = "localRepoOptions.heading")
     LocalRepoOptions localRepoOptions;
@@ -62,8 +63,10 @@ public class RevertCommand extends AbstractCommand {
         final Path installationDirectory = determineInstallationDirectory(directory);
         final MavenSessionManager mavenSessionManager = new MavenSessionManager(LocalRepoOptions.getLocalMavenCache(localRepoOptions), offline);
 
+        final List<Repository> overrideRepositories = TemporaryRepositoriesHandler.from(temporaryRepositories);
+
         InstallationHistoryAction historyAction = actionFactory.history(installationDirectory, console);
-        historyAction.rollback(new SavedState(revision), mavenSessionManager, remoteRepositories);
+        historyAction.rollback(new SavedState(revision), mavenSessionManager, overrideRepositories);
         return ReturnCodes.SUCCESS;
     }
 }

--- a/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/RevertCommand.java
+++ b/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/RevertCommand.java
@@ -17,7 +17,10 @@
 
 package org.wildfly.prospero.cli.commands;
 
+import java.net.URL;
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 
 import org.wildfly.prospero.actions.Console;
@@ -41,6 +44,9 @@ public class RevertCommand extends AbstractCommand {
     @CommandLine.Option(names = CliConstants.REVISION, required = true)
     String revision;
 
+    @CommandLine.Option(names = CliConstants.REMOTE_REPOSITORIES)
+    List<URL> remoteRepositories = new ArrayList<>();
+
     @CommandLine.ArgGroup(exclusive = true, headingKey = "localRepoOptions.heading")
     LocalRepoOptions localRepoOptions;
 
@@ -54,10 +60,10 @@ public class RevertCommand extends AbstractCommand {
     @Override
     public Integer call() throws Exception {
         final Path installationDirectory = determineInstallationDirectory(directory);
-        final MavenSessionManager mavenSessionManager = new MavenSessionManager(LocalRepoOptions.getLocalRepo(localRepoOptions), offline);
+        final MavenSessionManager mavenSessionManager = new MavenSessionManager(LocalRepoOptions.getLocalMavenCache(localRepoOptions), offline);
 
         InstallationHistoryAction historyAction = actionFactory.history(installationDirectory, console);
-        historyAction.rollback(new SavedState(revision), mavenSessionManager);
+        historyAction.rollback(new SavedState(revision), mavenSessionManager, remoteRepositories);
         return ReturnCodes.SUCCESS;
     }
 }

--- a/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/RevertCommand.java
+++ b/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/RevertCommand.java
@@ -26,8 +26,8 @@ import org.wildfly.channel.Repository;
 import org.wildfly.prospero.actions.Console;
 import org.wildfly.prospero.actions.InstallationHistoryAction;
 import org.wildfly.prospero.api.SavedState;
-import org.wildfly.prospero.api.TemporaryRepositoriesHandler;
 import org.wildfly.prospero.cli.ActionFactory;
+import org.wildfly.prospero.cli.RepositoryDefinition;
 import org.wildfly.prospero.cli.ReturnCodes;
 import org.wildfly.prospero.cli.commands.options.LocalRepoOptions;
 import org.wildfly.prospero.wfchannel.MavenSessionManager;
@@ -45,7 +45,7 @@ public class RevertCommand extends AbstractCommand {
     @CommandLine.Option(names = CliConstants.REVISION, required = true)
     String revision;
 
-    @CommandLine.Option(names = CliConstants.REMOTE_REPOSITORIES)
+    @CommandLine.Option(names = CliConstants.REPOSITORIES)
     List<String> temporaryRepositories = new ArrayList<>();
 
     @CommandLine.ArgGroup(exclusive = true, headingKey = "localRepoOptions.heading")
@@ -63,7 +63,7 @@ public class RevertCommand extends AbstractCommand {
         final Path installationDirectory = determineInstallationDirectory(directory);
         final MavenSessionManager mavenSessionManager = new MavenSessionManager(LocalRepoOptions.getLocalMavenCache(localRepoOptions), offline);
 
-        final List<Repository> overrideRepositories = TemporaryRepositoriesHandler.from(temporaryRepositories);
+        final List<Repository> overrideRepositories = RepositoryDefinition.from(temporaryRepositories);
 
         InstallationHistoryAction historyAction = actionFactory.history(installationDirectory, console);
         historyAction.rollback(new SavedState(revision), mavenSessionManager, overrideRepositories);

--- a/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/UpdateCommand.java
+++ b/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/UpdateCommand.java
@@ -28,12 +28,12 @@ import org.jboss.logging.Logger;
 import org.wildfly.channel.Repository;
 import org.wildfly.prospero.actions.Console;
 import org.wildfly.prospero.actions.UpdateAction;
-import org.wildfly.prospero.api.TemporaryRepositoriesHandler;
 import org.wildfly.prospero.api.exceptions.ArtifactResolutionException;
 import org.wildfly.prospero.api.exceptions.MetadataException;
 import org.wildfly.prospero.cli.ActionFactory;
 import org.wildfly.prospero.cli.ArgumentParsingException;
 import org.wildfly.prospero.cli.CliMessages;
+import org.wildfly.prospero.cli.RepositoryDefinition;
 import org.wildfly.prospero.cli.ReturnCodes;
 import org.wildfly.prospero.cli.commands.options.LocalRepoOptions;
 import org.wildfly.prospero.galleon.GalleonUtils;
@@ -72,7 +72,7 @@ public class UpdateCommand extends AbstractCommand {
     LocalRepoOptions localRepoOptions;
 
     @CommandLine.Option(
-            names = CliConstants.REMOTE_REPOSITORIES,
+            names = CliConstants.REPOSITORIES,
             paramLabel = CliConstants.REPO_URL,
             descriptionKey = "update.remote-repositories",
             split = ",",
@@ -102,7 +102,7 @@ public class UpdateCommand extends AbstractCommand {
 
         final MavenSessionManager mavenSessionManager = new MavenSessionManager(LocalRepoOptions.getLocalMavenCache(localRepoOptions), offline);
 
-        final List<Repository> repositories = TemporaryRepositoriesHandler.from(temporaryRepositories);
+        final List<Repository> repositories = RepositoryDefinition.from(temporaryRepositories);
 
         try (UpdateAction updateAction = actionFactory.update(installationDir, mavenSessionManager, console, repositories)) {
             if (!dryRun) {

--- a/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/UpdateCommand.java
+++ b/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/UpdateCommand.java
@@ -17,7 +17,6 @@
 
 package org.wildfly.prospero.cli.commands;
 
-import java.net.URL;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
@@ -26,8 +25,10 @@ import java.util.Optional;
 
 import org.jboss.galleon.ProvisioningException;
 import org.jboss.logging.Logger;
+import org.wildfly.channel.Repository;
 import org.wildfly.prospero.actions.Console;
 import org.wildfly.prospero.actions.UpdateAction;
+import org.wildfly.prospero.api.TemporaryRepositoriesHandler;
 import org.wildfly.prospero.api.exceptions.ArtifactResolutionException;
 import org.wildfly.prospero.api.exceptions.MetadataException;
 import org.wildfly.prospero.cli.ActionFactory;
@@ -77,7 +78,7 @@ public class UpdateCommand extends AbstractCommand {
             split = ",",
             order = 5
     )
-    List<URL> additionalRepositories = new ArrayList<>();
+    List<String> temporaryRepositories = new ArrayList<>();
 
     public UpdateCommand(Console console, ActionFactory actionFactory) {
         super(console, actionFactory);
@@ -101,7 +102,9 @@ public class UpdateCommand extends AbstractCommand {
 
         final MavenSessionManager mavenSessionManager = new MavenSessionManager(LocalRepoOptions.getLocalMavenCache(localRepoOptions), offline);
 
-        try (UpdateAction updateAction = actionFactory.update(installationDir, mavenSessionManager, console, additionalRepositories)) {
+        final List<Repository> repositories = TemporaryRepositoriesHandler.from(temporaryRepositories);
+
+        try (UpdateAction updateAction = actionFactory.update(installationDir, mavenSessionManager, console, repositories)) {
             if (!dryRun) {
                 performUpdate(updateAction);
             } else {

--- a/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/UpdateCommand.java
+++ b/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/UpdateCommand.java
@@ -70,8 +70,6 @@ public class UpdateCommand extends AbstractCommand {
     @CommandLine.ArgGroup(exclusive = true, headingKey = "localRepoOptions.heading")
     LocalRepoOptions localRepoOptions;
 
-    // Option for BETA update support
-    // TODO: evaluate in GA - replace by repository:add / custom channels?
     @CommandLine.Option(
             names = CliConstants.REMOTE_REPOSITORIES,
             paramLabel = CliConstants.REPO_URL,
@@ -79,7 +77,7 @@ public class UpdateCommand extends AbstractCommand {
             split = ",",
             order = 5
     )
-    List<URL> remoteRepositories = new ArrayList<>();
+    List<URL> additionalRepositories = new ArrayList<>();
 
     public UpdateCommand(Console console, ActionFactory actionFactory) {
         super(console, actionFactory);
@@ -101,9 +99,9 @@ public class UpdateCommand extends AbstractCommand {
             installationDir = determineInstallationDirectory(directory);
         }
 
-        final MavenSessionManager mavenSessionManager = new MavenSessionManager(LocalRepoOptions.getLocalRepo(localRepoOptions), offline);
+        final MavenSessionManager mavenSessionManager = new MavenSessionManager(LocalRepoOptions.getLocalMavenCache(localRepoOptions), offline);
 
-        try (UpdateAction updateAction = actionFactory.update(installationDir, mavenSessionManager, console, remoteRepositories)) {
+        try (UpdateAction updateAction = actionFactory.update(installationDir, mavenSessionManager, console, additionalRepositories)) {
             if (!dryRun) {
                 performUpdate(updateAction);
             } else {

--- a/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/channel/ChannelInitializeCommand.java
+++ b/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/channel/ChannelInitializeCommand.java
@@ -53,9 +53,9 @@ public class ChannelInitializeCommand extends AbstractCommand {
     public static final String CUSTOM_CHANNELS_GROUP_ID = "custom.channels";
     public static final String DEFAULT_CUSTOMIZATION_REPOSITORY = "customization-repository";
     @CommandLine.Option(
-            names = CliConstants.CUSTOMIZATION_CHANNEL_NAME
+            names = CliConstants.CHANNEL_MANIFEST
     )
-    private Optional<String> name;
+    private Optional<String> manifestName;
 
     @CommandLine.Option(
             names = CliConstants.CUSTOMIZATION_REPOSITORY_URL,
@@ -97,19 +97,19 @@ public class ChannelInitializeCommand extends AbstractCommand {
                 url = defaultLocalRepoPath.toUri().toURL();
             }
 
-            if (name.isEmpty()) {
+            if (manifestName.isEmpty()) {
                 if (customizationChannelExists(metadataAction)) {
                     console.error(CliMessages.MESSAGES.customizationChannelAlreadyExists());
                     return ReturnCodes.PROCESSING_ERROR;
                 }
-                name = Optional.of(CUSTOM_CHANNELS_GROUP_ID + ":" + RandomStringUtils.randomAlphanumeric(8));
+                manifestName = Optional.of(CUSTOM_CHANNELS_GROUP_ID + ":" + RandomStringUtils.randomAlphanumeric(8));
             }
 
             // add new channel
-            console.println(CliMessages.MESSAGES.registeringCustomChannel(name.get()));
+            console.println(CliMessages.MESSAGES.registeringCustomChannel(manifestName.get()));
             Channel channel = new Channel("customization", null, null, null,
                     List.of(new Repository(CUSTOMIZATION_REPO_ID, url.toExternalForm())),
-                    ArtifactUtils.manifestFromString(name.get()));
+                    ArtifactUtils.manifestFromString(manifestName.get()));
             metadataAction.addChannel(channel);
         }
 
@@ -156,17 +156,17 @@ public class ChannelInitializeCommand extends AbstractCommand {
     }
 
     private boolean validateChannel() {
-        if (name.isEmpty()) {
+        if (manifestName.isEmpty()) {
             return true;
         }
         try {
-            final ChannelManifestCoordinate manifestRef = ArtifactUtils.manifestFromString(name.get());
+            final ChannelManifestCoordinate manifestRef = ArtifactUtils.manifestFromString(manifestName.get());
             if (manifestRef.getGav() == null) {
-                console.error(CliMessages.MESSAGES.illegalChannel(name.get()));
+                console.error(CliMessages.MESSAGES.illegalChannel(manifestName.get()));
                 return false;
             }
         } catch (IllegalArgumentException e) {
-            console.error(CliMessages.MESSAGES.illegalChannel(name.get()));
+            console.error(CliMessages.MESSAGES.illegalChannel(manifestName.get()));
             return false;
         }
         return true;

--- a/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/channel/ChannelPromoteCommand.java
+++ b/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/channel/ChannelPromoteCommand.java
@@ -44,7 +44,7 @@ import static org.wildfly.prospero.cli.commands.channel.ChannelInitializeCommand
 )
 public class ChannelPromoteCommand extends AbstractCommand {
     @CommandLine.Option(
-            names = CliConstants.CUSTOMIZATION_CHANNEL_NAME
+            names = CliConstants.CHANNEL_MANIFEST
     )
     private Optional<String> name;
 
@@ -92,7 +92,7 @@ public class ChannelPromoteCommand extends AbstractCommand {
             if (res.isPresent()) {
                 this.url = res;
             } else {
-                console.error(CliMessages.MESSAGES.noCustomizationConfigFound(CliConstants.CUSTOMIZATION_CHANNEL_NAME, CliConstants.CUSTOMIZATION_REPOSITORY_URL));
+                console.error(CliMessages.MESSAGES.noCustomizationConfigFound(CliConstants.CHANNEL_NAME, CliConstants.CUSTOMIZATION_REPOSITORY_URL));
                 return ReturnCodes.INVALID_ARGUMENTS;
             }
         }
@@ -106,7 +106,7 @@ public class ChannelPromoteCommand extends AbstractCommand {
             if (res.isPresent()) {
                 this.name = res;
             } else {
-                console.error(CliMessages.MESSAGES.noCustomizationConfigFound(CliConstants.CUSTOMIZATION_CHANNEL_NAME, CliConstants.CUSTOMIZATION_REPOSITORY_URL));
+                console.error(CliMessages.MESSAGES.noCustomizationConfigFound(CliConstants.CHANNEL_NAME, CliConstants.CUSTOMIZATION_REPOSITORY_URL));
                 return ReturnCodes.INVALID_ARGUMENTS;
             }
         }

--- a/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/options/LocalRepoOptions.java
+++ b/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/options/LocalRepoOptions.java
@@ -29,11 +29,11 @@ import java.util.Optional;
 
 public class LocalRepoOptions {
     @CommandLine.Option(
-            names = CliConstants.LOCAL_REPO,
+            names = CliConstants.LOCAL_CACHE,
             paramLabel = CliConstants.PATH,
             order = 6
     )
-    Path localRepo;
+    Path localMavenCache;
 
     @CommandLine.Option(
             names = CliConstants.NO_LOCAL_MAVEN_CACHE,
@@ -41,16 +41,16 @@ public class LocalRepoOptions {
     )
     boolean noLocalCache;
 
-    public static Optional<Path> getLocalRepo(LocalRepoOptions localRepoParam) throws ArgumentParsingException {
+    public static Optional<Path> getLocalMavenCache(LocalRepoOptions localRepoParam) throws ArgumentParsingException {
         if (localRepoParam == null) {
             return Optional.of(MavenSessionManager.LOCAL_MAVEN_REPO);
         } else if (localRepoParam.noLocalCache) {
             return Optional.empty();
         } else {
-            if (Files.exists(localRepoParam.localRepo) && !Files.isDirectory(localRepoParam.localRepo)) {
-                throw new ArgumentParsingException(CliMessages.MESSAGES.repositoryIsNotDirectory(localRepoParam.localRepo));
+            if (Files.exists(localRepoParam.localMavenCache) && !Files.isDirectory(localRepoParam.localMavenCache)) {
+                throw new ArgumentParsingException(CliMessages.MESSAGES.repositoryIsNotDirectory(localRepoParam.localMavenCache));
             }
-            return Optional.of(localRepoParam.localRepo);
+            return Optional.of(localRepoParam.localMavenCache);
         }
     }
 }

--- a/prospero-cli/src/main/resources/UsageMessages.properties
+++ b/prospero-cli/src/main/resources/UsageMessages.properties
@@ -28,7 +28,7 @@ prospero.usage.customSynopsis=             @|bold ${prospero.dist.name}|@ [@|fg(
 
 prospero.install.usage.header = Install a new application server instance.
 prospero.install.usage.customSynopsis.0 =             @|bold ${prospero.dist.name} install|@ @|fg(yellow) --fpl|@=@|italic <predefined-name>|@ [@|fg(yellow) OPTION|@]...
-prospero.install.usage.customSynopsis.1 = \u0020 or:  @|bold ${prospero.dist.name} install|@ @|fg(yellow) --fpl|@=@|italic <predefined-name>|@ @|fg(yellow) --channel|@=@|italic <URL/GAV/path>|@ @|fg(yellow) --remote-repositories|@=@|italic <URL>[,...]|@ [@|fg(yellow) OPTION|@]...
+prospero.install.usage.customSynopsis.1 = \u0020 or:  @|bold ${prospero.dist.name} install|@ @|fg(yellow) --fpl|@=@|italic <predefined-name>|@ @|fg(yellow) --manifest|@=@|italic <URL/GAV/path>|@ @|fg(yellow) --remote-repositories|@=@|italic <URL>[,...]|@ [@|fg(yellow) OPTION|@]...
 prospero.install.usage.customSynopsis.2 = \u0020 or:  @|bold ${prospero.dist.name} install|@ @|fg(yellow) --fpl|@=@|italic <URL/GA>|@ @|fg(yellow) --provision-config|@=@|italic <path>|@ [@|fg(yellow) OPTION|@]...
 prospero.install.usage.customSynopsis.3 = \u0020        (to install a feature pack)
 prospero.install.usage.customSynopsis.4 = \u0020 or:  @|bold ${prospero.dist.name} install|@ @|fg(yellow) --definition|@=@|italic <path>|@ [@|fg(yellow) OPTION|@]...
@@ -62,7 +62,7 @@ localRepoOptions.heading = %nMaven cache:%n
 # Option Descriptions
 #
 
-channel = Channel file location. This can be URL, Maven GAV or path. Alternative to --provision-config.
+manifest = Channel manifest file location. This can be URL, Maven GAV or path. Alternative to --provision-config.
 remote-repositories = Remote Maven repositories that contains the artifacts required to install the application \
   server (multiple repositories are separated by comma). These repositories will override any other configured repositories in all channels \
   for this operation only. Valid values are either URLs or ID::URL pairs. \
@@ -88,7 +88,7 @@ local-cache = Path to the local Maven repository cache. It overrides the default
 no-resolve-local-cache = Perform the operation without resolving or installing artifacts from/into local maven cache.
 offline = Perform installation from local or file-system Maven repositories only.
 provision-config = Provisioning configuration file path. This is special JSON configuration file that contains list \
-  of channel file references and list of remote Maven repositories. Alternative to --channel and --remote-repositories.
+  of channel file references and list of remote Maven repositories. Alternative to --manifest and --remote-repositories.
 revision = Hash of an installation state.
 repoId = Repository ID
 repoUrl = Repository URL

--- a/prospero-cli/src/main/resources/UsageMessages.properties
+++ b/prospero-cli/src/main/resources/UsageMessages.properties
@@ -64,10 +64,11 @@ localRepoOptions.heading = %nMaven cache:%n
 
 channel = Channel file location. This can be URL, Maven GAV or path. Alternative to --provision-config.
 remote-repositories = URLs of remote Maven repositories that contains the artifacts required to install the application \
-  server (multiple URLs are separated by comma). Alternative to --provision-config.
+  server (multiple URLs are separated by comma). These repositories will override any other configured repositories in all channels. \
+  Alternative to --provision-config.
 update.remote-repositories = URLs of remote Maven repositories that contains the artifacts required to install the application \
-  server (multiple URLs are separated by comma).
-archive = Path to archive with custom changes.
+  server (multiple URLs are separated by comma). These repositories will override any other configured repositories in all channels \
+  for this operation only. The repositories will not be persisted in the server configuration.
 channel-name = Custom channel name in groupId:artifactId format.
 customization-repository = URL to repository containing custom artifacts.
 definition = Galleon provisioning XML definition file path.
@@ -81,7 +82,7 @@ dry-run = Print components that can be upgraded, but do not perform the upgrades
 fpl = Feature pack location. This can be a feature pack "GA" like "org.jboss.eap:wildfly-ee-galleon-pack", or one of \
   pre-defined feature pack names: \ [${COMPLETION-CANDIDATES}].
 help = Display this help message.
-local-repo = Path to the local Maven repository. It overrides the default Maven repository at ~/.m2/repository.
+local-cache = Path to the local Maven repository cache. It overrides the default Maven repository at ~/.m2/repository.
 no-resolve-local-cache = Perform the operation without resolving or installing artifacts from/into local maven cache.
 offline = Perform installation from local or file-system Maven repositories only.
 provision-config = Provisioning configuration file path. This is special JSON configuration file that contains list \

--- a/prospero-cli/src/main/resources/UsageMessages.properties
+++ b/prospero-cli/src/main/resources/UsageMessages.properties
@@ -63,12 +63,14 @@ localRepoOptions.heading = %nMaven cache:%n
 #
 
 channel = Channel file location. This can be URL, Maven GAV or path. Alternative to --provision-config.
-remote-repositories = URLs of remote Maven repositories that contains the artifacts required to install the application \
-  server (multiple URLs are separated by comma). These repositories will override any other configured repositories in all channels. \
+remote-repositories = Remote Maven repositories that contains the artifacts required to install the application \
+  server (multiple repositories are separated by comma). These repositories will override any other configured repositories in all channels \
+  for this operation only. Valid values are either URLs or ID::URL pairs. \
   Alternative to --provision-config.
-update.remote-repositories = URLs of remote Maven repositories that contains the artifacts required to install the application \
-  server (multiple URLs are separated by comma). These repositories will override any other configured repositories in all channels \
-  for this operation only. The repositories will not be persisted in the server configuration.
+update.remote-repositories = Remote Maven repositories that contains the artifacts required to install the application \
+  server (multiple repositories are separated by comma). These repositories will override any other configured repositories in all channels \
+  for this operation only. Valid values are either URLs or ID::URL pairs. \
+  The repositories will not be persisted in the server configuration.
 channel-name = Custom channel name in groupId:artifactId format.
 customization-repository = URL to repository containing custom artifacts.
 definition = Galleon provisioning XML definition file path.

--- a/prospero-cli/src/main/resources/UsageMessages.properties
+++ b/prospero-cli/src/main/resources/UsageMessages.properties
@@ -28,7 +28,7 @@ prospero.usage.customSynopsis=             @|bold ${prospero.dist.name}|@ [@|fg(
 
 prospero.install.usage.header = Install a new application server instance.
 prospero.install.usage.customSynopsis.0 =             @|bold ${prospero.dist.name} install|@ @|fg(yellow) --fpl|@=@|italic <predefined-name>|@ [@|fg(yellow) OPTION|@]...
-prospero.install.usage.customSynopsis.1 = \u0020 or:  @|bold ${prospero.dist.name} install|@ @|fg(yellow) --fpl|@=@|italic <predefined-name>|@ @|fg(yellow) --manifest|@=@|italic <URL/GAV/path>|@ @|fg(yellow) --remote-repositories|@=@|italic <URL>[,...]|@ [@|fg(yellow) OPTION|@]...
+prospero.install.usage.customSynopsis.1 = \u0020 or:  @|bold ${prospero.dist.name} install|@ @|fg(yellow) --fpl|@=@|italic <predefined-name>|@ @|fg(yellow) --manifest|@=@|italic <URL/GAV/path>|@ @|fg(yellow) --repositories|@=@|italic <URL>[,...]|@ [@|fg(yellow) OPTION|@]...
 prospero.install.usage.customSynopsis.2 = \u0020 or:  @|bold ${prospero.dist.name} install|@ @|fg(yellow) --fpl|@=@|italic <URL/GA>|@ @|fg(yellow) --provision-config|@=@|italic <path>|@ [@|fg(yellow) OPTION|@]...
 prospero.install.usage.customSynopsis.3 = \u0020        (to install a feature pack)
 prospero.install.usage.customSynopsis.4 = \u0020 or:  @|bold ${prospero.dist.name} install|@ @|fg(yellow) --definition|@=@|italic <path>|@ [@|fg(yellow) OPTION|@]...
@@ -43,12 +43,12 @@ prospero.update.usage.customSynopsis.3 = \u0020        (to update ${prospero.dis
 prospero.history.usage.header = List previous installation states.
 prospero.revert.usage.header  = Reverts to a previous installation state.
 
-prospero.repository.usage.header        = Manage list of maven repositories used by an installation.
-prospero.repository.add.usage.header    = Add a maven repository to an installation.
-prospero.repository.list.usage.header   = List maven repositories used by an installation.
-prospero.repository.remove.usage.header = Remove a maven repository from an installation.
 
-prospero.channel.init-channel.usage.header = Add a custom channel to be used by the server
+prospero.channel.usage.header = Manage channels the installation is subscribed to.
+prospero.channel.add.usage.header    = Subscribes the installation to a new channel.
+prospero.channel.list.usage.header   = List channels subscribed to by the installation.
+prospero.channel.remove.usage.header = Unsubscribe the installation from a channel.
+prospero.channel.initialize.usage.header = Add a custom channel to be used by the server
 prospero.channel.promote.usage.header = Promote a bundle of artifacts to a custom repository
 
 #
@@ -62,16 +62,17 @@ localRepoOptions.heading = %nMaven cache:%n
 # Option Descriptions
 #
 
-manifest = Channel manifest file location. This can be URL, Maven GAV or path. Alternative to --provision-config.
-remote-repositories = Remote Maven repositories that contains the artifacts required to install the application \
+archive = Path to the promoted artifact bundle.
+manifest = Location of a Channel Manifest. This can be URL, Maven GAV or path. Alternative to --provision-config.
+prospero.channel.promote.manifest = Location of the custom Channel Manifest in GAV form.
+repositories.0 = Remote Maven repositories that contains the artifacts required to install the application \
   server (multiple repositories are separated by comma). These repositories will override any other configured repositories in all channels \
-  for this operation only. Valid values are either URLs or ID::URL pairs. \
-  Alternative to --provision-config.
-update.remote-repositories = Remote Maven repositories that contains the artifacts required to install the application \
-  server (multiple repositories are separated by comma). These repositories will override any other configured repositories in all channels \
-  for this operation only. Valid values are either URLs or ID::URL pairs. \
-  The repositories will not be persisted in the server configuration.
-channel-name = Custom channel name in groupId:artifactId format.
+  for this operation only. Valid values are either URLs or ID::URL pairs.
+repositories.1 = These repositories will not be persisted in the server configuration.
+prospero.install.repositories.0 = ${repositories.0}
+prospero.install.repositories.1 =  Alternative to --provision-config.
+channel-name = Name of the new channel. Channel names have to be unique within the installation.
+prospero.channel.remove.channel-name = Name of the channel to unsubscribe the installation from.
 customization-repository = URL to repository containing custom artifacts.
 definition = Galleon provisioning XML definition file path.
 
@@ -88,7 +89,7 @@ local-cache = Path to the local Maven repository cache. It overrides the default
 no-resolve-local-cache = Perform the operation without resolving or installing artifacts from/into local maven cache.
 offline = Perform installation from local or file-system Maven repositories only.
 provision-config = Provisioning configuration file path. This is special JSON configuration file that contains list \
-  of channel file references and list of remote Maven repositories. Alternative to --manifest and --remote-repositories.
+  of channel file references and list of remote Maven repositories. Alternative to --manifest and --repositories.
 revision = Hash of an installation state.
 repoId = Repository ID
 repoUrl = Repository URL

--- a/prospero-cli/src/test/java/org/wildfly/prospero/cli/RepositoryDefinitionTest.java
+++ b/prospero-cli/src/test/java/org/wildfly/prospero/cli/RepositoryDefinitionTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.prospero.cli;
+
+import org.apache.commons.lang3.StringUtils;
+import org.junit.Test;
+import org.wildfly.channel.Repository;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+import static org.wildfly.prospero.cli.RepositoryDefinition.from;
+
+public class RepositoryDefinitionTest {
+
+    @Test
+    public void generatesRepositoryIdsIfNotProvided() throws Exception {
+        assertThat(from(List.of("http://test.te")))
+                .map(Repository::getId)
+                .noneMatch(id-> StringUtils.isEmpty(id));
+    }
+
+    @Test
+    public void generatedRepositoryIdsAreUnique() throws Exception {
+        final Set<String> collectedIds = from(List.of("http://test1.te", "http://test2.te", "http://test3.te")).stream()
+                .map(Repository::getId)
+                .collect(Collectors.toSet());
+
+        assertEquals(3, collectedIds.size());
+    }
+
+    @Test
+    public void keepsRepositoryIdsIfProvided() throws Exception {
+        assertThat(from(List.of("repo-1::http://test1.te", "repo-2::http://test2.te", "repo-3::http://test3.te")))
+                .map(Repository::getId)
+                .containsExactly("repo-1", "repo-2", "repo-3");
+    }
+
+    @Test
+    public void mixGeneratedAndProvidedIds() throws Exception {
+        assertThat(from(List.of("repo-1::http://test1.te", "http://test2.te", "repo-3::http://test3.te")))
+                .map(Repository::getId)
+                .contains("repo-1", "repo-3")
+                .hasSize(3)
+                .noneMatch(id-> StringUtils.isEmpty(id));
+    }
+
+    @Test
+    public void throwsErrorIfFormatIsIncorrect() throws Exception {
+        assertThrows(ArgumentParsingException.class, ()->from(List.of("::http://test1.te")));
+
+        assertThrows(ArgumentParsingException.class, ()->from(List.of("repo-1::")));
+
+        assertThrows(ArgumentParsingException.class, ()->from(List.of("repo-1:::http://test1.te")));
+
+        assertThrows(ArgumentParsingException.class, ()->from(List.of("foo::bar::http://test1.te")));
+
+        assertThrows(ArgumentParsingException.class, ()->from(List.of("imnoturl")));
+    }
+}

--- a/prospero-cli/src/test/java/org/wildfly/prospero/cli/commands/AbstractMavenCommandTest.java
+++ b/prospero-cli/src/test/java/org/wildfly/prospero/cli/commands/AbstractMavenCommandTest.java
@@ -48,7 +48,7 @@ public abstract class AbstractMavenCommandTest extends AbstractConsoleTest {
     public void overrideMavenRepoIfLocalRepoParameterPresent() throws Exception {
         doLocalMock();
 
-        int exitCode = commandLine.execute(getArgs(CliConstants.LOCAL_REPO, "test-path"));
+        int exitCode = commandLine.execute(getArgs(CliConstants.LOCAL_CACHE, "test-path"));
 
         assertEquals(ReturnCodes.SUCCESS, exitCode);
         MavenSessionManager msm = getCapturedSessionManager();
@@ -81,7 +81,7 @@ public abstract class AbstractMavenCommandTest extends AbstractConsoleTest {
 
     @Test
     public void noLocalCacheAndLocalRepoAreMutuallyExclusive() throws Exception {
-        int exitCode = commandLine.execute(getArgs(CliConstants.LOCAL_REPO, "test-path", CliConstants.NO_LOCAL_MAVEN_CACHE));
+        int exitCode = commandLine.execute(getArgs(CliConstants.LOCAL_CACHE, "test-path", CliConstants.NO_LOCAL_MAVEN_CACHE));
 
         assertEquals(ReturnCodes.INVALID_ARGUMENTS, exitCode);
     }

--- a/prospero-cli/src/test/java/org/wildfly/prospero/cli/commands/ChannelCommandTest.java
+++ b/prospero-cli/src/test/java/org/wildfly/prospero/cli/commands/ChannelCommandTest.java
@@ -86,8 +86,9 @@ public class ChannelCommandTest extends AbstractConsoleTest {
     public void testAddEmptyRepository() {
         int exitCode = commandLine.execute(CliConstants.Commands.CHANNEL, CliConstants.Commands.ADD,
                 CliConstants.DIR, dir.toString(),
-                CliConstants.MANIFEST, "org.test:test",
-                CliConstants.REPOSITORY, "");
+                CliConstants.CHANNEL_NAME, "channel-0",
+                CliConstants.CHANNEL_MANIFEST, "org.test:test",
+                CliConstants.REPOSITORIES, "");
 
         Assert.assertEquals(ReturnCodes.INVALID_ARGUMENTS, exitCode);
         assertTrue(getErrorOutput().contains(CliMessages.MESSAGES.invalidRepositoryDefinition("")
@@ -95,23 +96,12 @@ public class ChannelCommandTest extends AbstractConsoleTest {
     }
 
     @Test
-    public void testAddInvalidRepositoryNoId() {
-        int exitCode = commandLine.execute(CliConstants.Commands.CHANNEL, CliConstants.Commands.ADD,
-                CliConstants.DIR, dir.toString(),
-                CliConstants.MANIFEST, "org.test:test",
-                CliConstants.REPOSITORY, "http://test.te");
-
-        Assert.assertEquals(ReturnCodes.INVALID_ARGUMENTS, exitCode);
-        assertTrue(getErrorOutput().contains(CliMessages.MESSAGES.invalidRepositoryDefinition("http://test.te")
-                .getMessage()));
-    }
-
-    @Test
     public void testAddInvalidRepositoryTooManyParts() {
         int exitCode = commandLine.execute(CliConstants.Commands.CHANNEL, CliConstants.Commands.ADD,
                 CliConstants.DIR, dir.toString(),
-                CliConstants.MANIFEST, "org.test:test",
-                CliConstants.REPOSITORY, "id::http://test.te::foo");
+                CliConstants.CHANNEL_NAME, "channel-0",
+                CliConstants.CHANNEL_MANIFEST, "org.test:test",
+                CliConstants.REPOSITORIES, "id::http://test.te::foo");
 
         Assert.assertEquals(ReturnCodes.INVALID_ARGUMENTS, exitCode);
         assertTrue(getErrorOutput().contains(CliMessages.MESSAGES.invalidRepositoryDefinition("id::http://test.te::foo")
@@ -122,20 +112,23 @@ public class ChannelCommandTest extends AbstractConsoleTest {
     public void testAdd() throws MetadataException, MalformedURLException {
         int exitCode = commandLine.execute(CliConstants.Commands.CHANNEL, CliConstants.Commands.ADD,
                 CliConstants.DIR, dir.toString(),
-                CliConstants.MANIFEST, "org.test:test",
-                CliConstants.REPOSITORY, "test_repo::http://test.te");
+                CliConstants.CHANNEL_NAME, "channel-0",
+                CliConstants.CHANNEL_MANIFEST, "org.test:test",
+                CliConstants.REPOSITORIES, "test_repo::http://test.te");
         Assert.assertEquals(ReturnCodes.SUCCESS, exitCode);
 
         exitCode = commandLine.execute(CliConstants.Commands.CHANNEL, CliConstants.Commands.ADD,
                 CliConstants.DIR, dir.toString(),
-                CliConstants.MANIFEST, "g:a2",
-                CliConstants.REPOSITORY, "test_repo::http://test.te");
+                CliConstants.CHANNEL_NAME, "channel-1",
+                CliConstants.CHANNEL_MANIFEST, "g:a2",
+                CliConstants.REPOSITORIES, "test_repo::http://test.te");
         Assert.assertEquals(ReturnCodes.SUCCESS, exitCode);
 
         exitCode = commandLine.execute(CliConstants.Commands.CHANNEL, CliConstants.Commands.ADD,
                 CliConstants.DIR, dir.toString(),
-                CliConstants.MANIFEST, "file:/path",
-                CliConstants.REPOSITORY, "test_repo::http://test.te");
+                CliConstants.CHANNEL_NAME, "channel-2",
+                CliConstants.CHANNEL_MANIFEST, "file:/path",
+                CliConstants.REPOSITORIES, "test_repo::http://test.te");
         Assert.assertEquals(ReturnCodes.SUCCESS, exitCode);
 
         InstallationMetadata installationMetadata = new InstallationMetadata(dir);
@@ -166,8 +159,9 @@ public class ChannelCommandTest extends AbstractConsoleTest {
     @Test
     public void testAddInvalidInstallationDir() {
         int exitCode = commandLine.execute(CliConstants.Commands.CHANNEL, CliConstants.Commands.ADD,
-                CliConstants.MANIFEST, "org.test:test",
-                CliConstants.REPOSITORY, "test_repo::http://test.te");
+                CliConstants.CHANNEL_NAME, "channel-0",
+                CliConstants.CHANNEL_MANIFEST, "org.test:test",
+                CliConstants.REPOSITORIES, "test_repo::http://test.te");
 
         Assert.assertEquals(ReturnCodes.INVALID_ARGUMENTS, exitCode);
         assertTrue(getErrorOutput().contains(CliMessages.MESSAGES.invalidInstallationDir(ChannelCommand.currentDir())
@@ -176,7 +170,8 @@ public class ChannelCommandTest extends AbstractConsoleTest {
 
     @Test
     public void testRemoveInvalidInstallationDir() {
-        int exitCode = commandLine.execute(CliConstants.Commands.CHANNEL, CliConstants.Commands.REMOVE, "0");
+        int exitCode = commandLine.execute(CliConstants.Commands.CHANNEL, CliConstants.Commands.REMOVE,
+                CliConstants.CHANNEL_NAME, "test2");
 
         Assert.assertEquals(ReturnCodes.INVALID_ARGUMENTS, exitCode);
         assertTrue(getErrorOutput().contains(CliMessages.MESSAGES.invalidInstallationDir(ChannelCommand.currentDir())
@@ -212,7 +207,8 @@ public class ChannelCommandTest extends AbstractConsoleTest {
             installationMetadata.getProsperoConfig().getChannels().forEach(System.out::println);
         }
         int exitCode = commandLine.execute(CliConstants.Commands.CHANNEL, CliConstants.Commands.REMOVE,
-                CliConstants.DIR, dir.toString(), "1");
+                CliConstants.DIR, dir.toString(),
+                CliConstants.CHANNEL_NAME, "test2");
         Assert.assertEquals(ReturnCodes.SUCCESS, exitCode);
         try (InstallationMetadata installationMetadata = new InstallationMetadata(dir)) {
             assertThat(installationMetadata.getProsperoConfig().getChannels())
@@ -225,7 +221,8 @@ public class ChannelCommandTest extends AbstractConsoleTest {
         }
 
         exitCode = commandLine.execute(CliConstants.Commands.CHANNEL, CliConstants.Commands.REMOVE,
-                CliConstants.DIR, dir.toString(), "0");
+                CliConstants.DIR, dir.toString(),
+                CliConstants.CHANNEL_NAME, "test1");
         Assert.assertEquals(ReturnCodes.SUCCESS, exitCode);
         try (InstallationMetadata installationMetadata = new InstallationMetadata(dir)) {
             assertThat(installationMetadata.getProsperoConfig().getChannels())
@@ -237,7 +234,8 @@ public class ChannelCommandTest extends AbstractConsoleTest {
         }
 
         exitCode = commandLine.execute(CliConstants.Commands.CHANNEL, CliConstants.Commands.REMOVE,
-                CliConstants.DIR, dir.toString(), "0");
+                CliConstants.DIR, dir.toString(),
+                CliConstants.CHANNEL_NAME, "test3");
         Assert.assertEquals(ReturnCodes.SUCCESS, exitCode);
         try (InstallationMetadata installationMetadata = new InstallationMetadata(dir)) {
             assertThat(installationMetadata.getProsperoConfig().getChannels())
@@ -250,23 +248,22 @@ public class ChannelCommandTest extends AbstractConsoleTest {
     @Test
     public void testRemoveNonExisting() {
         int exitCode = commandLine.execute(CliConstants.Commands.CHANNEL, CliConstants.Commands.REMOVE,
-                CliConstants.DIR, dir.toString(), "4");
+                CliConstants.DIR, dir.toString(),
+                CliConstants.CHANNEL_NAME,  "test4");
         Assert.assertEquals(ReturnCodes.INVALID_ARGUMENTS, exitCode);
 
         exitCode = commandLine.execute(CliConstants.Commands.CHANNEL, CliConstants.Commands.REMOVE,
-                CliConstants.DIR, dir.toString(), "-1");
+                CliConstants.DIR, dir.toString(),
+                CliConstants.CHANNEL_NAME, "test-1");
         Assert.assertEquals(ReturnCodes.INVALID_ARGUMENTS, exitCode);
 
-        // remove all channels
+        // remove the channel twice
         commandLine.execute(CliConstants.Commands.CHANNEL, CliConstants.Commands.REMOVE,
-                CliConstants.DIR, dir.toString(), "0");
-        commandLine.execute(CliConstants.Commands.CHANNEL, CliConstants.Commands.REMOVE,
-                CliConstants.DIR, dir.toString(), "0");
-        commandLine.execute(CliConstants.Commands.CHANNEL, CliConstants.Commands.REMOVE,
-                CliConstants.DIR, dir.toString(), "0");
-
+                CliConstants.DIR, dir.toString(),
+                CliConstants.CHANNEL_NAME, "test1");
         exitCode = commandLine.execute(CliConstants.Commands.CHANNEL, CliConstants.Commands.REMOVE,
-                CliConstants.DIR, dir.toString(), "0");
+                CliConstants.DIR, dir.toString(),
+                CliConstants.CHANNEL_NAME, "test1");
         Assert.assertEquals(ReturnCodes.INVALID_ARGUMENTS, exitCode);
     }
 

--- a/prospero-cli/src/test/java/org/wildfly/prospero/cli/commands/InstallCommandTest.java
+++ b/prospero-cli/src/test/java/org/wildfly/prospero/cli/commands/InstallCommandTest.java
@@ -238,12 +238,12 @@ public class InstallCommandTest extends AbstractMavenCommandTest {
 
         int exitCode = commandLine.execute(CliConstants.Commands.INSTALL, CliConstants.DIR, "test",
                 CliConstants.PROVISION_CONFIG, provisionConfigFile.getAbsolutePath(),
-                CliConstants.REMOTE_REPOSITORIES, "file:/test",
+                CliConstants.REPOSITORIES, "file:/test",
                 CliConstants.FPL, "test");
 
         assertEquals(ReturnCodes.INVALID_ARGUMENTS, exitCode);
         assertTrue(getErrorOutput().contains(CliMessages.MESSAGES
-                .exclusiveOptions(CliConstants.PROVISION_CONFIG, CliConstants.REMOTE_REPOSITORIES).getMessage()));
+                .exclusiveOptions(CliConstants.PROVISION_CONFIG, CliConstants.REPOSITORIES).getMessage()));
     }
 
     @Override

--- a/prospero-cli/src/test/java/org/wildfly/prospero/cli/commands/InstallCommandTest.java
+++ b/prospero-cli/src/test/java/org/wildfly/prospero/cli/commands/InstallCommandTest.java
@@ -224,12 +224,12 @@ public class InstallCommandTest extends AbstractMavenCommandTest {
 
         int exitCode = commandLine.execute(CliConstants.Commands.INSTALL, CliConstants.DIR, "test",
                 CliConstants.PROVISION_CONFIG, provisionConfigFile.getAbsolutePath(),
-                CliConstants.CHANNEL, "g:a:v",
+                CliConstants.CHANNEL_MANIFEST, "g:a:v",
                 CliConstants.FPL, "test");
 
         assertEquals(ReturnCodes.INVALID_ARGUMENTS, exitCode);
         assertTrue(getErrorOutput().contains(CliMessages.MESSAGES
-                .exclusiveOptions(CliConstants.PROVISION_CONFIG, CliConstants.CHANNEL).getMessage()));
+                .exclusiveOptions(CliConstants.PROVISION_CONFIG, CliConstants.CHANNEL_MANIFEST).getMessage()));
     }
 
     @Test

--- a/prospero-cli/src/test/java/org/wildfly/prospero/cli/commands/RevertCommandTest.java
+++ b/prospero-cli/src/test/java/org/wildfly/prospero/cli/commands/RevertCommandTest.java
@@ -123,7 +123,7 @@ public class RevertCommandTest extends AbstractMavenCommandTest {
     public void passRemoteRepositories() throws Exception {
         int exitCode = commandLine.execute(CliConstants.Commands.REVERT, CliConstants.DIR, installationDir.toString(),
                 CliConstants.REVISION, "abcd",
-                CliConstants.REMOTE_REPOSITORIES, "http://temp.repo.te",
+                CliConstants.REPOSITORIES, "http://temp.repo.te",
                 CliConstants.LOCAL_CACHE, "local-repo");
 
         assertEquals(ReturnCodes.SUCCESS, exitCode);

--- a/prospero-cli/src/test/java/org/wildfly/prospero/cli/commands/RevertCommandTest.java
+++ b/prospero-cli/src/test/java/org/wildfly/prospero/cli/commands/RevertCommandTest.java
@@ -17,7 +17,6 @@
 
 package org.wildfly.prospero.cli.commands;
 
-import java.net.URL;
 import java.nio.file.Path;
 import java.util.List;
 
@@ -31,6 +30,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
+import org.wildfly.channel.Repository;
 import org.wildfly.prospero.actions.Console;
 import org.wildfly.prospero.actions.InstallationHistoryAction;
 import org.wildfly.prospero.api.SavedState;
@@ -40,6 +40,7 @@ import org.wildfly.prospero.cli.ReturnCodes;
 import org.wildfly.prospero.test.MetadataTestUtils;
 import org.wildfly.prospero.wfchannel.MavenSessionManager;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -54,6 +55,9 @@ public class RevertCommandTest extends AbstractMavenCommandTest {
 
     @Captor
     private ArgumentCaptor<MavenSessionManager> mavenSessionManager;
+
+    @Captor
+    private ArgumentCaptor<List<Repository>> repositories;
 
     @Rule
     public TemporaryFolder tempDir = new TemporaryFolder();
@@ -123,7 +127,11 @@ public class RevertCommandTest extends AbstractMavenCommandTest {
                 CliConstants.LOCAL_CACHE, "local-repo");
 
         assertEquals(ReturnCodes.SUCCESS, exitCode);
-        verify(historyAction).rollback(eq(new SavedState("abcd")), any(), eq(List.of(new URL("http://temp.repo.te"))));
+        verify(historyAction).rollback(eq(new SavedState("abcd")), any(), repositories.capture());
+
+        assertThat(repositories.getValue())
+                .map(Repository::getUrl)
+                .containsExactly("http://temp.repo.te");
     }
 
     @Override

--- a/prospero-cli/src/test/java/org/wildfly/prospero/cli/commands/RevertCommandTest.java
+++ b/prospero-cli/src/test/java/org/wildfly/prospero/cli/commands/RevertCommandTest.java
@@ -17,7 +17,9 @@
 
 package org.wildfly.prospero.cli.commands;
 
+import java.net.URL;
 import java.nio.file.Path;
+import java.util.List;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -99,23 +101,34 @@ public class RevertCommandTest extends AbstractMavenCommandTest {
                 CliConstants.REVISION, "abcd");
 
         assertEquals(ReturnCodes.SUCCESS, exitCode);
-        verify(historyAction).rollback(eq(new SavedState("abcd")), any());
+        verify(historyAction).rollback(eq(new SavedState("abcd")), any(), any());
     }
 
     @Test
     public void useOfflineMavenSessionManagerIfOfflineSet() throws Exception {
         int exitCode = commandLine.execute(CliConstants.Commands.REVERT, CliConstants.DIR, installationDir.toString(),
                 CliConstants.REVISION, "abcd",
-                CliConstants.OFFLINE, CliConstants.LOCAL_REPO, "local-repo");
+                CliConstants.OFFLINE, CliConstants.LOCAL_CACHE, "local-repo");
 
         assertEquals(ReturnCodes.SUCCESS, exitCode);
-        verify(historyAction).rollback(eq(new SavedState("abcd")), mavenSessionManager.capture());
+        verify(historyAction).rollback(eq(new SavedState("abcd")), mavenSessionManager.capture(), any());
         assertTrue(mavenSessionManager.getValue().isOffline());
+    }
+
+    @Test
+    public void passRemoteRepositories() throws Exception {
+        int exitCode = commandLine.execute(CliConstants.Commands.REVERT, CliConstants.DIR, installationDir.toString(),
+                CliConstants.REVISION, "abcd",
+                CliConstants.REMOTE_REPOSITORIES, "http://temp.repo.te",
+                CliConstants.LOCAL_CACHE, "local-repo");
+
+        assertEquals(ReturnCodes.SUCCESS, exitCode);
+        verify(historyAction).rollback(eq(new SavedState("abcd")), any(), eq(List.of(new URL("http://temp.repo.te"))));
     }
 
     @Override
     protected MavenSessionManager getCapturedSessionManager() throws Exception {
-        verify(historyAction).rollback(eq(new SavedState("abcd")), mavenSessionManager.capture());
+        verify(historyAction).rollback(eq(new SavedState("abcd")), mavenSessionManager.capture(), any());
         return mavenSessionManager.getValue();
     }
 

--- a/prospero-cli/src/test/java/org/wildfly/prospero/cli/commands/channel/ChannelInitializeCommandTest.java
+++ b/prospero-cli/src/test/java/org/wildfly/prospero/cli/commands/channel/ChannelInitializeCommandTest.java
@@ -83,7 +83,7 @@ public class ChannelInitializeCommandTest extends AbstractConsoleTest {
         int exitCode = commandLine.execute(
                 CliConstants.Commands.CHANNEL, CliConstants.Commands.CUSTOMIZATION_INIT_CHANNEL,
                 CliConstants.DIR, installationDir.toString(),
-                CliConstants.CUSTOMIZATION_CHANNEL_NAME, "org.test:custom-channel",
+                CliConstants.CHANNEL_MANIFEST, "org.test:custom-channel",
                 CliConstants.CUSTOMIZATION_REPOSITORY_URL, customRepoUrl);
         Assert.assertEquals(ReturnCodes.SUCCESS, exitCode);
         assertThat(actualChannels())
@@ -112,7 +112,7 @@ public class ChannelInitializeCommandTest extends AbstractConsoleTest {
         int exitCode = commandLine.execute(
                 CliConstants.Commands.CHANNEL, CliConstants.Commands.CUSTOMIZATION_INIT_CHANNEL,
                 CliConstants.DIR, installationDir.toString(),
-                CliConstants.CUSTOMIZATION_CHANNEL_NAME, "org.test:custom-channel",
+                CliConstants.CHANNEL_MANIFEST, "org.test:custom-channel",
                 CliConstants.CUSTOMIZATION_REPOSITORY_URL, customRepoUrl);
 
         Assert.assertEquals(ReturnCodes.INVALID_ARGUMENTS, exitCode);
@@ -131,7 +131,7 @@ public class ChannelInitializeCommandTest extends AbstractConsoleTest {
         int exitCode = commandLine.execute(
                 CliConstants.Commands.CHANNEL, CliConstants.Commands.CUSTOMIZATION_INIT_CHANNEL,
                 CliConstants.DIR, installationDir.toString(),
-                CliConstants.CUSTOMIZATION_CHANNEL_NAME, "org.test.custom-channel",
+                CliConstants.CHANNEL_MANIFEST, "org.test.custom-channel",
                 CliConstants.CUSTOMIZATION_REPOSITORY_URL, customRepoUrl);
 
         Assert.assertEquals(ReturnCodes.INVALID_ARGUMENTS, exitCode);
@@ -152,7 +152,7 @@ public class ChannelInitializeCommandTest extends AbstractConsoleTest {
         int exitCode = commandLine.execute(
                 CliConstants.Commands.CHANNEL, CliConstants.Commands.CUSTOMIZATION_INIT_CHANNEL,
                 CliConstants.DIR, installationDir.toString(),
-                CliConstants.CUSTOMIZATION_CHANNEL_NAME, "org.test:custom-channel",
+                CliConstants.CHANNEL_MANIFEST, "org.test:custom-channel",
                 CliConstants.CUSTOMIZATION_REPOSITORY_URL, customRepoUrl);
 
         Assert.assertEquals(ReturnCodes.SUCCESS, exitCode);
@@ -172,7 +172,7 @@ public class ChannelInitializeCommandTest extends AbstractConsoleTest {
             int exitCode = commandLine.execute(
                     CliConstants.Commands.CHANNEL, CliConstants.Commands.CUSTOMIZATION_INIT_CHANNEL,
                     CliConstants.DIR, installationDir.toString(),
-                    CliConstants.CUSTOMIZATION_CHANNEL_NAME, "org.test:custom-channel",
+                    CliConstants.CHANNEL_MANIFEST, "org.test:custom-channel",
                     CliConstants.CUSTOMIZATION_REPOSITORY_URL, customRepoUrl);
 
             Assert.assertEquals(ReturnCodes.PROCESSING_ERROR, exitCode);
@@ -201,7 +201,7 @@ public class ChannelInitializeCommandTest extends AbstractConsoleTest {
         int exitCode = commandLine.execute(
                 CliConstants.Commands.CHANNEL, CliConstants.Commands.CUSTOMIZATION_INIT_CHANNEL,
                 CliConstants.DIR, installationDir.toString(),
-                CliConstants.CUSTOMIZATION_CHANNEL_NAME, "org.test:custom-channel",
+                CliConstants.CHANNEL_MANIFEST, "org.test:custom-channel",
                 CliConstants.CUSTOMIZATION_REPOSITORY_URL, customRepoUrl);
 
         Assert.assertEquals(ReturnCodes.PROCESSING_ERROR, exitCode);
@@ -222,7 +222,7 @@ public class ChannelInitializeCommandTest extends AbstractConsoleTest {
         int exitCode = commandLine.execute(
                 CliConstants.Commands.CHANNEL, CliConstants.Commands.CUSTOMIZATION_INIT_CHANNEL,
                 CliConstants.DIR, installationDir.toString(),
-                CliConstants.CUSTOMIZATION_CHANNEL_NAME, "org.test:custom-channel");
+                CliConstants.CHANNEL_MANIFEST, "org.test:custom-channel");
 
         Assert.assertEquals(ReturnCodes.SUCCESS, exitCode);
         assertThat(actualRepositories())

--- a/prospero-cli/src/test/java/org/wildfly/prospero/cli/commands/channel/ChannelPromoteCommandTest.java
+++ b/prospero-cli/src/test/java/org/wildfly/prospero/cli/commands/channel/ChannelPromoteCommandTest.java
@@ -76,7 +76,7 @@ public class ChannelPromoteCommandTest extends AbstractConsoleTest {
                 CliConstants.Commands.CHANNEL, CUSTOMIZATION_PROMOTE,
                 CliConstants.CUSTOMIZATION_REPOSITORY_URL, "file:///test/test",
                 CliConstants.CUSTOMIZATION_ARCHIVE, "test/archive.zip",
-                CliConstants.CUSTOMIZATION_CHANNEL_NAME, "org.test:custom-channel");
+                CliConstants.CHANNEL_MANIFEST, "org.test:custom-channel");
 
         assertEquals(ReturnCodes.SUCCESS, exitCode);
         verify(promoter).promote(Paths.get("test/archive.zip").toAbsolutePath(), new URL("file:///test/test"),
@@ -88,7 +88,7 @@ public class ChannelPromoteCommandTest extends AbstractConsoleTest {
         int exitCode = commandLine.execute(
                 CliConstants.Commands.CHANNEL, CUSTOMIZATION_PROMOTE,
                 CliConstants.CUSTOMIZATION_ARCHIVE, "test/archive.zip",
-                CliConstants.CUSTOMIZATION_CHANNEL_NAME, "org.test:custom-channel");
+                CliConstants.CHANNEL_MANIFEST, "org.test:custom-channel");
 
         assertEquals(ReturnCodes.INVALID_ARGUMENTS, exitCode);
         assertTrue(getErrorOutput().contains("Unable to determine custom channel and repository"));
@@ -99,7 +99,7 @@ public class ChannelPromoteCommandTest extends AbstractConsoleTest {
         int exitCode = commandLine.execute(
                 CliConstants.Commands.CHANNEL, CUSTOMIZATION_PROMOTE,
                 CliConstants.CUSTOMIZATION_REPOSITORY_URL, "file:///test/test",
-                CliConstants.CUSTOMIZATION_CHANNEL_NAME, "org.test:custom-channel");
+                CliConstants.CHANNEL_MANIFEST, "org.test:custom-channel");
 
         assertEquals(ReturnCodes.INVALID_ARGUMENTS, exitCode);
         assertTrue(getErrorOutput().contains(String.format("Missing required option: '%s", CliConstants.CUSTOMIZATION_ARCHIVE)));
@@ -122,7 +122,7 @@ public class ChannelPromoteCommandTest extends AbstractConsoleTest {
                 CliConstants.Commands.CHANNEL, CUSTOMIZATION_PROMOTE,
                 CliConstants.CUSTOMIZATION_REPOSITORY_URL, "file:///test/test",
                 CliConstants.CUSTOMIZATION_ARCHIVE, "test/archive.zip",
-                CliConstants.CUSTOMIZATION_CHANNEL_NAME, "wrongchannelsyntax");
+                CliConstants.CHANNEL_MANIFEST, "wrongchannelsyntax");
 
         assertEquals(ReturnCodes.INVALID_ARGUMENTS, exitCode);
         assertTrue(getErrorOutput().contains(CliMessages.MESSAGES.wrongChannelCoordinateFormat()));
@@ -163,7 +163,7 @@ public class ChannelPromoteCommandTest extends AbstractConsoleTest {
         int exitCode = commandLine.execute(
                 CliConstants.Commands.CHANNEL, CUSTOMIZATION_PROMOTE,
                 CliConstants.CUSTOMIZATION_REPOSITORY_URL, "http://test.repo",
-                CliConstants.CUSTOMIZATION_CHANNEL_NAME, "org.custom:test",
+                CliConstants.CHANNEL_MANIFEST, "org.custom:test",
                 CliConstants.CUSTOMIZATION_ARCHIVE, "test/archive.zip",
                 CliConstants.DIR, installationDir.toString()
         );

--- a/prospero-cli/src/test/java/org/wildfly/prospero/cli/commands/options/LocalRepoOptionsTest.java
+++ b/prospero-cli/src/test/java/org/wildfly/prospero/cli/commands/options/LocalRepoOptionsTest.java
@@ -37,7 +37,7 @@ public class LocalRepoOptionsTest {
 
     @Test
     public void defaultLocalPathIfNoOptionsSpecified() throws Exception {
-        assertEquals(Optional.of(MavenSessionManager.LOCAL_MAVEN_REPO), LocalRepoOptions.getLocalRepo(null));
+        assertEquals(Optional.of(MavenSessionManager.LOCAL_MAVEN_REPO), LocalRepoOptions.getLocalMavenCache(null));
     }
 
     @Test
@@ -45,25 +45,25 @@ public class LocalRepoOptionsTest {
         final LocalRepoOptions localRepoParam = new LocalRepoOptions();
         localRepoParam.noLocalCache = true;
 
-        assertEquals(Optional.empty(), LocalRepoOptions.getLocalRepo(localRepoParam));
+        assertEquals(Optional.empty(), LocalRepoOptions.getLocalMavenCache(localRepoParam));
     }
 
     @Test
     public void customLocalPathIfLocalRepoSpecified() throws Exception {
         final LocalRepoOptions localRepoParam = new LocalRepoOptions();
         final Path localRepo = temp.newFolder().toPath();
-        localRepoParam.localRepo = localRepo;
+        localRepoParam.localMavenCache = localRepo;
 
-        assertEquals(Optional.of(localRepo), LocalRepoOptions.getLocalRepo(localRepoParam));
+        assertEquals(Optional.of(localRepo), LocalRepoOptions.getLocalMavenCache(localRepoParam));
     }
 
     @Test
     public void localRepoPointsAtFile() throws Exception {
         final LocalRepoOptions localRepoParam = new LocalRepoOptions();
         File file = temp.newFile();
-        localRepoParam.localRepo = file.toPath();
+        localRepoParam.localMavenCache = file.toPath();
         Assert.assertThrows(ArgumentParsingException.class, () ->
-                LocalRepoOptions.getLocalRepo(localRepoParam)
+                LocalRepoOptions.getLocalMavenCache(localRepoParam)
         );
     }
 }

--- a/prospero-common/src/main/java/org/wildfly/prospero/Messages.java
+++ b/prospero-common/src/main/java/org/wildfly/prospero/Messages.java
@@ -91,4 +91,7 @@ public interface Messages {
 
     @Message("Path `%s` does not contain a server installation provisioned by prospero.")
     IllegalArgumentException invalidInstallationDir(Path path);
+
+    @Message("Unable to parse repository definition: %s")
+    IllegalArgumentException invalidRepositoryDefinition(String text);
 }

--- a/prospero-common/src/main/java/org/wildfly/prospero/Messages.java
+++ b/prospero-common/src/main/java/org/wildfly/prospero/Messages.java
@@ -91,7 +91,4 @@ public interface Messages {
 
     @Message("Path `%s` does not contain a server installation provisioned by prospero.")
     IllegalArgumentException invalidInstallationDir(Path path);
-
-    @Message("Unable to parse repository definition: %s")
-    IllegalArgumentException invalidRepositoryDefinition(String text);
 }

--- a/prospero-common/src/main/java/org/wildfly/prospero/actions/InstallationHistoryAction.java
+++ b/prospero-common/src/main/java/org/wildfly/prospero/actions/InstallationHistoryAction.java
@@ -33,10 +33,8 @@ import org.wildfly.prospero.model.ProsperoConfig;
 import org.wildfly.prospero.wfchannel.MavenSessionManager;
 import org.jboss.galleon.ProvisioningException;
 
-import java.net.URL;
 import java.nio.file.Path;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import static org.wildfly.prospero.galleon.GalleonUtils.MAVEN_REPO_LOCAL;
 
@@ -60,11 +58,9 @@ public class InstallationHistoryAction {
         return installationMetadata.getRevisions();
     }
 
-    public void rollback(SavedState savedState, MavenSessionManager mavenSessionManager, List<URL> overrideRepositoryUrls) throws OperationException, ProvisioningException {
+    public void rollback(SavedState savedState, MavenSessionManager mavenSessionManager, List<Repository> overrideRepositories) throws OperationException, ProvisioningException {
         InstallationMetadata metadata = new InstallationMetadata(installation);
 
-        final List<Repository> overrideRepositories = TemporaryRepositoriesHandler.from(
-                overrideRepositoryUrls.stream().map(URL::toExternalForm).collect(Collectors.toList()));
         final ProsperoConfig prosperoConfig = new ProsperoConfig(
                 TemporaryRepositoriesHandler.addRepositories(metadata.getProsperoConfig().getChannels(), overrideRepositories));
 

--- a/prospero-common/src/main/java/org/wildfly/prospero/actions/InstallationHistoryAction.java
+++ b/prospero-common/src/main/java/org/wildfly/prospero/actions/InstallationHistoryAction.java
@@ -18,7 +18,9 @@
 package org.wildfly.prospero.actions;
 
 import org.jboss.galleon.ProvisioningManager;
+import org.wildfly.channel.Repository;
 import org.wildfly.channel.UnresolvedMavenArtifactException;
+import org.wildfly.prospero.api.TemporaryRepositoriesHandler;
 import org.wildfly.prospero.api.ArtifactChange;
 import org.wildfly.prospero.api.exceptions.ArtifactResolutionException;
 import org.wildfly.prospero.api.exceptions.OperationException;
@@ -31,8 +33,10 @@ import org.wildfly.prospero.model.ProsperoConfig;
 import org.wildfly.prospero.wfchannel.MavenSessionManager;
 import org.jboss.galleon.ProvisioningException;
 
+import java.net.URL;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static org.wildfly.prospero.galleon.GalleonUtils.MAVEN_REPO_LOCAL;
 
@@ -56,11 +60,16 @@ public class InstallationHistoryAction {
         return installationMetadata.getRevisions();
     }
 
-    public void rollback(SavedState savedState, MavenSessionManager mavenSessionManager) throws OperationException, ProvisioningException {
+    public void rollback(SavedState savedState, MavenSessionManager mavenSessionManager, List<URL> overrideRepositoryUrls) throws OperationException, ProvisioningException {
         InstallationMetadata metadata = new InstallationMetadata(installation);
+
+        final List<Repository> overrideRepositories = TemporaryRepositoriesHandler.from(
+                overrideRepositoryUrls.stream().map(URL::toExternalForm).collect(Collectors.toList()));
+        final ProsperoConfig prosperoConfig = new ProsperoConfig(
+                TemporaryRepositoriesHandler.addRepositories(metadata.getProsperoConfig().getChannels(), overrideRepositories));
+
         try {
             metadata = metadata.rollback(savedState);
-            final ProsperoConfig prosperoConfig = metadata.getProsperoConfig();
             final GalleonEnvironment galleonEnv = GalleonEnvironment
                     .builder(installation, prosperoConfig, mavenSessionManager)
                     .setConsole(console)

--- a/prospero-common/src/main/java/org/wildfly/prospero/actions/MetadataAction.java
+++ b/prospero-common/src/main/java/org/wildfly/prospero/actions/MetadataAction.java
@@ -41,12 +41,14 @@ public class MetadataAction implements AutoCloseable {
         this.installationMetadata = installationMetadata;
     }
 
-
-    // channels clash if they define the same manifest & repositories
     public void addChannel(Channel channel) throws MetadataException {
         final ProsperoConfig prosperoConfig = installationMetadata.getProsperoConfig();
         final List<Channel> channels = prosperoConfig.getChannels();
-        // TODO: check for duplicates
+
+        if (channels.stream().filter(c->c.getName().equals(channel.getName())).findAny().isPresent()) {
+            throw new MetadataException(String.format("Channel %s already exists", channel.getName()));
+        }
+
         channels.add(channel);
         installationMetadata.updateProsperoConfig(prosperoConfig);
     }

--- a/prospero-common/src/main/java/org/wildfly/prospero/actions/UpdateAction.java
+++ b/prospero-common/src/main/java/org/wildfly/prospero/actions/UpdateAction.java
@@ -20,12 +20,12 @@ package org.wildfly.prospero.actions;
 import java.net.URL;
 import java.nio.file.Path;
 import java.util.List;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.wildfly.channel.Channel;
 import org.wildfly.channel.Repository;
 import org.wildfly.channel.UnresolvedMavenArtifactException;
+import org.wildfly.prospero.api.TemporaryRepositoriesHandler;
 import org.wildfly.prospero.api.InstallationMetadata;
 import org.wildfly.prospero.api.exceptions.MetadataException;
 import org.wildfly.prospero.api.exceptions.ArtifactResolutionException;
@@ -46,11 +46,11 @@ public class UpdateAction implements AutoCloseable {
     private final GalleonEnvironment galleonEnv;
     private final ProsperoConfig prosperoConfig;
 
-    public UpdateAction(Path installDir, MavenSessionManager mavenSessionManager, Console console, List<URL> additionalRepositories)
+    public UpdateAction(Path installDir, MavenSessionManager mavenSessionManager, Console console, List<URL> overrideRepositories)
             throws ProvisioningException, OperationException {
         this.metadata = new InstallationMetadata(installDir);
 
-        this.prosperoConfig = addTemporaryRepositories(additionalRepositories);
+        this.prosperoConfig = addTemporaryRepositories(overrideRepositories);
         galleonEnv = GalleonEnvironment
                 .builder(installDir, prosperoConfig, mavenSessionManager)
                 .setConsole(console)
@@ -79,18 +79,14 @@ public class UpdateAction implements AutoCloseable {
         metadata.close();
     }
 
-    private ProsperoConfig addTemporaryRepositories(List<URL> additionalRepositories) {
+    private ProsperoConfig addTemporaryRepositories(List<URL> repositoryUrls) {
         final ProsperoConfig prosperoConfig = metadata.getProsperoConfig();
-        for (Channel channel : prosperoConfig.getChannels()) {
-            int i = 0;
-            final Set<String> existingRepos = channel.getRepositories().stream().map(Repository::getUrl).collect(Collectors.toSet());
-            for (URL additionalRepository : additionalRepositories) {
-                if (!existingRepos.contains(additionalRepository.toString())) {
-                    channel.getRepositories().add(new Repository("temp-repo-"+i++, additionalRepository.toString()));
-                }
-            }
-        }
-        return prosperoConfig;
+
+        final List<Repository> repositories = TemporaryRepositoriesHandler.from(
+                repositoryUrls.stream().map(URL::toExternalForm).collect(Collectors.toList()));
+        final List<Channel> channels = TemporaryRepositoriesHandler.addRepositories(prosperoConfig.getChannels(), repositories);
+
+        return new ProsperoConfig(channels);
     }
 
     private void applyUpdates() throws ProvisioningException, ArtifactResolutionException {

--- a/prospero-common/src/main/java/org/wildfly/prospero/actions/UpdateAction.java
+++ b/prospero-common/src/main/java/org/wildfly/prospero/actions/UpdateAction.java
@@ -17,10 +17,8 @@
 
 package org.wildfly.prospero.actions;
 
-import java.net.URL;
 import java.nio.file.Path;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import org.wildfly.channel.Channel;
 import org.wildfly.channel.Repository;
@@ -46,7 +44,7 @@ public class UpdateAction implements AutoCloseable {
     private final GalleonEnvironment galleonEnv;
     private final ProsperoConfig prosperoConfig;
 
-    public UpdateAction(Path installDir, MavenSessionManager mavenSessionManager, Console console, List<URL> overrideRepositories)
+    public UpdateAction(Path installDir, MavenSessionManager mavenSessionManager, Console console, List<Repository> overrideRepositories)
             throws ProvisioningException, OperationException {
         this.metadata = new InstallationMetadata(installDir);
 
@@ -79,11 +77,9 @@ public class UpdateAction implements AutoCloseable {
         metadata.close();
     }
 
-    private ProsperoConfig addTemporaryRepositories(List<URL> repositoryUrls) {
+    private ProsperoConfig addTemporaryRepositories(List<Repository> repositories) {
         final ProsperoConfig prosperoConfig = metadata.getProsperoConfig();
 
-        final List<Repository> repositories = TemporaryRepositoriesHandler.from(
-                repositoryUrls.stream().map(URL::toExternalForm).collect(Collectors.toList()));
         final List<Channel> channels = TemporaryRepositoriesHandler.addRepositories(prosperoConfig.getChannels(), repositories);
 
         return new ProsperoConfig(channels);

--- a/prospero-common/src/main/java/org/wildfly/prospero/api/ProvisioningDefinition.java
+++ b/prospero-common/src/main/java/org/wildfly/prospero/api/ProvisioningDefinition.java
@@ -60,7 +60,7 @@ public class ProvisioningDefinition {
     private ProvisioningDefinition(Builder builder) throws ArtifactResolutionException, NoChannelException {
         final Optional<String> fpl = Optional.ofNullable(builder.fpl);
         final Optional<URI> definition = Optional.ofNullable(builder.definitionFile);
-        final List<String> additionalRepos = builder.additionalRepositories;
+        final List<String> overrideRepos = builder.overrideRepositories;
         final Optional<Path> provisionConfigFile = Optional.ofNullable(builder.provisionConfigFile);
         final Optional<ChannelManifestCoordinate> manifest = Optional.ofNullable(builder.manifest);
         final Optional<Set<String>> includedPackages = Optional.ofNullable(builder.includedPackages);
@@ -73,7 +73,7 @@ public class ProvisioningDefinition {
                 this.fpl = null;
                 this.definition = featurePackInfo.getGalleonConfiguration();
                 this.repositories.addAll(featurePackInfo.getRemoteRepositories());
-                setUpBuildEnv(additionalRepos, provisionConfigFile, manifest, featurePackInfo.getChannels());
+                setUpBuildEnv(overrideRepos, provisionConfigFile, manifest, featurePackInfo.getChannels());
             } else if (provisionConfigFile.isPresent()) {
                 this.fpl = fpl.orElse(null);
                 this.definition = definition.orElse(null);
@@ -128,16 +128,6 @@ public class ProvisioningDefinition {
         }
     }
 
-    private List<Repository> mapOverrideRepos(List<String> overrideRemoteRepos) {
-        ArrayList<Repository> repos = new ArrayList<>();
-        for (int i = 0; i < overrideRemoteRepos.size(); i++) {
-            String url = overrideRemoteRepos.get(i);
-            final String channelRepoId = "repo-" + (i);
-            repos.add(new Repository(channelRepoId, url));
-        }
-        return repos;
-    }
-
     public static Builder builder() {
         return new Builder();
     }
@@ -182,7 +172,7 @@ public class ProvisioningDefinition {
         private String fpl;
         private Path provisionConfigFile;
         private URI definitionFile;
-        private List<String> additionalRepositories = Collections.emptyList();
+        private List<String> overrideRepositories = Collections.emptyList();
         private Set<String> includedPackages;
         private ChannelManifestCoordinate manifest;
 
@@ -201,8 +191,8 @@ public class ProvisioningDefinition {
             return this;
         }
 
-        public Builder setAdditionalRepositories(List<String> repositories) {
-            this.additionalRepositories = repositories;
+        public Builder setOverrideRepositories(List<String> repositories) {
+            this.overrideRepositories = repositories;
             return this;
         }
 

--- a/prospero-common/src/main/java/org/wildfly/prospero/api/TemporaryRepositoriesHandler.java
+++ b/prospero-common/src/main/java/org/wildfly/prospero/api/TemporaryRepositoriesHandler.java
@@ -19,10 +19,7 @@ package org.wildfly.prospero.api;
 
 import org.wildfly.channel.Channel;
 import org.wildfly.channel.Repository;
-import org.wildfly.prospero.Messages;
 
-import java.net.MalformedURLException;
-import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -40,47 +37,12 @@ public class TemporaryRepositoriesHandler {
         ArrayList<Channel> mergedChannels = new ArrayList<>(originalChannels.size());
 
         for (Channel oc : originalChannels) {
-            final List<Repository> repositories = mergeRepositories(oc.getRepositories(), additionalRepositories);
             final Channel c = new Channel(oc.getSchemaVersion(), oc.getName(), oc.getDescription(), oc.getVendor(),
-                    oc.getChannelRequirements(), repositories, oc.getManifestRef());
+                    oc.getChannelRequirements(), additionalRepositories, oc.getManifestRef());
             mergedChannels.add(c);
         }
 
         return mergedChannels;
     }
 
-    public static List<Repository> from(List<String> repos) {
-        ArrayList<Repository> repositories = new ArrayList<>(repos.size());
-        for (int i = 0; i < repos.size(); i++) {
-            final String text = repos.get(i);
-            if(text.contains("::")) {
-                final String[] parts = text.split("::");
-                if (parts.length != 2 || parts[0].isEmpty() || parts[1].isEmpty() || !isValidUrl(parts[1])) {
-                    throw Messages.MESSAGES.invalidRepositoryDefinition(text);
-                }
-
-                repositories.add(new Repository(parts[0], parts[1]));
-            } else {
-                if (!isValidUrl(text)) {
-                    throw Messages.MESSAGES.invalidRepositoryDefinition(text);
-                }
-
-                repositories.add(new Repository("temp-repo-" + i, text));
-            }
-        }
-        return repositories;
-    }
-
-    private static boolean isValidUrl(String text) {
-        try {
-            new URL(text);
-            return true;
-        } catch (MalformedURLException e) {
-            return false;
-        }
-    }
-
-    private static List<Repository> mergeRepositories(List<Repository> originalRepositories, List<Repository> additionalRepositories) {
-        return additionalRepositories;
-    }
 }

--- a/prospero-common/src/main/java/org/wildfly/prospero/api/TemporaryRepositoriesHandler.java
+++ b/prospero-common/src/main/java/org/wildfly/prospero/api/TemporaryRepositoriesHandler.java
@@ -1,32 +1,31 @@
 /*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
  *
- *  * Copyright 2022 Red Hat, Inc. and/or its affiliates
- *  * and other contributors as indicated by the @author tags.
- *  *
- *  * Licensed under the Apache License, Version 2.0 (the "License");
- *  * you may not use this file except in compliance with the License.
- *  * You may obtain a copy of the License at
- *  *
- *  *   http://www.apache.org/licenses/LICENSE-2.0
- *  *
- *  * Unless required by applicable law or agreed to in writing, software
- *  * distributed under the License is distributed on an "AS IS" BASIS,
- *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  * See the License for the specific language governing permissions and
- *  * limitations under the License.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package org.wildfly.prospero.api;
 
 import org.wildfly.channel.Channel;
 import org.wildfly.channel.Repository;
+import org.wildfly.prospero.Messages;
 
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 
 public class TemporaryRepositoriesHandler {
 
@@ -51,9 +50,34 @@ public class TemporaryRepositoriesHandler {
     }
 
     public static List<Repository> from(List<String> repos) {
-        return IntStream.range(0, repos.size())
-                .mapToObj(i -> new Repository("temp-repo-" + i, repos.get(i)))
-                .collect(Collectors.toList());
+        ArrayList<Repository> repositories = new ArrayList<>(repos.size());
+        for (int i = 0; i < repos.size(); i++) {
+            final String text = repos.get(i);
+            if(text.contains("::")) {
+                final String[] parts = text.split("::");
+                if (parts.length != 2 || parts[0].isEmpty() || parts[1].isEmpty() || !isValidUrl(parts[1])) {
+                    throw Messages.MESSAGES.invalidRepositoryDefinition(text);
+                }
+
+                repositories.add(new Repository(parts[0], parts[1]));
+            } else {
+                if (!isValidUrl(text)) {
+                    throw Messages.MESSAGES.invalidRepositoryDefinition(text);
+                }
+
+                repositories.add(new Repository("temp-repo-" + i, text));
+            }
+        }
+        return repositories;
+    }
+
+    private static boolean isValidUrl(String text) {
+        try {
+            new URL(text);
+            return true;
+        } catch (MalformedURLException e) {
+            return false;
+        }
     }
 
     private static List<Repository> mergeRepositories(List<Repository> originalRepositories, List<Repository> additionalRepositories) {

--- a/prospero-common/src/main/java/org/wildfly/prospero/api/TemporaryRepositoriesHandler.java
+++ b/prospero-common/src/main/java/org/wildfly/prospero/api/TemporaryRepositoriesHandler.java
@@ -1,0 +1,62 @@
+/*
+ *
+ *  * Copyright 2022 Red Hat, Inc. and/or its affiliates
+ *  * and other contributors as indicated by the @author tags.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *   http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package org.wildfly.prospero.api;
+
+import org.wildfly.channel.Channel;
+import org.wildfly.channel.Repository;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+public class TemporaryRepositoriesHandler {
+
+    public static List<Channel> addRepositories(List<Channel> originalChannels, List<Repository> additionalRepositories) {
+        Objects.requireNonNull(originalChannels);
+        Objects.requireNonNull(additionalRepositories);
+
+        if (additionalRepositories.isEmpty()) {
+            return new ArrayList<>(originalChannels);
+        }
+
+        ArrayList<Channel> mergedChannels = new ArrayList<>(originalChannels.size());
+
+        for (Channel oc : originalChannels) {
+            final List<Repository> repositories = mergeRepositories(oc.getRepositories(), additionalRepositories);
+            final Channel c = new Channel(oc.getSchemaVersion(), oc.getName(), oc.getDescription(), oc.getVendor(),
+                    oc.getChannelRequirements(), repositories, oc.getManifestRef());
+            mergedChannels.add(c);
+        }
+
+        return mergedChannels;
+    }
+
+    public static List<Repository> from(List<String> repos) {
+        return IntStream.range(0, repos.size())
+                .mapToObj(i -> new Repository("temp-repo-" + i, repos.get(i)))
+                .collect(Collectors.toList());
+    }
+
+    private static List<Repository> mergeRepositories(List<Repository> originalRepositories, List<Repository> additionalRepositories) {
+        return additionalRepositories;
+    }
+}

--- a/prospero-common/src/main/resources/prospero-known-combinations.yaml
+++ b/prospero-common/src/main/resources/prospero-known-combinations.yaml
@@ -3,6 +3,7 @@
   galleonConfiguration: "classpath:wildfly-provisioning.xml"
   channels:
     - schemaVersion: "2.0.0"
+      name: "wildfly"
       repositories:
         - id: "central"
           url: "https://repo1.maven.org/maven2/"

--- a/prospero-common/src/test/java/org/wildfly/prospero/api/ProvisioningDefinitionTest.java
+++ b/prospero-common/src/test/java/org/wildfly/prospero/api/ProvisioningDefinitionTest.java
@@ -107,7 +107,7 @@ public class ProvisioningDefinitionTest {
     public void addAdditionalRemoteRepos() throws Exception {
         final ProvisioningDefinition.Builder builder = new ProvisioningDefinition.Builder()
                 .setFpl(EAP_FPL)
-                .setAdditionalRepositories(Arrays.asList("http://test.repo1", "http://test.repo2"));
+                .setOverrideRepositories(Arrays.asList("http://test.repo1", "http://test.repo2"));
 
         final ProvisioningDefinition def = builder.build();
 
@@ -148,7 +148,7 @@ public class ProvisioningDefinitionTest {
         final ProvisioningDefinition.Builder builder = new ProvisioningDefinition.Builder()
                 .setFpl("multi-channel")
                 .setManifest("file:/tmp/foo.bar")
-                .setAdditionalRepositories(Arrays.asList("http://test.repo1", "http://test.repo2"));
+                .setOverrideRepositories(Arrays.asList("http://test.repo1", "http://test.repo2"));
 
         final ProvisioningDefinition def = builder.build();
 

--- a/prospero-common/src/test/java/org/wildfly/prospero/api/ProvisioningDefinitionTest.java
+++ b/prospero-common/src/test/java/org/wildfly/prospero/api/ProvisioningDefinitionTest.java
@@ -107,7 +107,9 @@ public class ProvisioningDefinitionTest {
     public void addAdditionalRemoteRepos() throws Exception {
         final ProvisioningDefinition.Builder builder = new ProvisioningDefinition.Builder()
                 .setFpl(EAP_FPL)
-                .setOverrideRepositories(Arrays.asList("http://test.repo1", "http://test.repo2"));
+                .setOverrideRepositories(Arrays.asList(
+                        new Repository("temp-repo-0", "http://test.repo1"),
+                        new Repository("temp-repo-1", "http://test.repo2")));
 
         final ProvisioningDefinition def = builder.build();
 
@@ -148,7 +150,9 @@ public class ProvisioningDefinitionTest {
         final ProvisioningDefinition.Builder builder = new ProvisioningDefinition.Builder()
                 .setFpl("multi-channel")
                 .setManifest("file:/tmp/foo.bar")
-                .setOverrideRepositories(Arrays.asList("http://test.repo1", "http://test.repo2"));
+                .setOverrideRepositories(Arrays.asList(
+                        new Repository("temp-repo-0", "http://test.repo1"),
+                        new Repository("temp-repo-1", "http://test.repo2")));
 
         final ProvisioningDefinition def = builder.build();
 

--- a/prospero-common/src/test/java/org/wildfly/prospero/api/ProvisioningDefinitionTest.java
+++ b/prospero-common/src/test/java/org/wildfly/prospero/api/ProvisioningDefinitionTest.java
@@ -39,6 +39,7 @@ import java.util.List;
 import javax.xml.stream.XMLStreamException;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
@@ -103,10 +104,10 @@ public class ProvisioningDefinitionTest {
     }
 
     @Test
-    public void overrideRemoteRepos() throws Exception {
+    public void addAdditionalRemoteRepos() throws Exception {
         final ProvisioningDefinition.Builder builder = new ProvisioningDefinition.Builder()
                 .setFpl(EAP_FPL)
-                .setRemoteRepositories(Arrays.asList("http://test.repo1", "http://test.repo2"));
+                .setAdditionalRepositories(Arrays.asList("http://test.repo1", "http://test.repo2"));
 
         final ProvisioningDefinition def = builder.build();
 
@@ -114,8 +115,8 @@ public class ProvisioningDefinitionTest {
                 .flatMap(Channel::getRepositories)
                 .map(r-> Tuple.tuple(r.getId(), r.getUrl()))
                 .containsExactlyInAnyOrder(
-                Tuple.tuple("repo-0" ,"http://test.repo1"),
-                        Tuple.tuple("repo-1" ,"http://test.repo2")
+                        tuple("temp-repo-0", "http://test.repo1"),
+                        Tuple.tuple("temp-repo-1" ,"http://test.repo2")
                 );
     }
 
@@ -147,7 +148,7 @@ public class ProvisioningDefinitionTest {
         final ProvisioningDefinition.Builder builder = new ProvisioningDefinition.Builder()
                 .setFpl("multi-channel")
                 .setManifest("file:/tmp/foo.bar")
-                .setRemoteRepositories(Arrays.asList("http://test.repo1", "http://test.repo2"));
+                .setAdditionalRepositories(Arrays.asList("http://test.repo1", "http://test.repo2"));
 
         final ProvisioningDefinition def = builder.build();
 
@@ -157,8 +158,8 @@ public class ProvisioningDefinitionTest {
         assertThat(channel.getRepositories())
                 .map(r-> Tuple.tuple(r.getId(), r.getUrl()))
                 .containsExactlyInAnyOrder(
-                        Tuple.tuple("repo-0" ,"http://test.repo1"),
-                        Tuple.tuple("repo-1" ,"http://test.repo2")
+                        Tuple.tuple("temp-repo-0" ,"http://test.repo1"),
+                        Tuple.tuple("temp-repo-1" ,"http://test.repo2")
                 );
     }
 

--- a/prospero-common/src/test/java/org/wildfly/prospero/api/TemporaryRepositoriesHandlerTest.java
+++ b/prospero-common/src/test/java/org/wildfly/prospero/api/TemporaryRepositoriesHandlerTest.java
@@ -1,0 +1,107 @@
+/*
+ *
+ *  * Copyright 2022 Red Hat, Inc. and/or its affiliates
+ *  * and other contributors as indicated by the @author tags.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *   http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package org.wildfly.prospero.api;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.wildfly.channel.Channel;
+import org.wildfly.channel.Repository;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TemporaryRepositoriesHandlerTest {
+
+    @Test
+    public void emptyListReturnsEmptyList() {
+        final List<Channel> channels = merge(Collections.emptyList(), Collections.emptyList());
+
+        assertThat(channels).isEmpty();
+    }
+
+    @Test
+    public void emptyRepositoriesUnchangedChannels() {
+        final List<Channel> originalChannels = List.of(getChannel("channel-0", repo("repo-0", "http://test.te")));
+        final List<Channel> channels = merge(originalChannels, Collections.emptyList());
+
+        Assert.assertNotSame("The resulting list should be a clone of original", channels, originalChannels);
+        assertChannelNamesContainsExactly(channels, "channel-0");
+        assertRepositoryIdContainsExactly(channels, "repo-0");
+        assertRepositoryUrlContainsExactly(channels, "http://test.te");
+    }
+
+    @Test
+    public void addRepositoryToSingleChannel() {
+        final List<Channel> originalChannels = List.of(getChannel("channel-0", repo("repo-0", "http://test.te")));
+        final List<Channel> channels = merge(originalChannels, List.of(repo("temp-0", "http://temp.te")));
+
+        Assert.assertNotSame("The resulting list should be a clone of original", channels, originalChannels);
+        assertChannelNamesContainsExactly(channels,"channel-0");
+        assertRepositoryIdContainsExactly(channels, "temp-0");
+        assertRepositoryUrlContainsExactly(channels, "http://temp.te");
+    }
+
+    @Test
+    public void addRepositoryToMultipleChannels() {
+        final List<Channel> originalChannels = List.of(getChannel("channel-0", repo("repo-0", "http://test.te")),
+                getChannel("channel-1", repo("repo-1", "http://test1.te")));
+        final List<Channel> channels = merge(originalChannels, List.of(repo("temp-0", "http://temp.te")));
+
+        Assert.assertNotSame("The resulting list should be a clone of original", channels, originalChannels);
+        assertChannelNamesContainsExactly(channels,"channel-0", "channel-1");
+        assertRepositoryIdContainsExactly(channels, "temp-0", "temp-0");
+        assertRepositoryUrlContainsExactly(channels, "http://temp.te", "http://temp.te");
+    }
+
+    private static void assertRepositoryIdContainsExactly(List<Channel> channels, String... ids) {
+        assertThat(channels)
+                .flatMap(Channel::getRepositories)
+                .map(Repository::getId)
+                .containsExactly(ids);
+    }
+
+    private static void assertRepositoryUrlContainsExactly(List<Channel> channels, String... urls) {
+        assertThat(channels)
+                .flatMap(Channel::getRepositories)
+                .map(Repository::getUrl)
+                .containsExactly(urls);
+    }
+
+    private static void assertChannelNamesContainsExactly(List<Channel> channels, String... names) {
+        assertThat(channels)
+                .map(Channel::getName)
+                .containsExactly(names);
+    }
+
+    private static Channel getChannel(String channelName, Repository... repos) {
+        return new Channel(channelName, null, null, null,
+                List.of(repos), null);
+    }
+
+    private static Repository repo(String id, String url) {
+        return new Repository(id, url);
+    }
+
+    private static List<Channel> merge(List<Channel> originalChannels, List<Repository> additionalRepositories) {
+        return TemporaryRepositoriesHandler.addRepositories(originalChannels, additionalRepositories);
+    }
+}

--- a/prospero-common/src/test/java/org/wildfly/prospero/api/TemporaryRepositoriesHandlerTest.java
+++ b/prospero-common/src/test/java/org/wildfly/prospero/api/TemporaryRepositoriesHandlerTest.java
@@ -17,7 +17,6 @@
 
 package org.wildfly.prospero.api;
 
-import org.apache.commons.lang3.StringUtils;
 import org.junit.Assert;
 import org.junit.Test;
 import org.wildfly.channel.Channel;
@@ -25,13 +24,8 @@ import org.wildfly.channel.Repository;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
-import static org.wildfly.prospero.api.TemporaryRepositoriesHandler.from;
 
 public class TemporaryRepositoriesHandlerTest {
 
@@ -74,51 +68,6 @@ public class TemporaryRepositoriesHandlerTest {
         assertChannelNamesContainsExactly(channels,"channel-0", "channel-1");
         assertRepositoryIdContainsExactly(channels, "temp-0", "temp-0");
         assertRepositoryUrlContainsExactly(channels, "http://temp.te", "http://temp.te");
-    }
-
-    @Test
-    public void generatesRepositoryIdsIfNotProvided() {
-        assertThat(from(List.of("http://test.te")))
-                .map(Repository::getId)
-                .noneMatch(id-> StringUtils.isEmpty(id));
-    }
-
-    @Test
-    public void generatedRepositoryIdsAreUnique() {
-        final Set<String> collectedIds = from(List.of("http://test1.te", "http://test2.te", "http://test3.te")).stream()
-                .map(Repository::getId)
-                .collect(Collectors.toSet());
-
-        assertEquals(3, collectedIds.size());
-    }
-
-    @Test
-    public void keepsRepositoryIdsIfProvided() {
-        assertThat(from(List.of("repo-1::http://test1.te", "repo-2::http://test2.te", "repo-3::http://test3.te")))
-                .map(Repository::getId)
-                .containsExactly("repo-1", "repo-2", "repo-3");
-    }
-
-    @Test
-    public void mixGeneratedAndProvidedIds() {
-        assertThat(from(List.of("repo-1::http://test1.te", "http://test2.te", "repo-3::http://test3.te")))
-                .map(Repository::getId)
-                .contains("repo-1", "repo-3")
-                .hasSize(3)
-                .noneMatch(id-> StringUtils.isEmpty(id));
-    }
-
-    @Test
-    public void throwsErrorIfFormatIsIncorrect() {
-        assertThrows(IllegalArgumentException.class, ()->from(List.of("::http://test1.te")));
-
-        assertThrows(IllegalArgumentException.class, ()->from(List.of("repo-1::")));
-
-        assertThrows(IllegalArgumentException.class, ()->from(List.of("repo-1:::http://test1.te")));
-
-        assertThrows(IllegalArgumentException.class, ()->from(List.of("foo::bar::http://test1.te")));
-
-        assertThrows(IllegalArgumentException.class, ()->from(List.of("imnoturl")));
     }
 
     private static void assertRepositoryIdContainsExactly(List<Channel> channels, String... ids) {


### PR DESCRIPTION
`--repositories` overrides any repositories already configured either in installed server, or known-feature-packs.
In operations on installed server (update, revert) the repositories defined that way are not persisted. 
The values permitted are either comma-separated URLs or pairs or ID::URL

Renamed `--local-repo` to `--local-cache` and `--channel` to `--manifest`