### PR TITLE
Support properties in prospero-config.yaml

### DIFF
--- a/dist/common/src/main/resources/modules/system/layers/base/org/jboss/prospero/main/module.xml
+++ b/dist/common/src/main/resources/modules/system/layers/base/org/jboss/prospero/main/module.xml
@@ -35,6 +35,7 @@
         <artifact name="${info.picocli:picocli}"/>
         <artifact name="${com.fasterxml.jackson.dataformat:jackson-dataformat-yaml}"/>
         <artifact name="${com.networknt:json-schema-validator}"/>
+        <artifact name="${org.apache.commons:commons-text}"/>
         <artifact name="${org.apache.maven:maven-artifact}"/>
         <artifact name="${org.apache.maven:maven-builder-support}"/>
         <artifact name="${org.apache.maven:maven-model}"/>

--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,7 @@
         <prospero.dist.name>prospero</prospero.dist.name>
         <prospero.target.server>Wildfly</prospero.target.server>
         <version.io.undertow>2.2.17.Final</version.io.undertow>
+        <version.org.apache.commons.commons-text>1.10.0</version.org.apache.commons.commons-text>
         <version.org.apache.maven.plugins.antrun>1.8</version.org.apache.maven.plugins.antrun>
         <version.org.apache.maven.plugins.jar>3.0.2</version.org.apache.maven.plugins.jar>
         <version.org.apache.maven.plugins.pmd>3.16.0</version.org.apache.maven.plugins.pmd>
@@ -86,6 +87,11 @@
                 <artifactId>wildfly-ee-galleon-pack</artifactId>
                 <version>${version.org.wildfly.galleon-pack}</version>
                 <type>zip</type>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-text</artifactId>
+                <version>${version.org.apache.commons.commons-text}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.maven.resolver</groupId>

--- a/prospero-common/pom.xml
+++ b/prospero-common/pom.xml
@@ -14,6 +14,10 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-text</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.wildfly.installation-manager</groupId>
             <artifactId>installation-manager-api</artifactId>
         </dependency>

--- a/prospero-common/src/main/java/org/wildfly/prospero/Messages.java
+++ b/prospero-common/src/main/java/org/wildfly/prospero/Messages.java
@@ -164,4 +164,7 @@ public interface Messages {
 
     @Message("Installation meta was restored from: [%s] to [%s].")
     String installationMetaRestored(Path restorePath, Path installPath);
+
+    @Message("Malformed URL in substituted value : %s from %s")
+    MetadataException invalidPropertySubstitutionValue(String substituted, String url);
 }

--- a/prospero-common/src/main/java/org/wildfly/prospero/galleon/ChannelManifestSubstitutor.java
+++ b/prospero-common/src/main/java/org/wildfly/prospero/galleon/ChannelManifestSubstitutor.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.prospero.galleon;
+
+import org.apache.commons.text.StringSubstitutor;
+import org.jboss.logging.Logger;
+import org.wildfly.channel.Channel;
+import org.wildfly.channel.ChannelManifestCoordinate;
+import org.wildfly.prospero.Messages;
+import org.wildfly.prospero.api.exceptions.MetadataException;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+
+public class ChannelManifestSubstitutor {
+
+    private static final Logger logger = Logger.getLogger(ChannelManifestSubstitutor.class);
+
+    public static Channel substitute(Channel channel) throws MetadataException {
+        ChannelManifestCoordinate channelManifestCoordinate = channel.getManifestRef();
+        if (channelManifestCoordinate.getUrl() == null) {
+            return channel;
+        } else {
+            String url = channelManifestCoordinate.getUrl().toString();
+            String substitutedFromSystemProperty = StringSubstitutor.replaceSystemProperties(url);
+            String substituted = !url.equals(substitutedFromSystemProperty) ? substitutedFromSystemProperty : StringSubstitutor.replace(url, System.getenv());
+            if (url.equals(substituted)) {
+                return channel;
+            } else {
+                URL substitutedURL;
+                try {
+                    substitutedURL = new URL(substituted);
+                } catch (MalformedURLException e) {
+                    throw Messages.MESSAGES.invalidPropertySubstitutionValue(substituted, url);
+                }
+                logger.debug("Channel's manifest URL " + url + " is substituted by " + substituted);
+                ChannelManifestCoordinate substitutedChannelManifestCoordinate = new ChannelManifestCoordinate(substitutedURL);
+                if (channel.getSchemaVersion().isEmpty()) {
+                    return new Channel(channel.getName(), channel.getDescription(), channel.getVendor(), channel.getChannelRequirements(), channel.getRepositories(), substitutedChannelManifestCoordinate);
+                } else {
+                    return new Channel(channel.getSchemaVersion(), channel.getName(), channel.getDescription(), channel.getVendor(), channel.getChannelRequirements(), channel.getRepositories(), substitutedChannelManifestCoordinate);
+                }
+            }
+        }
+    }
+}

--- a/prospero-common/src/main/java/org/wildfly/prospero/test/MetadataTestUtils.java
+++ b/prospero-common/src/main/java/org/wildfly/prospero/test/MetadataTestUtils.java
@@ -93,7 +93,7 @@ public final class MetadataTestUtils {
     }
 
     public static Path prepareChannel(String manifestDescriptor) throws IOException {
-        final Path provisionConfigFile = Files.createTempFile("channels", "yaml").toAbsolutePath();
+        final Path provisionConfigFile = Files.createTempFile("channels", ".yaml").toAbsolutePath();
         provisionConfigFile.toFile().deleteOnExit();
 
         prepareChannel(provisionConfigFile, manifestDescriptor);

--- a/prospero-common/src/test/java/org/wildfly/prospero/galleon/ChannelManifestSubstitutorTest.java
+++ b/prospero-common/src/test/java/org/wildfly/prospero/galleon/ChannelManifestSubstitutorTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.prospero.galleon;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.wildfly.channel.Channel;
+import org.wildfly.channel.ChannelManifestCoordinate;
+import org.wildfly.channel.Repository;
+import org.wildfly.prospero.api.exceptions.MetadataException;
+
+import java.net.MalformedURLException;
+import java.util.List;
+
+public class ChannelManifestSubstitutorTest {
+    @Test
+    public void testChannelManifestSubstituted() throws MalformedURLException, MetadataException {
+        String url = "file:${propName}/examples/wildfly-27.0.0.Alpha2-manifest.yaml";
+        System.setProperty("propName", "propValue");
+        String expected = "file:propValue/examples/wildfly-27.0.0.Alpha2-manifest.yaml";
+        Channel channel = new Channel("channel1", "", null, null, List.of(new Repository("test", "http://test.org")), ChannelManifestCoordinate.create(url, null));
+        Channel substitutedChannel = ChannelManifestSubstitutor.substitute(channel);
+        System.clearProperty("propName");
+        Assert.assertEquals(expected, substitutedChannel.getManifestRef().getUrl().toString());
+    }
+
+    @Test
+    public void testChannelManifestNotSubstituted() throws MalformedURLException, MetadataException {
+        String url = "file:/Users/examples/wildfly-27.0.0.Alpha2-manifest.yaml";
+        Channel channel = new Channel("channel1", "", null, null, List.of(new Repository("test", "http://test.org")), ChannelManifestCoordinate.create(url, null));
+        Channel substitutedChannel = ChannelManifestSubstitutor.substitute(channel);
+        Assert.assertEquals(url, substitutedChannel.getManifestRef().getUrl().toString());
+    }
+}


### PR DESCRIPTION
Support properties in prospero-config.yaml.

This resolve any predefined system property or environment variable for manifest URL prospero config file.

```
---
schemaVersion: "2.0.0"
name: "wildfly"
repositories:
  - id: "central"
    url: "https://repo1.maven.org/maven2/"
  - id: "jboss-public"
    url: "https://repository.jboss.org/nexus/content/groups/public/"
manifest:
  url: "file:${installation.home}/examples/wildfly-27.0.0.Alpha2-manifest.yaml"

```