### PR TITLE
Clear properties to fix forked process runner in WFLY env

### DIFF
--- a/.github/workflows/future.yml
+++ b/.github/workflows/future.yml
@@ -25,9 +25,9 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
-          repository: yersan/wildfly-installation-manager-api
+          repository: wildfly-extras/wildfly-installation-manager-api
           path: wildfly-installation-manager-api
-          ref: integration-wip
+          ref: main
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0

--- a/prospero-common/src/main/java/org/wildfly/prospero/galleon/GalleonUtils.java
+++ b/prospero-common/src/main/java/org/wildfly/prospero/galleon/GalleonUtils.java
@@ -60,14 +60,19 @@ public class GalleonUtils {
 
     private static final String CLASSPATH_SCHEME = "classpath";
     private static final String FILE_SCHEME = "file";
+    static final String JAVAX_MANAGEMENT_BUILDER_INITIAL_PROPERTY = "javax.management.builder.initial";
 
     public static void executeGalleon(GalleonExecution execution, Path localRepository) throws ProvisioningException, UnresolvedMavenArtifactException {
         final String modulePathProperty = System.getProperty(MODULE_PATH_PROPERTY);
+        final String javaxManagementBuilderProperty = System.getProperty(JAVAX_MANAGEMENT_BUILDER_INITIAL_PROPERTY);
 
         try {
             System.setProperty(MAVEN_REPO_LOCAL, localRepository.toString());
             if (modulePathProperty != null) {
                 System.clearProperty(MODULE_PATH_PROPERTY);
+            }
+            if (javaxManagementBuilderProperty != null) {
+                System.clearProperty(JAVAX_MANAGEMENT_BUILDER_INITIAL_PROPERTY);
             }
             final Map<String, String> options = new HashMap<>();
             options.put(GalleonUtils.JBOSS_FORK_EMBEDDED_PROPERTY, GalleonUtils.JBOSS_FORK_EMBEDDED_VALUE);
@@ -82,6 +87,9 @@ public class GalleonUtils {
             System.clearProperty(MAVEN_REPO_LOCAL);
             if (modulePathProperty != null) {
                 System.setProperty(MODULE_PATH_PROPERTY, modulePathProperty);
+            }
+            if (javaxManagementBuilderProperty != null) {
+                System.setProperty(JAVAX_MANAGEMENT_BUILDER_INITIAL_PROPERTY, javaxManagementBuilderProperty);
             }
         }
     }

--- a/prospero-common/src/test/java/org/wildfly/prospero/galleon/GalleonUtilsTest.java
+++ b/prospero-common/src/test/java/org/wildfly/prospero/galleon/GalleonUtilsTest.java
@@ -51,6 +51,17 @@ public class GalleonUtilsTest {
     }
 
     @Test
+    public void clearAndRestoreMBeanBuilderProperty() throws Exception {
+        System.setProperty(GalleonUtils.JAVAX_MANAGEMENT_BUILDER_INITIAL_PROPERTY, "foo");
+        try {
+            GalleonUtils.executeGalleon((options) -> assertNull(System.getProperty(GalleonUtils.JAVAX_MANAGEMENT_BUILDER_INITIAL_PROPERTY)), Paths.get("test"));
+            assertEquals(System.getProperty(GalleonUtils.JAVAX_MANAGEMENT_BUILDER_INITIAL_PROPERTY), "foo");
+        } finally {
+            System.clearProperty(GalleonUtils.JAVAX_MANAGEMENT_BUILDER_INITIAL_PROPERTY);
+        }
+    }
+
+    @Test
     public void extractFailedArtifactResolutionOnCopy() throws Exception {
         final ProvisioningException test = new ProvisioningException(
                 new UnresolvedMavenArtifactException("test"));


### PR DESCRIPTION
When running prospero from within WFLY (as CLI operation) property `javax.management.builder.initial` causes ClassNotFoundException 