### PR TITLE
Support relative path in installer-config.yaml

### DIFF
--- a/integration-tests/src/test/java/org/wildfly/prospero/it/cli/UpdateWithAdditionalRepositoryTest.java
+++ b/integration-tests/src/test/java/org/wildfly/prospero/it/cli/UpdateWithAdditionalRepositoryTest.java
@@ -60,7 +60,7 @@ public class UpdateWithAdditionalRepositoryTest extends WfCoreTestBase {
         final ProsperoConfig prosperoConfig = ProsperoConfig.readConfig(targetDir.toPath().resolve(MetadataTestUtils.PROVISION_CONFIG_FILE_PATH));
         // TODO: replace with GA channel
         final URL modifiedChannel = this.getClass().getClassLoader().getResource("channels/wfcore-19-upgrade-component.yaml");
-        prosperoConfig.addChannel(new ChannelRef(null, modifiedChannel.toString()));
+        prosperoConfig.addChannel(new ChannelRef(ChannelRef.Type.URL, null, modifiedChannel.toString(), null, null));
         prosperoConfig.writeConfig(targetDir.toPath().resolve(MetadataTestUtils.PROVISION_CONFIG_FILE_PATH).toFile());
         URL internalRepo = mockInternalRepo();
 

--- a/integration-tests/src/test/java/org/wildfly/prospero/it/commonapi/UpdateTest.java
+++ b/integration-tests/src/test/java/org/wildfly/prospero/it/commonapi/UpdateTest.java
@@ -136,7 +136,7 @@ public class UpdateTest extends WfCoreTestBase {
         final List<RepositoryRef> repositories = new ArrayList<>(defaultRemoteRepositories());
         final File configFile = temp.newFile(InstallationMetadata.PROSPERO_CONFIG_FILE_NAME);
         repositories.add(new RepositoryRef("test-repo", mockRepo.toURI().toURL().toString()));
-        new ProsperoConfig(Arrays.asList(new ChannelRef("test:channel", null)), repositories).writeConfig(configFile);
+        new ProsperoConfig(Arrays.asList(new ChannelRef(ChannelRef.Type.GAV, "test:channel", null, null, null)), repositories).writeConfig(configFile);
         return configFile;
     }
 

--- a/prospero-cli/src/main/java/org/wildfly/prospero/cli/CliMessages.java
+++ b/prospero-cli/src/main/java/org/wildfly/prospero/cli/CliMessages.java
@@ -138,6 +138,9 @@ public interface CliMessages {
     @Message("Only one of %s and %s can be set.")
     IllegalArgumentException exclusiveOptions(String option1, String option2);
 
+    @Message("Option %s must present before %s can be set.")
+    IllegalArgumentException requiredOptions(String option1, String option2);
+
     @Message("Custom repository `%s` already exist.")
     String customizationRepoExist(String repositoryId);
 

--- a/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/CliConstants.java
+++ b/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/CliConstants.java
@@ -54,6 +54,7 @@ public final class CliConstants {
     // Parameter and option labels:
 
     public static final String CHANNEL_REFERENCE = "<channel-reference>";
+    public static final String RELATIVE_TO_REFERENCE = "<relative-to-reference>";
     public static final String FEATURE_PACK_REFERENCE = "<feature-pack-reference>";
     public static final String PATH = "<path>";
     public static final String REPO_ID = "<repo-id>";
@@ -73,6 +74,7 @@ public final class CliConstants {
     public static final String NO_LOCAL_MAVEN_CACHE = "--no-resolve-local-cache";
     public static final String OFFLINE = "--offline";
     public static final String PROVISION_CONFIG = "--provision-config";
+    public static final String RELATIVE_TO = "--relative-to";
     public static final String REVISION = "--revision";
     public static final String SELF = "--self";
     public static final String V = "-v";

--- a/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/channel/ChannelAddCommand.java
+++ b/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/channel/ChannelAddCommand.java
@@ -35,6 +35,9 @@ public class ChannelAddCommand extends AbstractCommand {
     @CommandLine.Parameters(index = "0", paramLabel = "gav-or-url")
     String gavOrUrl;
 
+    @CommandLine.Option(names = CliConstants.RELATIVE_TO)
+    String relativeTo;
+
     @CommandLine.Option(names = CliConstants.DIR)
     Optional<Path> directory;
 
@@ -46,7 +49,7 @@ public class ChannelAddCommand extends AbstractCommand {
     public Integer call() throws Exception {
         Path installationDirectory = determineInstallationDirectory(directory);
         MetadataAction metadataAction = actionFactory.metadataActions(installationDirectory);
-        metadataAction.addChannel(gavOrUrl);
+        metadataAction.addChannel(gavOrUrl, relativeTo);
         console.println(CliMessages.MESSAGES.channelAdded(gavOrUrl));
         return ReturnCodes.SUCCESS;
     }

--- a/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/channel/ChannelInitializeCommand.java
+++ b/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/channel/ChannelInitializeCommand.java
@@ -103,7 +103,7 @@ public class ChannelInitializeCommand extends AbstractCommand {
 
         // add new channel
         console.println(CliMessages.MESSAGES.registeringCustomChannel(name.get()));
-        metadataAction.addChannel(name.get());
+        metadataAction.addChannel(name.get(), null);
 
         // add new repository
         console.println(CliMessages.MESSAGES.registeringCustomRepository(url.toString()));

--- a/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/channel/ChannelRemoveCommand.java
+++ b/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/channel/ChannelRemoveCommand.java
@@ -35,6 +35,8 @@ public class ChannelRemoveCommand extends AbstractCommand {
     @CommandLine.Parameters(index = "0", paramLabel = "gav-or-url")
     String gavOrUrl;
 
+    @CommandLine.Option(names = CliConstants.RELATIVE_TO)
+    String relativeTo;
     @CommandLine.Option(names = CliConstants.DIR)
     Optional<Path> directory;
 
@@ -46,7 +48,7 @@ public class ChannelRemoveCommand extends AbstractCommand {
     public Integer call() throws Exception {
         Path installationDirectory = determineInstallationDirectory(directory);
         MetadataAction metadataAction = actionFactory.metadataActions(installationDirectory);
-        metadataAction.removeChannel(gavOrUrl);
+        metadataAction.removeChannel(gavOrUrl, relativeTo);
         console.println(CliMessages.MESSAGES.channelRemoved(gavOrUrl));
         return ReturnCodes.SUCCESS;
     }

--- a/prospero-cli/src/main/resources/UsageMessages.properties
+++ b/prospero-cli/src/main/resources/UsageMessages.properties
@@ -86,6 +86,7 @@ no-resolve-local-cache = Perform the operation without resolving or installing a
 offline = Perform installation from local or file-system Maven repositories only.
 provision-config = Provisioning configuration file path. This is special JSON configuration file that contains list \
   of channel file references and list of remote Maven repositories. Alternative to --channel and --remote-repositories.
+relative-to = The name of another previously named path, or of one of the standard paths provided by the system. If 'relative-to' is provided, the value of the 'path' attribute is treated as relative to the path specified by this attribute.
 revision = Hash of an installation state.
 repoId = Repository ID
 repoUrl = Repository URL

--- a/prospero-cli/src/test/java/org/wildfly/prospero/cli/commands/ChannelCommandTest.java
+++ b/prospero-cli/src/test/java/org/wildfly/prospero/cli/commands/ChannelCommandTest.java
@@ -54,9 +54,9 @@ public class ChannelCommandTest extends AbstractConsoleTest {
         super.setUp();
 
         this.dir = tempDir.newFolder().toPath();
-        ChannelRef gaChannel = new ChannelRef(GA, null);
-        ChannelRef gavChannel = new ChannelRef(GAV, null);
-        ChannelRef urlChannel = new ChannelRef(null, URL);
+        ChannelRef gaChannel = new ChannelRef(ChannelRef.Type.GAV, GA, null, null, null);
+        ChannelRef gavChannel = new ChannelRef(ChannelRef.Type.GAV, GAV, null, null, null);
+        ChannelRef urlChannel = new ChannelRef(ChannelRef.Type.URL, null, URL, null, null);
         MetadataTestUtils.createInstallationMetadata(dir,
                 Arrays.asList(gaChannel, gavChannel, urlChannel), Collections.emptyList());
         MetadataTestUtils.createGalleonProvisionedState(dir);

--- a/prospero-cli/src/test/java/org/wildfly/prospero/cli/commands/InstallCommandTest.java
+++ b/prospero-cli/src/test/java/org/wildfly/prospero/cli/commands/InstallCommandTest.java
@@ -111,7 +111,7 @@ public class InstallCommandTest extends AbstractMavenCommandTest {
 
     @Test
     public void callProvisionOnInstallCommandWithCustomFpl() throws Exception {
-        List<ChannelRef> channels = Collections.singletonList(new ChannelRef("g:a:v", null));
+        List<ChannelRef> channels = Collections.singletonList(new ChannelRef(ChannelRef.Type.GAV, "g:a:v", null, null, null));
         List<RepositoryRef> repositories = new ArrayList<>();
         final File provisionConfigFile = temporaryFolder.newFile();
         new ProsperoConfig(channels, repositories).writeConfig(provisionConfigFile);
@@ -135,7 +135,7 @@ public class InstallCommandTest extends AbstractMavenCommandTest {
 
     @Test
     public void callProvisionOnInstallKnownFplOverrideChannelsCommand() throws Exception {
-        List<ChannelRef> channels = Arrays.asList(new ChannelRef("org.wildfly:wildfly-channel", null));
+        List<ChannelRef> channels = Arrays.asList(new ChannelRef(ChannelRef.Type.GAV, "org.wildfly:wildfly-channel", null, null, null));
         List<RepositoryRef> repositories = Arrays.asList(new RepositoryRef("dev", "http://test.test"));
         final File provisionConfigFile = temporaryFolder.newFile();
         new ProsperoConfig(channels, repositories).writeConfig(provisionConfigFile);
@@ -151,7 +151,7 @@ public class InstallCommandTest extends AbstractMavenCommandTest {
 
     @Test
     public void usingProvisionDefinitonRequiresChannel() throws Exception {
-        List<ChannelRef> channels = Arrays.asList(new ChannelRef("org.wildfly:wildfly-channel", null));
+        List<ChannelRef> channels = Arrays.asList(new ChannelRef(ChannelRef.Type.GAV, "org.wildfly:wildfly-channel", null, null, null));
         List<RepositoryRef> repositories = Arrays.asList(new RepositoryRef("dev", "http://test.test"));
         final File provisionDefinitionFile = temporaryFolder.newFile("provision.xml");
         final File provisionConfigFile = temporaryFolder.newFile();

--- a/prospero-cli/src/test/java/org/wildfly/prospero/cli/commands/channel/ChannelInitializeCommandTest.java
+++ b/prospero-cli/src/test/java/org/wildfly/prospero/cli/commands/channel/ChannelInitializeCommandTest.java
@@ -86,7 +86,7 @@ public class ChannelInitializeCommandTest extends AbstractConsoleTest {
                 CliConstants.CUSTOMIZATION_REPOSITORY_URL, customRepoUrl);
         Assert.assertEquals(ReturnCodes.SUCCESS, exitCode);
         assertThat(actualChannels()).contains(
-                new ChannelRef("org.test:custom-channel", null)
+                new ChannelRef(ChannelRef.Type.GAV, "org.test:custom-channel", null, null, null)
         );
         assertThat(actualRepositories()).contains(
                 new RepositoryRef(CUSTOMIZATION_REPO_ID, customRepoUrl)
@@ -110,7 +110,7 @@ public class ChannelInitializeCommandTest extends AbstractConsoleTest {
         Assert.assertEquals(ReturnCodes.INVALID_ARGUMENTS, exitCode);
         assertTrue(getErrorOutput().contains(CliMessages.MESSAGES.customizationRepoExist(CUSTOMIZATION_REPO_ID)));
         assertThat(actualChannels()).doesNotContain(
-                new ChannelRef("org.test:custom-channel", null)
+                new ChannelRef(ChannelRef.Type.GAV, "org.test:custom-channel", null, null, null)
         );
     }
 
@@ -168,7 +168,7 @@ public class ChannelInitializeCommandTest extends AbstractConsoleTest {
                     new RepositoryRef(CUSTOMIZATION_REPO_ID, customRepoUrl)
             );
             assertThat(actualChannels()).doesNotContain(
-                    new ChannelRef("org.test:custom-channel", null)
+                    new ChannelRef(ChannelRef.Type.GAV, "org.test:custom-channel", null, null, null)
             );
         } finally {
             base.toFile().setWritable(true);
@@ -193,7 +193,7 @@ public class ChannelInitializeCommandTest extends AbstractConsoleTest {
                 new RepositoryRef(CUSTOMIZATION_REPO_ID, customRepoUrl)
         );
         assertThat(actualChannels()).doesNotContain(
-                new ChannelRef("org.test:custom-channel", null)
+                new ChannelRef(ChannelRef.Type.GAV, "org.test:custom-channel", null, null, null)
         );
     }
 
@@ -210,7 +210,7 @@ public class ChannelInitializeCommandTest extends AbstractConsoleTest {
                         installationDir.resolve(InstallationMetadata.METADATA_DIR).resolve(DEFAULT_CUSTOMIZATION_REPOSITORY).toUri().toURL().toString())
         );
         assertThat(actualChannels()).contains(
-                new ChannelRef("org.test:custom-channel", null)
+                new ChannelRef(ChannelRef.Type.GAV, "org.test:custom-channel", null, null, null)
         );
     }
 
@@ -231,13 +231,13 @@ public class ChannelInitializeCommandTest extends AbstractConsoleTest {
                         installationDir.resolve(InstallationMetadata.METADATA_DIR).resolve(DEFAULT_CUSTOMIZATION_REPOSITORY).toUri().toURL().toString())
         );
         assertThat(actualChannels()).contains(
-                new ChannelRef(channelName, null)
+                new ChannelRef(ChannelRef.Type.GAV, channelName, null, null, null)
         );
     }
 
     @Test
     public void onlyOneDefaultChannelCanBeCreated() throws Exception {
-        new ProsperoConfig(Arrays.asList(new ChannelRef(CUSTOM_CHANNELS_GROUP_ID + ":existing", null)),
+        new ProsperoConfig(Arrays.asList(new ChannelRef(ChannelRef.Type.GAV, CUSTOM_CHANNELS_GROUP_ID + ":existing", null, null, null)),
                 Collections.emptyList())
                 .writeConfig(installationDir.resolve(InstallationMetadata.METADATA_DIR).resolve(InstallationMetadata.PROSPERO_CONFIG_FILE_NAME).toFile());
         int exitCode = commandLine.execute(
@@ -249,7 +249,7 @@ public class ChannelInitializeCommandTest extends AbstractConsoleTest {
 
         assertThat(actualRepositories()).isEmpty();
         assertThat(actualChannels()).containsOnly(
-                new ChannelRef(CUSTOM_CHANNELS_GROUP_ID + ":existing", null)
+                new ChannelRef(ChannelRef.Type.GAV, CUSTOM_CHANNELS_GROUP_ID + ":existing", null, null, null)
         );
     }
 

--- a/prospero-cli/src/test/java/org/wildfly/prospero/cli/commands/channel/ChannelPromoteCommandTest.java
+++ b/prospero-cli/src/test/java/org/wildfly/prospero/cli/commands/channel/ChannelPromoteCommandTest.java
@@ -134,7 +134,7 @@ public class ChannelPromoteCommandTest extends AbstractConsoleTest {
 
         when(actionFactory.promoter(any())).thenReturn(promoter);
         when(actionFactory.metadataActions(any())).thenReturn(metadataAction);
-        when(metadataAction.getChannels()).thenReturn(Arrays.asList(new ChannelRef(CUSTOM_CHANNELS_GROUP_ID + ":test1", null)));
+        when(metadataAction.getChannels()).thenReturn(Arrays.asList(new ChannelRef(ChannelRef.Type.GAV, CUSTOM_CHANNELS_GROUP_ID + ":test1", null, null, null)));
         when(metadataAction.getRepositories()).thenReturn(Arrays.asList(new RepositoryRef(CUSTOMIZATION_REPO_ID, "file:///test/test")));
 
         int exitCode = commandLine.execute(
@@ -175,7 +175,7 @@ public class ChannelPromoteCommandTest extends AbstractConsoleTest {
 
         when(actionFactory.promoter(any())).thenReturn(promoter);
         when(actionFactory.metadataActions(any())).thenReturn(metadataAction);
-        when(metadataAction.getChannels()).thenReturn(Arrays.asList(new ChannelRef(CUSTOM_CHANNELS_GROUP_ID + ":test1", null)));
+        when(metadataAction.getChannels()).thenReturn(Arrays.asList(new ChannelRef(ChannelRef.Type.GAV, CUSTOM_CHANNELS_GROUP_ID + ":test1", null, null, null)));
 
         int exitCode = commandLine.execute(
                 CliConstants.Commands.CHANNEL, CUSTOMIZATION_PROMOTE,

--- a/prospero-common/src/main/java/org/wildfly/prospero/Messages.java
+++ b/prospero-common/src/main/java/org/wildfly/prospero/Messages.java
@@ -88,4 +88,25 @@ public interface Messages {
 
     @Message("Unable to close the update store.")
     MetadataException unableToCloseStore(@Cause Exception e);
+
+    @Message("(%s) is not a valid GAV value.")
+    IllegalArgumentException invalidGAV(String gav);
+
+    @Message("(%s) is not a valid URL value.")
+    IllegalArgumentException invalidURL(String url);
+
+    @Message("File in path (%s) does not exist.")
+    IllegalArgumentException pathNotExist(Path path);
+
+    @Message("Channel type (%s) is not a valid type.")
+    IllegalArgumentException invalidChannelType(String type);
+
+    @Message("Relative-to path (%s) can not be found.")
+    IllegalArgumentException invalidRelativeTo(String relativeTo);
+
+    @Message("Path (%s) is not an absolute path.")
+    IllegalArgumentException invalidAbsolutePath(String path);
+
+    @Message("An absolute path (%s) cannot be specified for relative-to.")
+    IllegalArgumentException invalidNonAbsolutePath(String path);
 }

--- a/prospero-common/src/main/java/org/wildfly/prospero/actions/MetadataAction.java
+++ b/prospero-common/src/main/java/org/wildfly/prospero/actions/MetadataAction.java
@@ -87,10 +87,10 @@ public class MetadataAction {
     /**
      * Adds a channel to an installation.
      */
-    public void addChannel(String gavOrUrl) throws MetadataException {
+    public void addChannel(String gavOrUrl, String relativeTo) throws MetadataException {
         try (final InstallationMetadata installationMetadata = new InstallationMetadata(installation)) {
             ProsperoConfig prosperoConfig = installationMetadata.getProsperoConfig();
-            ChannelRef channelRef = ChannelRef.fromString(gavOrUrl);
+            ChannelRef channelRef = relativeTo == null ? ChannelRef.fromString(gavOrUrl) :  ChannelRef.fromString(gavOrUrl, relativeTo);
             prosperoConfig.addChannel(channelRef);
             installationMetadata.updateProsperoConfig(prosperoConfig);
         }
@@ -99,10 +99,10 @@ public class MetadataAction {
     /**
      * Removes a remote maven repository from an installation.
      */
-    public void removeChannel(String gavOrUrl) throws MetadataException {
+    public void removeChannel(String gavOrUrl, String relativeTo) throws MetadataException {
         try (final InstallationMetadata installationMetadata = new InstallationMetadata(installation)) {
             ProsperoConfig prosperoConfig = installationMetadata.getProsperoConfig();
-            ChannelRef channelRef = ChannelRef.fromString(gavOrUrl);
+            ChannelRef channelRef = relativeTo == null ? ChannelRef.fromString(gavOrUrl) : ChannelRef.fromString(gavOrUrl, relativeTo);
             prosperoConfig.removeChannel(channelRef);
             installationMetadata.updateProsperoConfig(prosperoConfig);
         }

--- a/prospero-common/src/main/java/org/wildfly/prospero/api/InstallationMetadata.java
+++ b/prospero-common/src/main/java/org/wildfly/prospero/api/InstallationMetadata.java
@@ -65,6 +65,7 @@ public class InstallationMetadata implements AutoCloseable {
 
     private InstallationMetadata(Path manifestFile, Path prosperoConfigFile, Path provisioningFile) throws MetadataException {
         this.base = manifestFile.getParent();
+        System.setProperty("installation.home", base.toString());
         this.gitStorage = null;
         this.manifestFile = manifestFile;
         this.prosperoConfigFile = prosperoConfigFile;
@@ -79,6 +80,7 @@ public class InstallationMetadata implements AutoCloseable {
 
     protected InstallationMetadata(Path base, GitStorage gitStorage) throws MetadataException {
         this.base = base;
+        System.setProperty("installation.home", base.toString());
         this.gitStorage = gitStorage;
         this.manifestFile = base.resolve(METADATA_DIR).resolve(InstallationMetadata.MANIFEST_FILE_NAME);
         this.prosperoConfigFile = base.resolve(METADATA_DIR).resolve(InstallationMetadata.PROSPERO_CONFIG_FILE_NAME);
@@ -289,6 +291,7 @@ public class InstallationMetadata implements AutoCloseable {
                 gitStorage.close();
             } catch (Exception e) {
                 // log and ignore
+                // FIXME result of 'unableToCloseStore' not thrown. change unableToCloseStore to string and log based on above comment ?
                 Messages.MESSAGES.unableToCloseStore(e);
             }
         }

--- a/prospero-common/src/main/java/org/wildfly/prospero/api/ProvisioningDefinition.java
+++ b/prospero-common/src/main/java/org/wildfly/prospero/api/ProvisioningDefinition.java
@@ -99,7 +99,7 @@ public class ProvisioningDefinition {
                                Optional<ChannelRef> channel, List<String> channelGAs) throws IOException {
         if (!provisionConfigFile.isPresent() && !channel.isPresent()) {
             if (channelGAs != null) {
-                channelGAs.forEach(c -> this.channels.add(new ChannelRef(c, null)));
+                channelGAs.forEach(c -> this.channels.add(new ChannelRef(ChannelRef.Type.GAV, c, null, null, null)));
             }
             if (!overrideRemoteRepos.isEmpty()) {
                 this.repositories.clear();
@@ -182,9 +182,9 @@ public class ProvisioningDefinition {
             return this;
         }
 
-        public Builder setChannel(String channel) {
-            if (channel != null) {
-                this.channel = ChannelRef.fromString(channel);
+        public Builder setChannel(String channel, String relativeTo) {
+            if(channel != null) {
+                this.channel = relativeTo == null ? ChannelRef.fromString(channel) : ChannelRef.fromString(channel, relativeTo);
             }
             return this;
         }

--- a/prospero-common/src/main/java/org/wildfly/prospero/model/ChannelRef.java
+++ b/prospero-common/src/main/java/org/wildfly/prospero/model/ChannelRef.java
@@ -18,14 +18,18 @@
 package org.wildfly.prospero.model;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.commons.lang3.StringUtils;
 import org.wildfly.channel.maven.ChannelCoordinate;
+import org.wildfly.prospero.Messages;
 
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Objects;
 
@@ -34,26 +38,107 @@ public class ChannelRef {
 
     private final String url;
 
+    private final String path;
+
+    /**
+     * The name of another previously named path, or of one of the standard paths provided by the system.
+     * If 'relative-to' is provided, the value of the 'path' attribute is treated as relative to the path specified by this attribute.
+     * This is an optional field.
+     */
+    private final String relativeTo;
+
     private final String gav;
 
+    private final Type type;
+
     @JsonCreator
-    public ChannelRef(@JsonProperty(value = "gav") String gav, @JsonProperty(value = "fileUrl") String fileUrl) {
+    public ChannelRef(@JsonProperty(required = true, value = "type") Type type, @JsonProperty(value = "gav") String gav, @JsonProperty(value = "url") String url, @JsonProperty(value = "path") String path, @JsonProperty(value = "relativeTo") String relativeTo) {
+        this.type = type;
         this.gav = gav;
-        this.url = fileUrl;
+        this.url = url;
+        this.path = path;
+        this.relativeTo = relativeTo;
+        validate();
+    }
+
+    private void validate() {
+        switch (type) {
+            case GAV:
+                if (!isValidCoordinate(gav)) {
+                    throw Messages.MESSAGES.invalidGAV(gav);
+                }
+                break;
+            case URL:
+                try {
+                    URL url1 = new URL(url);
+                } catch (MalformedURLException e) {
+                    throw Messages.MESSAGES.invalidURL(url);
+                }
+                break;
+            case PATH:
+                // relativeTo must not be absolute.
+                validateNonAbsolutePath(relativeTo);
+                // find system property first, then env, otherwise throw exception.
+                String relativeToStr = System.getProperty(relativeTo) != null ? System.getProperty(relativeTo) : System.getenv(relativeTo);
+                if (relativeToStr == null) {
+                    throw Messages.MESSAGES.invalidRelativeTo(relativeTo);
+                }
+                Path p = Paths.get(relativeToStr, path);
+                if (!Files.exists(p)) {
+                    throw Messages.MESSAGES.pathNotExist(p);
+                }
+                break;
+            default:
+                throw Messages.MESSAGES.invalidChannelType(type.toString());
+        }
+    }
+
+    private static void validateNonAbsolutePath(String path) {
+        if (isAbsoluteUnixOrWindowsPath(path)) {
+            throw Messages.MESSAGES.invalidNonAbsolutePath(path);
+        }
     }
 
     public ChannelRef(ChannelRef other) {
-        if (other.getGav() != null && !other.getGav().isEmpty()) {
-            this.gav = other.getGav();
-            this.url = null;
-        } else {
-            this.gav = null;
-            this.url = other.getUrl();
+        this.type = other.getType();
+        switch (other.getType()) {
+            case GAV:
+                this.gav = other.getGav();
+                this.url = null;
+                this.path = null;
+                this.relativeTo = null;
+                break;
+            case URL:
+                this.url = other.getUrl();
+                this.gav = null;
+                this.path = null;
+                this.relativeTo = null;
+                break;
+            case PATH:
+                this.path = other.getPath();
+                this.relativeTo = other.getRelativeTo();
+                this.gav = null;
+                this.url = null;
+                break;
+            default:
+                throw Messages.MESSAGES.invalidChannelType(other.getType().toString());
         }
+    }
+
+    public Type getType() {
+        return type;
     }
 
     public String getUrl() {
         return url;
+    }
+
+    public String getPath() {
+        return path;
+    }
+
+    public String getRelativeTo() {
+        return relativeTo;
     }
 
     public String getGav() {
@@ -62,31 +147,51 @@ public class ChannelRef {
 
     @JsonIgnore
     public String getGavOrUrlString() {
-        if (StringUtils.isNotBlank(gav)) {
+        if (Type.GAV.equals(this.type)) {
             return gav;
-        } else {
+        } else if (Type.URL.equals(this.type)) {
             return url;
+        } else {
+            return this.path;
         }
     }
 
     @JsonIgnore
     public ChannelCoordinate toChannelCoordinate() {
-        if (StringUtils.isNotBlank(gav)) {
-            final String[] splitGav = gav.split(":");
-            return new ChannelCoordinate(splitGav[0], splitGav[1]);
-        } else {
-            try {
-                return new ChannelCoordinate(new URL(url));
-            } catch (MalformedURLException e) {
-                // TODO: handle proper
-                throw new RuntimeException(e);
-            }
+        switch (this.type) {
+            case GAV:
+                final String[] splitGav = gav.split(":");
+                return new ChannelCoordinate(splitGav[0], splitGav[1]);
+            case URL:
+                try {
+                    return new ChannelCoordinate(new URL(url));
+                } catch (MalformedURLException e) {
+                    throw new RuntimeException(e);
+                }
+            case PATH:
+                try {
+                    if (relativeTo == null) {
+                        return new ChannelCoordinate(new URL(path));
+                    } else {
+                        // find system property first, then env, otherwise throw exception.
+                        String relativeToStr = System.getProperty(relativeTo) != null ? System.getProperty(relativeTo) : System.getenv(relativeTo);
+                        if (relativeToStr == null) {
+                            throw Messages.MESSAGES.invalidRelativeTo(relativeTo);
+                        }
+                        URL urlx = Paths.get(relativeToStr, path).toUri().toURL();
+                        return new ChannelCoordinate(urlx);
+                    }
+                } catch (MalformedURLException e) {
+                    throw new RuntimeException(e);
+                }
+            default:
+                throw Messages.MESSAGES.invalidChannelType(this.getType().toString());
         }
     }
 
     @Override
     public String toString() {
-        return "Channel{" + "gav='" + gav + '\'' + ", url='" + url + '\'' + '}';
+        return "Channel{" + "gav='" + gav + '\'' + ", url='" + url + '\'' + ", path='" + path + '\'' + ", relative-to='" + relativeTo + '\'' + '}';
     }
 
     @Override
@@ -94,30 +199,46 @@ public class ChannelRef {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         ChannelRef that = (ChannelRef) o;
-        return Objects.equals(url, that.url) && Objects.equals(gav, that.gav);
+        return Objects.equals(url, that.url) && Objects.equals(path, that.path) && Objects.equals(relativeTo, that.relativeTo) && Objects.equals(gav, that.gav) && type == that.type;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(url, gav);
+        return Objects.hash(url, path, relativeTo, gav, type);
     }
-
 
     public static ChannelRef fromString(String urlGavOrPath) {
         try {
             URL url = new URL(urlGavOrPath);
-            return new ChannelRef(null, url.toExternalForm());
+            return new ChannelRef(Type.URL, null, url.toExternalForm(), null, null);
         } catch (MalformedURLException e) {
             if (isValidCoordinate(urlGavOrPath)) {
-                return new ChannelRef(urlGavOrPath, null);
+                return new ChannelRef(Type.GAV, urlGavOrPath, null, null, null);
             } else {
                 // assume the string is a path
                 try {
-                    return new ChannelRef(null,
-                            Paths.get(urlGavOrPath).toAbsolutePath().toUri().toURL().toExternalForm());
+                    return new ChannelRef(Type.URL, null,
+                            Paths.get(urlGavOrPath).toAbsolutePath().toUri().toURL().toExternalForm(), null, null);
                 } catch (MalformedURLException e2) {
                     throw new IllegalArgumentException("Can't convert path to URL", e2);
                 }
+            }
+        }
+    }
+
+    public static ChannelRef fromString(String path, String relativeTo) {
+        return new ChannelRef(Type.PATH, null, null, path, relativeTo);
+    }
+
+    public static Type determineChannelType(String channel) {
+        try {
+            URL url = new URL(channel);
+            return Type.URL;
+        } catch (MalformedURLException e) {
+            if (isValidCoordinate(channel)) {
+                return Type.GAV;
+            } else {
+                return Type.PATH;
             }
         }
     }
@@ -132,5 +253,53 @@ public class ChannelRef {
                 (parts.length == 2 // GA
                 && StringUtils.isNotBlank(parts[0])
                 && StringUtils.isNotBlank(parts[1]));
+    }
+
+    /**
+     * This is copied from AbstractPathService.java of wildfly-core project.
+     * Checks whether the given path looks like an absolute Unix or Windows filesystem pathname <strong>without
+     * regard for what the filesystem is underlying the Java Virtual Machine</strong>. A UNIX pathname is
+     * absolute if its prefix is <code>"/"</code>.  A Microsoft Windows pathname is absolute if its prefix is a drive
+     * specifier followed by <code>"\\"</code>, or if its prefix is <code>"\\\\"</code>.
+     * <p>
+     * <strong>This method differs from simply creating a new {@code File} and calling {@link java.io.File#isAbsolute()} in that
+     * its results do not change depending on what the filesystem underlying the Java Virtual Machine is. </strong>
+     * </p>
+     *
+     * @param path the path
+     *
+     * @return  {@code true} if {@code path} looks like an absolute Unix or Windows pathname
+     */
+    public static boolean isAbsoluteUnixOrWindowsPath(final String path) {
+        if (path != null) {
+            int length = path.length();
+            if (length > 0) {
+                char c0 = path.charAt(0);
+                if (c0 == '/') {
+                    return true;   // Absolute Unix path
+                } else if (length > 1) {
+                    char c1 = path.charAt(1);
+                    if (c0 == '\\' && c1 == '\\') {
+                        return true;   // Absolute UNC pathname "\\\\foo"
+                    } else return length > 2 && c1 == ':' && path.charAt(2) == '\\' && isDriveLetter(c0); // Absolute local pathname "z:\\foo"
+                }
+
+            }
+        }
+        return false;
+    }
+
+    private static boolean isDriveLetter(final char c) {
+        return ((c >= 'a') && (c <= 'z')) || ((c >= 'A') && (c <= 'Z'));
+    }
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING)
+    public enum Type {
+        @JsonProperty("gav")
+        GAV,
+        @JsonProperty("url")
+        URL,
+        @JsonProperty("path")
+        PATH
     }
 }

--- a/prospero-common/src/main/java/org/wildfly/prospero/test/MetadataTestUtils.java
+++ b/prospero-common/src/main/java/org/wildfly/prospero/test/MetadataTestUtils.java
@@ -110,7 +110,7 @@ public final class MetadataTestUtils {
         List<RepositoryRef> repositories = defaultRemoteRepositories().stream()
                 .map(r->new RepositoryRef(r.getId(), r.getUrl())).collect(Collectors.toList());
         for (int i = 0; i< channelUrls.size(); i++) {
-            channels.add(new ChannelRef(null, channelUrls.get(i).toString()));
+            channels.add(new ChannelRef(ChannelRef.Type.URL, null, channelUrls.get(i).toString(), null, null));
         }
         new ProsperoConfig(channels, repositories).writeConfig(provisionConfigFile.toFile());
     }

--- a/prospero-common/src/test/java/org/wildfly/prospero/api/ChanelRefMapperTest.java
+++ b/prospero-common/src/test/java/org/wildfly/prospero/api/ChanelRefMapperTest.java
@@ -57,7 +57,7 @@ public class ChanelRefMapperTest {
 
     @Test
     public void resolveChannelFileThrowsExceptionIfNoVersionsFound() throws Exception {
-        final List<ChannelRef> channels = Arrays.asList(new ChannelRef("org.test:test:1.0", null));
+        final List<ChannelRef> channels = Arrays.asList(new ChannelRef(ChannelRef.Type.GAV, "org.test:test:1.0", null, null, null));
         try {
             resolveChannel(new RemoteRepository.Builder("test", "default", this.getClass().getResource("/").toString())
                     .build(), channels);
@@ -73,7 +73,7 @@ public class ChanelRefMapperTest {
         deployChannel("test100", "1.0.0", system, session, testRepo);
         deployChannel("test101", "1.0.1", system, session, testRepo);
 
-        final List<ChannelRef> channels = Arrays.asList(new ChannelRef("test:channel-one", null));
+        final List<ChannelRef> channels = Arrays.asList(new ChannelRef(ChannelRef.Type.GAV, "test:channel-one", null, null, null));
         final List<Channel> resolved = resolveChannel(testRepo, channels);
         assertEquals(1, resolved.size());
         assertEquals("test101", resolved.get(0).getName());
@@ -86,7 +86,7 @@ public class ChanelRefMapperTest {
         deployChannel("test100", "1.0.0", system, session, testRepo);
         deployChannel("test101", "1.0.1", system, session, testRepo);
 
-        final List<ChannelRef> channels = Arrays.asList(new ChannelRef("test:channel-one:1.0.0", null));
+        final List<ChannelRef> channels = Arrays.asList(new ChannelRef(ChannelRef.Type.GAV, "test:channel-one:1.0.0", null, null, null));
         final List<Channel> resolved = resolveChannel(testRepo, channels);
         assertEquals(1, resolved.size());
         assertEquals("test101", resolved.get(0).getName());
@@ -100,7 +100,7 @@ public class ChanelRefMapperTest {
         deployChannel("test-2", "1.0.0.Beta1-redhat-20220915", system, session, testRepo);
         deployChannel("test-3", "1.0.0.Beta1-redhat-20220926", system, session, testRepo);
 
-        final List<ChannelRef> channels = Arrays.asList(new ChannelRef("test:channel-one", null));
+        final List<ChannelRef> channels = Arrays.asList(new ChannelRef(ChannelRef.Type.GAV, "test:channel-one", null, null, null));
         final List<Channel> resolved = resolveChannel(testRepo, channels);
         assertEquals(1, resolved.size());
         assertEquals("test-3", resolved.get(0).getName());

--- a/prospero-common/src/test/java/org/wildfly/prospero/api/InstallationMetadataTest.java
+++ b/prospero-common/src/test/java/org/wildfly/prospero/api/InstallationMetadataTest.java
@@ -61,7 +61,7 @@ public class InstallationMetadataTest {
     @Test
     public void testUpdateProsperoConfig() throws Exception {
         final ProsperoConfig config = installationMetadata.getProsperoConfig();
-        config.addChannel(new ChannelRef("new:channel", null));
+        config.addChannel(new ChannelRef(ChannelRef.Type.GAV, "new:channel", null, null, null));
         config.addRepository(new RepositoryRef("test", "file://foo.bar"));
 
         installationMetadata.updateProsperoConfig(config);
@@ -70,7 +70,7 @@ public class InstallationMetadataTest {
         final ProsperoConfig updatedConfig = installationMetadata.getProsperoConfig();
         assertEquals(2, updatedConfig.getChannels().size());
         assertEquals("new channel should be added in first place",
-                new ChannelRef("new:channel", null), updatedConfig.getChannels().get(0));
+                new ChannelRef(ChannelRef.Type.GAV, "new:channel", null, null, null), updatedConfig.getChannels().get(0));
         assertEquals(1, updatedConfig.getRepositories().size());
         assertEquals(new RepositoryRef("test", "file://foo.bar"), updatedConfig.getRepositories().get(0));
         verify(gitStorage).recordConfigChange();
@@ -79,14 +79,14 @@ public class InstallationMetadataTest {
     @Test
     public void dontOverrideProsperoConfigIfItExist() throws Exception {
         final ProsperoConfig config = installationMetadata.getProsperoConfig();
-        config.addChannel(new ChannelRef("new:channel", null));
+        config.addChannel(new ChannelRef(ChannelRef.Type.GAV, "new:channel", null, null, null));
 
         installationMetadata.recordProvision(false);
 
         final ProsperoConfig newConfig = ProsperoConfig.readConfig(base.resolve(InstallationMetadata.METADATA_DIR)
                 .resolve(InstallationMetadata.PROSPERO_CONFIG_FILE_NAME));
         assertThat(newConfig.getChannels()).doesNotContain(
-                new ChannelRef("new:channel", null)
+                new ChannelRef(ChannelRef.Type.GAV, "new:channel", null, null, null)
         );
     }
 
@@ -96,7 +96,7 @@ public class InstallationMetadataTest {
         base = temp.newFolder().toPath();
         installationMetadata = new InstallationMetadata(base,
                 new Channel(null, null, null, null, null),
-                Arrays.asList(new ChannelRef("new:channel", null)),
+                Arrays.asList(new ChannelRef(ChannelRef.Type.GAV, "new:channel", null, null, null)),
                 Arrays.asList(new RepositoryRef("test", "file://foo.bar").toRemoteRepository())
         );
 
@@ -105,7 +105,7 @@ public class InstallationMetadataTest {
         final ProsperoConfig newConfig = ProsperoConfig.readConfig(base.resolve(InstallationMetadata.METADATA_DIR)
                 .resolve(InstallationMetadata.PROSPERO_CONFIG_FILE_NAME));
         assertThat(newConfig.getChannels()).contains(
-                new ChannelRef("new:channel", null)
+                new ChannelRef(ChannelRef.Type.GAV, "new:channel", null, null, null)
         );
         assertThat(newConfig.getRepositories()).contains(
                 new RepositoryRef("test", "file://foo.bar")
@@ -120,7 +120,7 @@ public class InstallationMetadataTest {
         Files.writeString(metadataDir.resolve(InstallationMetadata.MANIFEST_FILE_NAME),
                 ChannelMapper.toYaml(new Channel(null, null, null, null, Collections.emptyList())),
                 StandardOpenOption.CREATE_NEW);
-        new ProsperoConfig(Arrays.asList(new ChannelRef("foo:bar", null)), Collections.emptyList()).writeConfig(
+        new ProsperoConfig(Arrays.asList(new ChannelRef(ChannelRef.Type.GAV, "foo:bar", null, null, null)), Collections.emptyList()).writeConfig(
                 metadataDir.resolve(InstallationMetadata.PROSPERO_CONFIG_FILE_NAME).toFile());
         return base;
     }

--- a/prospero-common/src/test/java/org/wildfly/prospero/api/ProvisioningDefinitionTest.java
+++ b/prospero-common/src/test/java/org/wildfly/prospero/api/ProvisioningDefinitionTest.java
@@ -37,7 +37,7 @@ public class ProvisioningDefinitionTest {
     public void setChannelWithFileUrl() throws Exception {
         final ProvisioningDefinition.Builder builder = new ProvisioningDefinition.Builder().setFpl(EAP_FPL);
 
-        builder.setChannel("file:/tmp/foo.bar");
+        builder.setChannel("file:/tmp/foo.bar", null);
 
         assertEquals("file:/tmp/foo.bar", builder.build().getChannelRefs().get(0).getUrl());
     }
@@ -46,7 +46,7 @@ public class ProvisioningDefinitionTest {
     public void setChannelWithHttpUrl() throws Exception {
         final ProvisioningDefinition.Builder builder = new ProvisioningDefinition.Builder().setFpl(EAP_FPL);
 
-        builder.setChannel("http://localhost/foo.bar");
+        builder.setChannel("http://localhost/foo.bar", null);
 
         assertEquals("http://localhost/foo.bar", builder.build().getChannelRefs().get(0).getUrl());
     }
@@ -55,7 +55,7 @@ public class ProvisioningDefinitionTest {
     public void setChannelWithLocalFilePath() throws Exception {
         final ProvisioningDefinition.Builder builder = new ProvisioningDefinition.Builder().setFpl(EAP_FPL);
 
-        builder.setChannel("tmp/foo.bar");
+        builder.setChannel("tmp/foo.bar", null);
 
         assertEquals(Paths.get("tmp/foo.bar").toAbsolutePath().toUri().toURL().toString(), builder.build().getChannelRefs().get(0).getUrl());
     }

--- a/prospero-common/src/test/java/org/wildfly/prospero/installation/git/GitStorageTest.java
+++ b/prospero-common/src/test/java/org/wildfly/prospero/installation/git/GitStorageTest.java
@@ -125,7 +125,7 @@ public class GitStorageTest {
         final Channel channel = new Channel("test", "", null, null,
                 new ArrayList<>());
         ManifestYamlSupport.write(channel, base.resolve(InstallationMetadata.MANIFEST_FILE_NAME));
-        new ProsperoConfig(Arrays.asList(new ChannelRef("foo:bar", null)), Collections.emptyList()).writeConfig(base.resolve(InstallationMetadata.PROSPERO_CONFIG_FILE_NAME).toFile());
+        new ProsperoConfig(Arrays.asList(new ChannelRef(ChannelRef.Type.GAV, "foo:bar", null, null, null)), Collections.emptyList()).writeConfig(base.resolve(InstallationMetadata.PROSPERO_CONFIG_FILE_NAME).toFile());
 
         gitStorage.record();
 


### PR DESCRIPTION
This change allows to define relative path type in `provision-config` YAML file / `installer-config.yaml` in `.installation` directory. Three types now are legitimate to define a channel:

```
channels:
- type: "gav"
  gav: "foo:bar"
- type: "url"
  url: "file:/Users/chaowan/work/git/wildfly-extra/prospero/examples/wildfly-27.0.0.Alpha2-channel.yaml"
- type: "path"
  path: "examples/wildfly-27.0.0.Alpha3-channel.yaml"
  relativeTo: "installation.home"

repositories: ...
```
In addition, this registers system property `installation.home` in InstallationMetadata to be used later.

Also, an optional `relative-to` option is added to channel commands and install command. e.g:

```
./prospero channel add examples/wildfly-27.0.0.Alpha3-channel.yaml --relative-to=installation.home --dir=wfly-27
./prospero channel remove examples/wildfly-27.0.0.Alpha3-channel.yaml --relative-to=installation.home  --dir=wfly-27

export mysysenv=/Users/chaowan/work/git/wildfly-extra/prospero
./prospero install --fpl=wildfly --dir=wfly-27 --channel=examples/wildfly-27.0.0.Alpha2-channel.yaml --relative-to=mysysenv --offline 
```

@spyrkob Let me know your thought when you have time. Once this is settled, I will add some tests for it.