### PR TITLE
Replace only selected properties in channel definitions

### DIFF
--- a/prospero-cli/pom.xml
+++ b/prospero-cli/pom.xml
@@ -51,6 +51,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-text</artifactId>
+        </dependency>
+
+
+        <dependency>
             <groupId>org.jboss.logging</groupId>
             <artifactId>jboss-logging</artifactId>
         </dependency>

--- a/prospero-common/pom.xml
+++ b/prospero-common/pom.xml
@@ -14,10 +14,6 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-text</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.wildfly.installation-manager</groupId>
             <artifactId>installation-manager-api</artifactId>
         </dependency>

--- a/prospero-common/src/main/java/org/wildfly/prospero/galleon/ChannelManifestSubstitutor.java
+++ b/prospero-common/src/main/java/org/wildfly/prospero/galleon/ChannelManifestSubstitutor.java
@@ -17,7 +17,6 @@
 
 package org.wildfly.prospero.galleon;
 
-import org.apache.commons.text.StringSubstitutor;
 import org.jboss.logging.Logger;
 import org.wildfly.channel.Channel;
 import org.wildfly.channel.ChannelManifestCoordinate;
@@ -26,19 +25,27 @@ import org.wildfly.prospero.api.exceptions.MetadataException;
 
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.Map;
 
 public class ChannelManifestSubstitutor {
 
     private static final Logger logger = Logger.getLogger(ChannelManifestSubstitutor.class);
+    private final Map<String, String> properties;
 
-    public static Channel substitute(Channel channel) throws MetadataException {
+    public ChannelManifestSubstitutor(Map<String, String> properties) {
+        this.properties = properties;
+    }
+
+    public Channel substitute(Channel channel) throws MetadataException {
         ChannelManifestCoordinate channelManifestCoordinate = channel.getManifestCoordinate();
         if (channelManifestCoordinate.getUrl() == null) {
             return channel;
         } else {
             String url = channelManifestCoordinate.getUrl().toString();
-            String substitutedFromSystemProperty = StringSubstitutor.replaceSystemProperties(url);
-            String substituted = !url.equals(substitutedFromSystemProperty) ? substitutedFromSystemProperty : StringSubstitutor.replace(url, System.getenv());
+            String substituted = url;
+            for (String key: properties.keySet()) {
+                substituted = substituted.replaceAll("\\$\\{"+key+"\\}", properties.get(key));
+            }
             if (url.equals(substituted)) {
                 return channel;
             } else {

--- a/prospero-common/src/main/java/org/wildfly/prospero/galleon/GalleonEnvironment.java
+++ b/prospero-common/src/main/java/org/wildfly/prospero/galleon/GalleonEnvironment.java
@@ -37,6 +37,7 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Consumer;
@@ -59,10 +60,10 @@ public class GalleonEnvironment {
         Optional<ChannelManifest> restoreManifest = Optional.ofNullable(builder.manifest);
         channels = builder.channels;
         List<Channel> substitutedChannels = new ArrayList<>();
-        System.setProperty("installation.home", builder.installDir.toString());
+        final ChannelManifestSubstitutor substitutor = new ChannelManifestSubstitutor(Map.of("installation.home", builder.installDir.toString()));
         // substitute any properties found in URL of ChannelManifestCoordinate.
         for (Channel channel : channels) {
-            substitutedChannels.add(ChannelManifestSubstitutor.substitute(channel));
+            substitutedChannels.add(substitutor.substitute(channel));
         }
 
         final RepositorySystem system = builder.mavenSessionManager.newRepositorySystem();

--- a/prospero-common/src/test/java/org/wildfly/prospero/galleon/ChannelManifestSubstitutorTest.java
+++ b/prospero-common/src/test/java/org/wildfly/prospero/galleon/ChannelManifestSubstitutorTest.java
@@ -25,17 +25,19 @@ import org.wildfly.channel.Repository;
 import org.wildfly.prospero.api.exceptions.MetadataException;
 
 import java.net.MalformedURLException;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 public class ChannelManifestSubstitutorTest {
     @Test
     public void testChannelManifestSubstituted() throws MalformedURLException, MetadataException {
         String url = "file:${propName}/examples/wildfly-27.0.0.Alpha2-manifest.yaml";
-        System.setProperty("propName", "propValue");
+        final ChannelManifestSubstitutor substitutor = new ChannelManifestSubstitutor(Map.of("propName", "propValue"));
         String expected = "file:propValue/examples/wildfly-27.0.0.Alpha2-manifest.yaml";
         Channel channel = new Channel("channel1", "", null, null, List.of(new Repository("test", "http://test.org")),
                 ChannelManifestCoordinate.create(url, null), null, null);
-        Channel substitutedChannel = ChannelManifestSubstitutor.substitute(channel);
+        Channel substitutedChannel = substitutor.substitute(channel);
         System.clearProperty("propName");
         Assert.assertEquals(expected, substitutedChannel.getManifestCoordinate().getUrl().toString());
     }
@@ -43,9 +45,10 @@ public class ChannelManifestSubstitutorTest {
     @Test
     public void testChannelManifestNotSubstituted() throws MalformedURLException, MetadataException {
         String url = "file:/Users/examples/wildfly-27.0.0.Alpha2-manifest.yaml";
+        final ChannelManifestSubstitutor substitutor = new ChannelManifestSubstitutor(Collections.emptyMap());
         Channel channel = new Channel("channel1", "", null, List.of(new Repository("test", "http://test.org")),
                 ChannelManifestCoordinate.create(url, null), null, null);
-        Channel substitutedChannel = ChannelManifestSubstitutor.substitute(channel);
+        Channel substitutedChannel = substitutor.substitute(channel);
         Assert.assertEquals(url, substitutedChannel.getManifestCoordinate().getUrl().toString());
     }
 }


### PR DESCRIPTION
Limit ChannelManifestSubstitutor to only replace curated list of properties rather then System.getProperties and System.getenv
