### PR TITLE
sync prospero metadata

### DIFF
--- a/integration-tests/src/test/java/org/wildfly/prospero/it/cli/CloneTest.java
+++ b/integration-tests/src/test/java/org/wildfly/prospero/it/cli/CloneTest.java
@@ -49,8 +49,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
-import static org.wildfly.prospero.api.InstallationMetadata.MANIFEST_FILE_NAME;
-import static org.wildfly.prospero.api.InstallationMetadata.METADATA_DIR;
 
 public class CloneTest extends WfCoreTestBase {
 
@@ -99,7 +97,7 @@ public class CloneTest extends WfCoreTestBase {
                 .withTimeLimit(10, TimeUnit.MINUTES)
                 .execute()
                 .assertReturnCode(ReturnCodes.SUCCESS);
-        return ManifestYamlSupport.parse(installDir.resolve(METADATA_DIR).resolve(MANIFEST_FILE_NAME).toFile());
+        return ManifestYamlSupport.parse(installDir.resolve(ProsperoMetadataUtils.METADATA_DIR).resolve(ProsperoMetadataUtils.MANIFEST_FILE_NAME).toFile());
     }
 
     private void checkMetaData(InstallationMetadata metadata, Stream stream, ChannelManifest installedManifest) throws Exception {

--- a/integration-tests/src/test/java/org/wildfly/prospero/it/commonapi/InstallationHistoryActionTest.java
+++ b/integration-tests/src/test/java/org/wildfly/prospero/it/commonapi/InstallationHistoryActionTest.java
@@ -22,7 +22,7 @@ import org.jboss.galleon.ProvisioningException;
 import org.junit.Assert;
 import org.wildfly.channel.Channel;
 import org.wildfly.channel.Repository;
-import org.wildfly.prospero.model.ManifestVersionRecord;
+import org.wildfly.prospero.metadata.ManifestVersionRecord;
 import org.wildfly.prospero.api.ArtifactChange;
 import org.wildfly.prospero.actions.InstallationHistoryAction;
 import org.wildfly.prospero.api.InstallationMetadata;

--- a/integration-tests/src/test/java/org/wildfly/prospero/it/commonapi/InstallationRestoreActionTest.java
+++ b/integration-tests/src/test/java/org/wildfly/prospero/it/commonapi/InstallationRestoreActionTest.java
@@ -25,12 +25,12 @@ import org.wildfly.prospero.actions.InstallationRestoreAction;
 import org.wildfly.prospero.actions.ProvisioningAction;
 import org.wildfly.prospero.api.ProvisioningDefinition;
 import org.wildfly.prospero.it.AcceptingConsole;
+import org.wildfly.prospero.metadata.ProsperoMetadataUtils;
 import org.wildfly.prospero.model.ManifestYamlSupport;
 import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.artifact.DefaultArtifact;
 import org.junit.Before;
 import org.junit.Test;
-import org.wildfly.prospero.model.ProsperoConfig;
 import org.wildfly.prospero.test.MetadataTestUtils;
 
 import java.io.File;
@@ -68,7 +68,7 @@ public class InstallationRestoreActionTest extends WfCoreTestBase {
                 .provision(provisioningDefinition.toProvisioningConfig(),
                         provisioningDefinition.resolveChannels(CHANNELS_RESOLVER_FACTORY));
 
-        prepareInstallerConfig(outputPath.resolve(MetadataTestUtils.INSTALLER_CHANNELS_FILE_PATH), CHANNEL_COMPONENT_UPDATES, CHANNEL_BASE_CORE_19);
+        prepareInstallerConfig(CHANNEL_COMPONENT_UPDATES, CHANNEL_BASE_CORE_19);
 
         new InstallationExportAction(outputPath).export(Paths.get("target/bundle.zip"));
 
@@ -87,7 +87,7 @@ public class InstallationRestoreActionTest extends WfCoreTestBase {
     }
 
     // config including correct channel names
-    private static void prepareInstallerConfig(Path provisionConfigFile, String... channelDescriptor)
+    private void prepareInstallerConfig(String... channelDescriptor)
             throws IOException {
         List<URL> channelUrls = Arrays.stream(channelDescriptor)
                 .map(d->InstallationRestoreActionTest.class.getClassLoader().getResource(d))
@@ -100,7 +100,8 @@ public class InstallationRestoreActionTest extends WfCoreTestBase {
                     new ChannelManifestCoordinate(channelUrls.get(i)), null, null));
         }
 
-        new ProsperoConfig(channels).writeConfig(provisionConfigFile.getParent());
+        final Path configFilePath = ProsperoMetadataUtils.configurationPath(outputPath);
+        ProsperoMetadataUtils.writeChannelsConfiguration(configFilePath, channels);
     }
 
 }

--- a/integration-tests/src/test/java/org/wildfly/prospero/it/commonapi/SimpleProvisionTest.java
+++ b/integration-tests/src/test/java/org/wildfly/prospero/it/commonapi/SimpleProvisionTest.java
@@ -35,7 +35,7 @@ import org.jboss.galleon.Constants;
 import org.jboss.galleon.ProvisioningException;
 import org.junit.Test;
 import org.wildfly.channel.Channel;
-import org.wildfly.prospero.model.ManifestVersionRecord;
+import org.wildfly.prospero.metadata.ManifestVersionRecord;
 import org.wildfly.prospero.actions.UpdateAction;
 import org.wildfly.prospero.api.ArtifactChange;
 import org.wildfly.prospero.api.ProvisioningDefinition;

--- a/integration-tests/src/test/java/org/wildfly/prospero/it/commonapi/SimpleProvisionTest.java
+++ b/integration-tests/src/test/java/org/wildfly/prospero/it/commonapi/SimpleProvisionTest.java
@@ -38,7 +38,6 @@ import org.wildfly.channel.Channel;
 import org.wildfly.prospero.model.ManifestVersionRecord;
 import org.wildfly.prospero.actions.UpdateAction;
 import org.wildfly.prospero.api.ArtifactChange;
-import org.wildfly.prospero.api.InstallationMetadata;
 import org.wildfly.prospero.api.ProvisioningDefinition;
 import org.wildfly.prospero.api.exceptions.OperationException;
 import org.wildfly.prospero.galleon.ArtifactCache;
@@ -100,7 +99,7 @@ public class SimpleProvisionTest extends WfCoreTestBase {
         installation.provision(provisioningDefinition.toProvisioningConfig(),
                 provisioningDefinition.resolveChannels(CHANNELS_RESOLVER_FACTORY));
 
-        final ProsperoConfig persistedConfig = ProsperoConfig.readConfig(outputPath.resolve(InstallationMetadata.METADATA_DIR));
+        final ProsperoConfig persistedConfig = ProsperoConfig.readConfig(outputPath.resolve(ProsperoMetadataUtils.METADATA_DIR));
         assertThat(persistedConfig.getChannels())
                 .map(Channel::getName)
                 .noneMatch(StringUtils::isEmpty)

--- a/integration-tests/src/test/java/org/wildfly/prospero/it/commonapi/UpdateTest.java
+++ b/integration-tests/src/test/java/org/wildfly/prospero/it/commonapi/UpdateTest.java
@@ -34,7 +34,7 @@ import org.wildfly.channel.ChannelManifestCoordinate;
 import org.wildfly.channel.ChannelMapper;
 import org.wildfly.channel.Repository;
 import org.wildfly.channel.Stream;
-import org.wildfly.prospero.model.ManifestVersionRecord;
+import org.wildfly.prospero.metadata.ManifestVersionRecord;
 import org.wildfly.prospero.actions.UpdateAction;
 import org.wildfly.prospero.api.MavenOptions;
 import org.wildfly.prospero.api.ProvisioningDefinition;

--- a/integration-tests/src/test/java/org/wildfly/prospero/it/commonapi/UpdateTest.java
+++ b/integration-tests/src/test/java/org/wildfly/prospero/it/commonapi/UpdateTest.java
@@ -36,7 +36,6 @@ import org.wildfly.channel.Repository;
 import org.wildfly.channel.Stream;
 import org.wildfly.prospero.model.ManifestVersionRecord;
 import org.wildfly.prospero.actions.UpdateAction;
-import org.wildfly.prospero.api.InstallationMetadata;
 import org.wildfly.prospero.api.MavenOptions;
 import org.wildfly.prospero.api.ProvisioningDefinition;
 import org.wildfly.prospero.api.RepositoryUtils;
@@ -114,8 +113,8 @@ public class UpdateTest extends WfCoreTestBase {
 
     @Test
     public void updateWildflyCoreIgnoreChangesInProsperoConfig() throws Exception {
-        final Path channelsFile = outputPath.resolve(InstallationMetadata.METADATA_DIR)
-                .resolve(InstallationMetadata.INSTALLER_CHANNELS_FILE_NAME);
+        final Path channelsFile = outputPath.resolve(ProsperoMetadataUtils.METADATA_DIR)
+                .resolve(ProsperoMetadataUtils.INSTALLER_CHANNELS_FILE_NAME);
 
         // deploy manifest file
         File manifestFile = new File(MetadataTestUtils.class.getClassLoader().getResource(CHANNEL_BASE_CORE_19).toURI());
@@ -226,7 +225,7 @@ public class UpdateTest extends WfCoreTestBase {
 
     private File buildConfigWithMockRepo() throws IOException {
         final List<Repository> repositories = new ArrayList<>(defaultRemoteRepositories());
-        final File channelsFile = temp.newFile(InstallationMetadata.INSTALLER_CHANNELS_FILE_NAME);
+        final File channelsFile = temp.newFile(ProsperoMetadataUtils.INSTALLER_CHANNELS_FILE_NAME);
         repositories.add(new Repository("test-repo", mockRepo.toURI().toURL().toString()));
         Channel channel = new Channel("test", "", null, repositories,
                 new ChannelManifestCoordinate("test", "channel"), null, null);

--- a/integration-tests/src/test/java/org/wildfly/prospero/it/commonapi/UpdateTest.java
+++ b/integration-tests/src/test/java/org/wildfly/prospero/it/commonapi/UpdateTest.java
@@ -31,6 +31,7 @@ import org.junit.Test;
 import org.wildfly.channel.Channel;
 import org.wildfly.channel.ChannelManifest;
 import org.wildfly.channel.ChannelManifestCoordinate;
+import org.wildfly.channel.ChannelMapper;
 import org.wildfly.channel.Repository;
 import org.wildfly.channel.Stream;
 import org.wildfly.prospero.model.ManifestVersionRecord;
@@ -42,7 +43,6 @@ import org.wildfly.prospero.api.RepositoryUtils;
 import org.wildfly.prospero.it.AcceptingConsole;
 import org.wildfly.prospero.metadata.ProsperoMetadataUtils;
 import org.wildfly.prospero.model.ManifestYamlSupport;
-import org.wildfly.prospero.model.ProsperoConfig;
 import org.wildfly.prospero.test.MetadataTestUtils;
 import org.wildfly.prospero.wfchannel.MavenSessionManager;
 
@@ -50,6 +50,7 @@ import java.io.File;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
@@ -217,8 +218,9 @@ public class UpdateTest extends WfCoreTestBase {
         }).collect(Collectors.toList());
 
         final File file = temp.newFile("test-channel.yaml");
-        ManifestYamlSupport.write(new ChannelManifest(manifest.getSchemaVersion(), manifest.getName(), null, streams),
-                file.toPath());
+        ChannelManifest manifest1 = new ChannelManifest(manifest.getSchemaVersion(), manifest.getName(), null, streams);
+        Path manifestPath1 = file.toPath();
+        ProsperoMetadataUtils.writeManifest(manifestPath1, manifest1);
         return file;
     }
 
@@ -228,7 +230,7 @@ public class UpdateTest extends WfCoreTestBase {
         repositories.add(new Repository("test-repo", mockRepo.toURI().toURL().toString()));
         Channel channel = new Channel("test", "", null, repositories,
                 new ChannelManifestCoordinate("test", "channel"), null, null);
-        new ProsperoConfig(List.of(channel)).writeConfig(channelsFile.toPath().getParent());
+        Files.writeString(channelsFile.toPath(), ChannelMapper.toYaml(List.of(channel)), StandardCharsets.UTF_8);
         return channelsFile;
     }
 

--- a/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/AbstractCommand.java
+++ b/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/AbstractCommand.java
@@ -29,6 +29,7 @@ import org.wildfly.prospero.api.InstallationMetadata;
 import org.wildfly.prospero.cli.ActionFactory;
 import org.wildfly.prospero.cli.CliConsole;
 import org.wildfly.prospero.cli.CliMessages;
+import org.wildfly.prospero.metadata.ProsperoMetadataUtils;
 import picocli.CommandLine;
 
 public abstract class AbstractCommand implements Callable<Integer> {
@@ -59,8 +60,8 @@ public abstract class AbstractCommand implements Callable<Integer> {
 
     static void verifyDirectoryContainsInstallation(Path path) {
         File dotGalleonDir = path.resolve(InstallationMetadata.GALLEON_INSTALLATION_DIR).toFile();
-        File channelsFile = path.resolve(InstallationMetadata.METADATA_DIR)
-                .resolve(InstallationMetadata.INSTALLER_CHANNELS_FILE_NAME).toFile();
+        File channelsFile = path.resolve(ProsperoMetadataUtils.METADATA_DIR)
+                .resolve(ProsperoMetadataUtils.INSTALLER_CHANNELS_FILE_NAME).toFile();
         if (!dotGalleonDir.isDirectory() || !channelsFile.isFile()) {
             if (currentDir().equals(path)) {
                 // if the path is the current directory, user may have forgotten to specify the --dir option

--- a/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/channel/ChannelInitializeCommand.java
+++ b/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/channel/ChannelInitializeCommand.java
@@ -23,7 +23,6 @@ import org.wildfly.channel.ChannelManifestCoordinate;
 import org.wildfly.channel.Repository;
 import org.wildfly.prospero.actions.MetadataAction;
 import org.wildfly.prospero.api.ArtifactUtils;
-import org.wildfly.prospero.api.InstallationMetadata;
 import org.wildfly.prospero.api.exceptions.MetadataException;
 import org.wildfly.prospero.cli.ActionFactory;
 import org.wildfly.prospero.cli.CliConsole;
@@ -31,6 +30,7 @@ import org.wildfly.prospero.cli.CliMessages;
 import org.wildfly.prospero.cli.ReturnCodes;
 import org.wildfly.prospero.cli.commands.AbstractCommand;
 import org.wildfly.prospero.cli.commands.CliConstants;
+import org.wildfly.prospero.metadata.ProsperoMetadataUtils;
 import picocli.CommandLine;
 
 import java.io.File;
@@ -89,7 +89,7 @@ public class ChannelInitializeCommand extends AbstractCommand {
                     }
                 }
             } else {
-                final Path defaultLocalRepoPath = installationDirectory.resolve(InstallationMetadata.METADATA_DIR)
+                final Path defaultLocalRepoPath = installationDirectory.resolve(ProsperoMetadataUtils.METADATA_DIR)
                         .resolve(DEFAULT_CUSTOMIZATION_REPOSITORY);
                 if (!createLocalRepository(defaultLocalRepoPath)) {
                     return ReturnCodes.PROCESSING_ERROR;

--- a/prospero-cli/src/test/java/org/wildfly/prospero/cli/commands/channel/ChannelInitializeCommandTest.java
+++ b/prospero-cli/src/test/java/org/wildfly/prospero/cli/commands/channel/ChannelInitializeCommandTest.java
@@ -33,6 +33,7 @@ import org.wildfly.prospero.cli.AbstractConsoleTest;
 import org.wildfly.prospero.cli.CliMessages;
 import org.wildfly.prospero.cli.ReturnCodes;
 import org.wildfly.prospero.cli.commands.CliConstants;
+import org.wildfly.prospero.metadata.ProsperoMetadataUtils;
 import org.wildfly.prospero.model.ProsperoConfig;
 import org.wildfly.prospero.test.MetadataTestUtils;
 
@@ -271,8 +272,9 @@ public class ChannelInitializeCommandTest extends AbstractConsoleTest {
                 List.of(new Repository("test", "http://test.org/repo")),
                 new ChannelManifestCoordinate(CUSTOM_CHANNELS_GROUP_ID, "existing"),
                 null, null);
-        new ProsperoConfig(List.of(channel))
-                .writeConfig(installationDir.resolve(InstallationMetadata.METADATA_DIR));
+
+        final Path configFilePath = ProsperoMetadataUtils.configurationPath(installationDir);
+        ProsperoMetadataUtils.writeChannelsConfiguration(configFilePath, List.of(channel));
         int exitCode = commandLine.execute(
                 CliConstants.Commands.CHANNEL, CliConstants.Commands.CUSTOMIZATION_INIT_CHANNEL,
                 CliConstants.CUSTOMIZATION_REPOSITORY_URL, "http://test.repo2",

--- a/prospero-cli/src/test/java/org/wildfly/prospero/cli/commands/channel/ChannelInitializeCommandTest.java
+++ b/prospero-cli/src/test/java/org/wildfly/prospero/cli/commands/channel/ChannelInitializeCommandTest.java
@@ -232,7 +232,7 @@ public class ChannelInitializeCommandTest extends AbstractConsoleTest {
                 .map(r-> tuple(r.getId(), r.getUrl()))
                 .contains(
                     tuple(CUSTOMIZATION_REPO_ID,
-                        installationDir.resolve(InstallationMetadata.METADATA_DIR).resolve(DEFAULT_CUSTOMIZATION_REPOSITORY).toUri().toURL().toString())
+                        installationDir.resolve(ProsperoMetadataUtils.METADATA_DIR).resolve(DEFAULT_CUSTOMIZATION_REPOSITORY).toUri().toURL().toString())
                 );
         assertThat(actualChannels())
                 .map(c -> c.getManifestCoordinate().getMaven())
@@ -257,7 +257,7 @@ public class ChannelInitializeCommandTest extends AbstractConsoleTest {
                 .map(r-> tuple(r.getId(), r.getUrl()))
                 .contains(
                     tuple(CUSTOMIZATION_REPO_ID,
-                        installationDir.resolve(InstallationMetadata.METADATA_DIR).resolve(DEFAULT_CUSTOMIZATION_REPOSITORY).toUri().toURL().toString())
+                        installationDir.resolve(ProsperoMetadataUtils.METADATA_DIR).resolve(DEFAULT_CUSTOMIZATION_REPOSITORY).toUri().toURL().toString())
         );
         assertThat(actualChannels())
                 .map(c -> c.getManifestCoordinate().getMaven())

--- a/prospero-common/src/main/java/org/wildfly/prospero/Messages.java
+++ b/prospero-common/src/main/java/org/wildfly/prospero/Messages.java
@@ -17,7 +17,6 @@
 
 package org.wildfly.prospero;
 
-import java.io.IOException;
 import java.net.URI;
 import java.net.URL;
 import java.nio.file.Path;
@@ -111,8 +110,8 @@ public interface Messages {
     @Message("Unable to read file at [%s]")
     MetadataException unableToReadFile(Path path, @Cause Exception e);
 
-    @Message("Unable to download file from [%s]")
-    MetadataException unableToDownloadFile(URL url, @Cause IOException e);
+    @Message("Unable to download file")
+    String unableToDownloadFile();
 
     @Message("Unable to write file at [%s]")
     MetadataException unableToWriteFile(Path path, @Cause Exception e);

--- a/prospero-common/src/main/java/org/wildfly/prospero/actions/InstallationHistoryAction.java
+++ b/prospero-common/src/main/java/org/wildfly/prospero/actions/InstallationHistoryAction.java
@@ -30,7 +30,7 @@ import org.wildfly.prospero.api.exceptions.MetadataException;
 import org.wildfly.prospero.api.SavedState;
 import org.wildfly.prospero.galleon.GalleonEnvironment;
 import org.wildfly.prospero.metadata.ProsperoMetadataUtils;
-import org.wildfly.prospero.model.ManifestVersionRecord;
+import org.wildfly.prospero.metadata.ManifestVersionRecord;
 import org.wildfly.prospero.model.ProsperoConfig;
 import org.wildfly.prospero.wfchannel.MavenSessionManager;
 import org.jboss.galleon.ProvisioningException;
@@ -117,7 +117,7 @@ public class InstallationHistoryAction {
         try {
             final Optional<ManifestVersionRecord> manifestHistory = revertMetadata.getManifestVersions();
             if (manifestHistory.isPresent()) {
-                ManifestVersionRecord.write(manifestHistory.get(), targetDir.resolve(METADATA_DIR).resolve(CURRENT_VERSION_FILE));
+                ProsperoMetadataUtils.writeVersionRecord(targetDir.resolve(METADATA_DIR).resolve(CURRENT_VERSION_FILE), manifestHistory.get());
             } else {
                 Path versionsFile = targetDir.resolve(METADATA_DIR).resolve(CURRENT_VERSION_FILE);
                 if (Files.exists(versionsFile)) {

--- a/prospero-common/src/main/java/org/wildfly/prospero/actions/PrepareCandidateAction.java
+++ b/prospero-common/src/main/java/org/wildfly/prospero/actions/PrepareCandidateAction.java
@@ -26,6 +26,7 @@ import org.jboss.galleon.xml.ProvisioningXmlParser;
 import org.wildfly.channel.Channel;
 import org.wildfly.channel.ChannelManifest;
 import org.wildfly.channel.UnresolvedMavenArtifactException;
+import org.wildfly.prospero.Messages;
 import org.wildfly.prospero.api.Console;
 import org.wildfly.prospero.api.InstallationMetadata;
 import org.wildfly.prospero.api.SavedState;
@@ -36,7 +37,8 @@ import org.wildfly.prospero.galleon.ChannelMavenArtifactRepositoryManager;
 import org.wildfly.prospero.galleon.GalleonEnvironment;
 import org.wildfly.prospero.galleon.GalleonFeaturePackAnalyzer;
 import org.wildfly.prospero.galleon.GalleonUtils;
-import org.wildfly.prospero.model.ManifestVersionRecord;
+import org.wildfly.prospero.metadata.ManifestVersionRecord;
+import org.wildfly.prospero.metadata.ManifestVersionResolver;
 import org.wildfly.prospero.model.ProsperoConfig;
 import org.wildfly.prospero.updates.MarkerFile;
 import org.wildfly.prospero.wfchannel.MavenSessionManager;
@@ -90,12 +92,13 @@ class PrepareCandidateAction implements AutoCloseable{
         }
 
         try {
-            final ManifestVersionRecord manifestRecord = new ManifestVersionResolver(mavenSessionManager)
-                    .getCurrentVersions(galleonEnv.getChannels());
+            final ManifestVersionRecord manifestRecord =
+                    new ManifestVersionResolver(mavenSessionManager.getProvisioningRepo(), mavenSessionManager.newRepositorySystem())
+                            .getCurrentVersions(galleonEnv.getChannels());
             writeProsperoMetadata(targetDir, galleonEnv.getRepositoryManager(), metadata.getProsperoConfig().getChannels(),
                     manifestRecord);
-        } catch (MetadataException ex) {
-            throw new ProvisioningException(ex);
+        } catch (IOException ex) {
+            throw new ProvisioningException(Messages.MESSAGES.unableToDownloadFile(), ex);
         }
 
         try {

--- a/prospero-common/src/main/java/org/wildfly/prospero/actions/ProvisioningAction.java
+++ b/prospero-common/src/main/java/org/wildfly/prospero/actions/ProvisioningAction.java
@@ -46,7 +46,8 @@ import java.util.stream.Collectors;
 
 import org.wildfly.prospero.licenses.License;
 import org.wildfly.prospero.licenses.LicenseManager;
-import org.wildfly.prospero.model.ManifestVersionRecord;
+import org.wildfly.prospero.metadata.ManifestVersionRecord;
+import org.wildfly.prospero.metadata.ManifestVersionResolver;
 import org.wildfly.prospero.model.ProsperoConfig;
 import org.wildfly.prospero.wfchannel.MavenSessionManager;
 import org.eclipse.aether.repository.RemoteRepository;
@@ -99,7 +100,13 @@ public class ProvisioningAction {
             throw new ArtifactResolutionException(e, repositories, mavenSessionManager.isOffline());
         }
 
-        final ManifestVersionRecord manifestRecord = new ManifestVersionResolver(mavenSessionManager).getCurrentVersions(channels);
+        final ManifestVersionRecord manifestRecord;
+        try {
+            manifestRecord = new ManifestVersionResolver(mavenSessionManager.getProvisioningRepo(), mavenSessionManager.newRepositorySystem())
+                    .getCurrentVersions(channels);
+        } catch (IOException e) {
+            throw new MetadataException(Messages.MESSAGES.unableToDownloadFile(), e);
+        }
 
         writeProsperoMetadata(installDir, galleonEnv.getRepositoryManager(), channels, manifestRecord);
 

--- a/prospero-common/src/main/java/org/wildfly/prospero/api/InstallationMetadata.java
+++ b/prospero-common/src/main/java/org/wildfly/prospero/api/InstallationMetadata.java
@@ -184,8 +184,8 @@ public class InstallationMetadata implements AutoCloseable {
                                    GitStorage gitStorage, Optional<ManifestVersionRecord> currentVersions) throws MetadataException {
         this.base = base;
         this.gitStorage = gitStorage;
-        this.manifestFile = base.resolve(METADATA_DIR).resolve(InstallationMetadata.MANIFEST_FILE_NAME);
-        this.channelsFile = base.resolve(METADATA_DIR).resolve(InstallationMetadata.INSTALLER_CHANNELS_FILE_NAME);
+        this.manifestFile = ProsperoMetadataUtils.manifestPath(base);
+        this.channelsFile = ProsperoMetadataUtils.configurationPath(base);
         this.readmeFile = base.resolve(METADATA_DIR).resolve(ProsperoMetadataUtils.README_FILE_NAME);
         this.provisioningFile = base.resolve(GALLEON_INSTALLATION_DIR).resolve(InstallationMetadata.PROVISIONING_FILE_NAME);
 
@@ -257,7 +257,7 @@ public class InstallationMetadata implements AutoCloseable {
 
     public void recordProvision(boolean overrideProsperoConfig, boolean gitRecord) throws MetadataException {
         try {
-            ManifestYamlSupport.write(this.manifest, this.manifestFile);
+            ProsperoMetadataUtils.writeManifest(this.manifestFile, this.manifest);
         } catch (IOException e) {
             throw Messages.MESSAGES.unableToSaveConfiguration(manifestFile, e);
         }
@@ -285,7 +285,7 @@ public class InstallationMetadata implements AutoCloseable {
 
     private void writeProsperoConfig() throws MetadataException {
         try {
-            getProsperoConfig().writeConfig(this.base.resolve(METADATA_DIR));
+            ProsperoMetadataUtils.writeChannelsConfiguration(channelsFile, getProsperoConfig().getChannels());
         } catch (IOException e) {
             throw Messages.MESSAGES.unableToSaveConfiguration(channelsFile, e);
         }

--- a/prospero-common/src/main/java/org/wildfly/prospero/api/InstallationMetadata.java
+++ b/prospero-common/src/main/java/org/wildfly/prospero/api/InstallationMetadata.java
@@ -56,12 +56,6 @@ import static org.wildfly.prospero.metadata.ProsperoMetadataUtils.CURRENT_VERSIO
 
 public class InstallationMetadata implements AutoCloseable {
 
-    @Deprecated
-    public static final String METADATA_DIR = ProsperoMetadataUtils.METADATA_DIR;
-    @Deprecated
-    public static final String MANIFEST_FILE_NAME = ProsperoMetadataUtils.MANIFEST_FILE_NAME;
-    @Deprecated
-    public static final String INSTALLER_CHANNELS_FILE_NAME = ProsperoMetadataUtils.INSTALLER_CHANNELS_FILE_NAME;
     public static final String PROVISIONING_FILE_NAME = "provisioning.xml";
     public static final String GALLEON_INSTALLATION_DIR = ".galleon";
     private static final String WARNING_MESSAGE = "WARNING: The files in .installation directory should be only edited by the provisioning tool.";
@@ -84,7 +78,7 @@ public class InstallationMetadata implements AutoCloseable {
      * @throws MetadataException
      */
     public static InstallationMetadata loadInstallation(Path base) throws MetadataException {
-        final Path manifestFile = base.resolve(METADATA_DIR).resolve(InstallationMetadata.MANIFEST_FILE_NAME);
+        final Path manifestFile = base.resolve(ProsperoMetadataUtils.METADATA_DIR).resolve(ProsperoMetadataUtils.MANIFEST_FILE_NAME);
 
         ChannelManifest manifest;
         ProsperoConfig prosperoConfig;
@@ -96,7 +90,7 @@ public class InstallationMetadata implements AutoCloseable {
             throw Messages.MESSAGES.unableToParseConfiguration(manifestFile, e);
         }
         try {
-            prosperoConfig = ProsperoConfig.readConfig(base.resolve(METADATA_DIR));
+            prosperoConfig = ProsperoConfig.readConfig(base.resolve(ProsperoMetadataUtils.METADATA_DIR));
         } catch (MetadataException e) {
             // re-wrap the exception to change the description
             throw Messages.MESSAGES.unableToParseConfiguration(base, e.getCause());
@@ -111,7 +105,7 @@ public class InstallationMetadata implements AutoCloseable {
                 gitStorage.record();
             }
         } catch (IOException e) {
-            throw Messages.MESSAGES.unableToCreateHistoryStorage(base.resolve(METADATA_DIR), e);
+            throw Messages.MESSAGES.unableToCreateHistoryStorage(base.resolve(ProsperoMetadataUtils.METADATA_DIR), e);
         }
         return metadata;
     }
@@ -153,13 +147,13 @@ public class InstallationMetadata implements AutoCloseable {
             Files.createDirectory(tempDirectory.resolve(Constants.PROVISIONED_STATE_DIR));
             while ((entry = zis.getNextEntry()) != null) {
 
-                if (entry.getName().equals(MANIFEST_FILE_NAME)) {
+                if (entry.getName().equals(ProsperoMetadataUtils.MANIFEST_FILE_NAME)) {
                     manifestFile = tempDirectory.resolve(ProsperoMetadataUtils.METADATA_DIR).resolve(ProsperoMetadataUtils.MANIFEST_FILE_NAME);
                     Files.copy(zis, manifestFile, StandardCopyOption.REPLACE_EXISTING);
                     manifestFile.toFile().deleteOnExit();
                 }
 
-                if (entry.getName().equals(INSTALLER_CHANNELS_FILE_NAME)) {
+                if (entry.getName().equals(ProsperoMetadataUtils.INSTALLER_CHANNELS_FILE_NAME)) {
                     channelsFile = tempDirectory.resolve(ProsperoMetadataUtils.METADATA_DIR).resolve(ProsperoMetadataUtils.INSTALLER_CHANNELS_FILE_NAME);
                     Files.copy(zis, channelsFile, StandardCopyOption.REPLACE_EXISTING);
                     channelsFile.toFile().deleteOnExit();
@@ -186,7 +180,7 @@ public class InstallationMetadata implements AutoCloseable {
         this.gitStorage = gitStorage;
         this.manifestFile = ProsperoMetadataUtils.manifestPath(base);
         this.channelsFile = ProsperoMetadataUtils.configurationPath(base);
-        this.readmeFile = base.resolve(METADATA_DIR).resolve(ProsperoMetadataUtils.README_FILE_NAME);
+        this.readmeFile = base.resolve(ProsperoMetadataUtils.METADATA_DIR).resolve(ProsperoMetadataUtils.README_FILE_NAME);
         this.provisioningFile = base.resolve(GALLEON_INSTALLATION_DIR).resolve(InstallationMetadata.PROVISIONING_FILE_NAME);
 
         this.manifest = manifest;
@@ -210,7 +204,7 @@ public class InstallationMetadata implements AutoCloseable {
         final File file = location.toFile();
 
         try (ZipOutputStream zos = new ZipOutputStream(new FileOutputStream(file))) {
-            zos.putNextEntry(new ZipEntry(MANIFEST_FILE_NAME));
+            zos.putNextEntry(new ZipEntry(ProsperoMetadataUtils.MANIFEST_FILE_NAME));
             try(FileInputStream fis = new FileInputStream(manifestFile.toFile())) {
                 byte[] buffer = new byte[1024];
                 int len;
@@ -220,7 +214,7 @@ public class InstallationMetadata implements AutoCloseable {
             }
             zos.closeEntry();
 
-            zos.putNextEntry(new ZipEntry(INSTALLER_CHANNELS_FILE_NAME));
+            zos.putNextEntry(new ZipEntry(ProsperoMetadataUtils.INSTALLER_CHANNELS_FILE_NAME));
             try(FileInputStream fis = new FileInputStream(channelsFile.toFile())) {
                 byte[] buffer = new byte[1024];
                 int len;

--- a/prospero-common/src/main/java/org/wildfly/prospero/api/InstallationMetadata.java
+++ b/prospero-common/src/main/java/org/wildfly/prospero/api/InstallationMetadata.java
@@ -64,7 +64,6 @@ public class InstallationMetadata implements AutoCloseable {
     public static final String INSTALLER_CHANNELS_FILE_NAME = ProsperoMetadataUtils.INSTALLER_CHANNELS_FILE_NAME;
     public static final String PROVISIONING_FILE_NAME = "provisioning.xml";
     public static final String GALLEON_INSTALLATION_DIR = ".galleon";
-    public static final String README_FILE_NAME = "README.txt";
     private static final String WARNING_MESSAGE = "WARNING: The files in .installation directory should be only edited by the provisioning tool.";
     private final Path manifestFile;
     private final Path channelsFile;
@@ -187,7 +186,7 @@ public class InstallationMetadata implements AutoCloseable {
         this.gitStorage = gitStorage;
         this.manifestFile = base.resolve(METADATA_DIR).resolve(InstallationMetadata.MANIFEST_FILE_NAME);
         this.channelsFile = base.resolve(METADATA_DIR).resolve(InstallationMetadata.INSTALLER_CHANNELS_FILE_NAME);
-        this.readmeFile = base.resolve(METADATA_DIR).resolve(InstallationMetadata.README_FILE_NAME);
+        this.readmeFile = base.resolve(METADATA_DIR).resolve(ProsperoMetadataUtils.README_FILE_NAME);
         this.provisioningFile = base.resolve(GALLEON_INSTALLATION_DIR).resolve(InstallationMetadata.PROVISIONING_FILE_NAME);
 
         this.manifest = manifest;

--- a/prospero-common/src/main/java/org/wildfly/prospero/galleon/ArtifactCache.java
+++ b/prospero-common/src/main/java/org/wildfly/prospero/galleon/ArtifactCache.java
@@ -22,7 +22,7 @@ import org.jboss.galleon.util.HashUtils;
 import org.jboss.galleon.util.IoUtils;
 import org.jboss.logging.Logger;
 import org.wildfly.channel.MavenArtifact;
-import org.wildfly.prospero.api.InstallationMetadata;
+import org.wildfly.prospero.metadata.ProsperoMetadataUtils;
 
 import java.io.BufferedWriter;
 import java.io.File;
@@ -55,7 +55,7 @@ public class ArtifactCache {
 
     static final String CACHE_LINE_SEPARATOR = "::";
     static final String CACHE_FILENAME = "artifacts.txt";
-    public static final Path CACHE_FOLDER = Path.of(InstallationMetadata.METADATA_DIR, ".cache");
+    public static final Path CACHE_FOLDER = Path.of(ProsperoMetadataUtils.METADATA_DIR, ".cache");
 
     private final Path cacheDir;
     private final Path installationDir;

--- a/prospero-common/src/main/java/org/wildfly/prospero/installation/git/GitStorage.java
+++ b/prospero-common/src/main/java/org/wildfly/prospero/installation/git/GitStorage.java
@@ -23,7 +23,7 @@ import org.eclipse.jgit.lib.StoredConfig;
 import org.wildfly.channel.Channel;
 import org.wildfly.channel.ChannelManifest;
 import org.wildfly.prospero.Messages;
-import org.wildfly.prospero.model.ManifestVersionRecord;
+import org.wildfly.prospero.metadata.ManifestVersionRecord;
 import org.wildfly.prospero.api.ChannelChange;
 import org.wildfly.prospero.api.exceptions.MetadataException;
 import org.wildfly.prospero.api.SavedState;
@@ -128,7 +128,12 @@ public class GitStorage implements AutoCloseable {
     }
 
     private String readCommitMessage() throws MetadataException {
-        return ManifestVersionRecord.read(base.resolve(CURRENT_VERSION_FILE)).map(ManifestVersionRecord::getSummary).orElse(null);
+        final Path versionsFile = base.resolve(CURRENT_VERSION_FILE);
+        try {
+            return ManifestVersionRecord.read(versionsFile).map(ManifestVersionRecord::getSummary).orElse(null);
+        } catch (IOException e) {
+            throw Messages.MESSAGES.unableToReadFile(versionsFile, e);
+        }
     }
 
     public void recordChange(SavedState.Type operation) throws MetadataException {

--- a/prospero-common/src/main/java/org/wildfly/prospero/model/ManifestYamlSupport.java
+++ b/prospero-common/src/main/java/org/wildfly/prospero/model/ManifestYamlSupport.java
@@ -21,10 +21,7 @@ import org.wildfly.channel.ChannelManifest;
 import org.wildfly.channel.ChannelManifestMapper;
 
 import java.io.File;
-import java.io.FileWriter;
 import java.io.IOException;
-import java.io.PrintWriter;
-import java.nio.file.Path;
 
 public class ManifestYamlSupport {
 
@@ -32,10 +29,4 @@ public class ManifestYamlSupport {
         return ChannelManifestMapper.from(manifestFile.toURI().toURL());
     }
 
-    public static void write(ChannelManifest manifest, Path channelFile) throws IOException {
-        String yaml = ChannelManifestMapper.toYaml(manifest);
-        try (PrintWriter pw = new PrintWriter(new FileWriter(channelFile.toFile()))) {
-            pw.println(yaml);
-        }
-    }
 }

--- a/prospero-common/src/main/java/org/wildfly/prospero/model/ProsperoConfig.java
+++ b/prospero-common/src/main/java/org/wildfly/prospero/model/ProsperoConfig.java
@@ -52,15 +52,11 @@ public class ProsperoConfig {
         return channels;
     }
 
-    public void writeConfig(Path configFile) throws IOException {
-        Files.writeString(configFile.resolve(ProsperoMetadataUtils.INSTALLER_CHANNELS_FILE_NAME), ChannelMapper.toYaml(channels));
-    }
-
     public static ProsperoConfig readConfig(Path path) throws MetadataException {
         final String yamlContent;
         MavenOptions opts = null;
         try {
-            yamlContent = Files.readString(path.resolve(ProsperoMetadataUtils.INSTALLER_CHANNELS_FILE_NAME));
+            yamlContent = Files.readString(path.resolve(ProsperoMetadataUtils.INSTALLER_CHANNELS_FILE_NAME)).trim();
         } catch (IOException e) {
             throw Messages.MESSAGES.unableToReadFile(path, e);
         }

--- a/prospero-common/src/main/java/org/wildfly/prospero/spi/ProsperoInstallationManagerFactory.java
+++ b/prospero-common/src/main/java/org/wildfly/prospero/spi/ProsperoInstallationManagerFactory.java
@@ -24,6 +24,7 @@ import org.wildfly.installationmanager.spi.InstallationManager;
 import org.wildfly.installationmanager.spi.InstallationManagerFactory;
 import org.wildfly.prospero.Messages;
 import org.wildfly.prospero.api.InstallationMetadata;
+import org.wildfly.prospero.metadata.ProsperoMetadataUtils;
 
 import java.io.File;
 import java.nio.file.Path;
@@ -42,8 +43,8 @@ public class ProsperoInstallationManagerFactory implements InstallationManagerFa
 
     private void verifyInstallationDirectory(Path path) {
         File dotGalleonDir = path.resolve(InstallationMetadata.GALLEON_INSTALLATION_DIR).toFile();
-        File channelsFile = path.resolve(InstallationMetadata.METADATA_DIR)
-                .resolve(InstallationMetadata.INSTALLER_CHANNELS_FILE_NAME).toFile();
+        File channelsFile = path.resolve(ProsperoMetadataUtils.METADATA_DIR)
+                .resolve(ProsperoMetadataUtils.INSTALLER_CHANNELS_FILE_NAME).toFile();
         if (!dotGalleonDir.isDirectory() || !channelsFile.isFile()) {
             throw Messages.MESSAGES.invalidInstallationDir(path);
         }

--- a/prospero-common/src/main/java/org/wildfly/prospero/test/MetadataTestUtils.java
+++ b/prospero-common/src/main/java/org/wildfly/prospero/test/MetadataTestUtils.java
@@ -54,14 +54,15 @@ import org.wildfly.channel.Stream;
 import org.wildfly.prospero.api.InstallationMetadata;
 import org.wildfly.prospero.api.SavedState;
 import org.wildfly.prospero.api.exceptions.MetadataException;
+import org.wildfly.prospero.metadata.ProsperoMetadataUtils;
 import org.wildfly.prospero.model.ProsperoConfig;
 
 public final class MetadataTestUtils {
 
     public static final Path MANIFEST_FILE_PATH =
-            Paths.get(InstallationMetadata.METADATA_DIR, InstallationMetadata.MANIFEST_FILE_NAME);
+            Paths.get(ProsperoMetadataUtils.METADATA_DIR, ProsperoMetadataUtils.MANIFEST_FILE_NAME);
     public static final Path INSTALLER_CHANNELS_FILE_PATH =
-            Paths.get(InstallationMetadata.METADATA_DIR, InstallationMetadata.INSTALLER_CHANNELS_FILE_NAME);
+            Paths.get(ProsperoMetadataUtils.METADATA_DIR, ProsperoMetadataUtils.INSTALLER_CHANNELS_FILE_NAME);
 
     private MetadataTestUtils() {
     }

--- a/prospero-common/src/main/java/org/wildfly/prospero/updates/MarkerFile.java
+++ b/prospero-common/src/main/java/org/wildfly/prospero/updates/MarkerFile.java
@@ -18,7 +18,7 @@
 package org.wildfly.prospero.updates;
 
 import org.wildfly.prospero.actions.ApplyCandidateAction;
-import org.wildfly.prospero.api.InstallationMetadata;
+import org.wildfly.prospero.metadata.ProsperoMetadataUtils;
 
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
@@ -28,7 +28,7 @@ import java.util.Objects;
 import java.util.Properties;
 
 public class MarkerFile {
-    public static final Path UPDATE_MARKER_FILE = Path.of(InstallationMetadata.METADATA_DIR, ".candidate.txt");
+    public static final Path UPDATE_MARKER_FILE = Path.of(ProsperoMetadataUtils.METADATA_DIR, ".candidate.txt");
     private static final String STATE_PROPERTY = "state";
     private static final String OPERATION_PROPERTY = "operation";
     private final String state;

--- a/prospero-common/src/test/java/org/wildfly/prospero/actions/ApplyCandidateActionTest.java
+++ b/prospero-common/src/test/java/org/wildfly/prospero/actions/ApplyCandidateActionTest.java
@@ -39,7 +39,7 @@ import org.wildfly.prospero.api.exceptions.InvalidUpdateCandidateException;
 import org.wildfly.prospero.galleon.ArtifactCache;
 import org.wildfly.prospero.installation.git.GitStorage;
 import org.wildfly.prospero.metadata.ProsperoMetadataUtils;
-import org.wildfly.prospero.model.ManifestVersionRecord;
+import org.wildfly.prospero.metadata.ManifestVersionRecord;
 import org.wildfly.prospero.updates.MarkerFile;
 import org.wildfly.prospero.utils.filestate.DirState;
 
@@ -325,12 +325,12 @@ public class ApplyCandidateActionTest {
         install(installationPath, FPL_100);
         final ManifestVersionRecord manifestVersionRecord = new ManifestVersionRecord();
         manifestVersionRecord.addManifest(new ManifestVersionRecord.MavenManifest("org.foo", "bar", "1.0.0"));
-        ManifestVersionRecord.write(manifestVersionRecord, installationPath.resolve(METADATA_DIR).resolve(CURRENT_VERSION_FILE));
+        ProsperoMetadataUtils.writeVersionRecord(installationPath.resolve(METADATA_DIR).resolve(CURRENT_VERSION_FILE), manifestVersionRecord);
 
         prepareUpdate(updatePath, installationPath, FPL_101);
         final ManifestVersionRecord manifestVersionRecord2 = new ManifestVersionRecord();
         manifestVersionRecord2.addManifest(new ManifestVersionRecord.MavenManifest("org.foo", "bar", "1.0.1"));
-        ManifestVersionRecord.write(manifestVersionRecord2, updatePath.resolve(METADATA_DIR).resolve(CURRENT_VERSION_FILE));
+        ProsperoMetadataUtils.writeVersionRecord(updatePath.resolve(METADATA_DIR).resolve(CURRENT_VERSION_FILE), manifestVersionRecord2);
 
         new ApplyCandidateAction(installationPath, updatePath).applyUpdate(ApplyCandidateAction.Type.UPDATE);
 

--- a/prospero-common/src/test/java/org/wildfly/prospero/actions/ApplyCandidateActionTest.java
+++ b/prospero-common/src/test/java/org/wildfly/prospero/actions/ApplyCandidateActionTest.java
@@ -35,7 +35,6 @@ import org.wildfly.channel.ChannelManifestMapper;
 import org.wildfly.channel.ChannelMapper;
 import org.wildfly.channel.Repository;
 import org.wildfly.prospero.api.FileConflict;
-import org.wildfly.prospero.api.InstallationMetadata;
 import org.wildfly.prospero.api.exceptions.InvalidUpdateCandidateException;
 import org.wildfly.prospero.galleon.ArtifactCache;
 import org.wildfly.prospero.installation.git.GitStorage;
@@ -82,7 +81,7 @@ public class ApplyCandidateActionTest {
         creator = FeaturePackCreator.getInstance().addArtifactResolver(repo);
         dirBuilder = DirState.rootBuilder()
                 .skip(Constants.PROVISIONED_STATE_DIR)
-                .skip(InstallationMetadata.METADATA_DIR);
+                .skip(METADATA_DIR);
     }
 
     @Test
@@ -218,11 +217,11 @@ public class ApplyCandidateActionTest {
 
         final DirState expectedState = DirState.rootBuilder()
                 .skip("prod1")
-                .skip(InstallationMetadata.METADATA_DIR + "/" + ".git")
+                .skip(METADATA_DIR + "/" + ".git")
                 .skip(Constants.PROVISIONED_STATE_DIR)
-                .addFile(InstallationMetadata.METADATA_DIR + "/" + InstallationMetadata.MANIFEST_FILE_NAME,
+                .addFile(METADATA_DIR + "/" + ProsperoMetadataUtils.MANIFEST_FILE_NAME,
                         manifest("manifest " + FPL_101).trim())
-                .addFile(InstallationMetadata.METADATA_DIR + "/" + InstallationMetadata.INSTALLER_CHANNELS_FILE_NAME,
+                .addFile(METADATA_DIR + "/" + ProsperoMetadataUtils.INSTALLER_CHANNELS_FILE_NAME,
                         channel("channels " + FPL_100).trim())
                 .addFile(ArtifactCache.CACHE_FOLDER.toString().replace(File.separatorChar, '/') + "/" + "artifacts.txt" , FPL_101+"::abcd::foo/bar")
                 .build();
@@ -417,10 +416,10 @@ public class ApplyCandidateActionTest {
         options.put(Constants.EXPORT_SYSTEM_PATHS, "true");
         getPm(path).install(FeaturePackLocation.fromString(fpl), options);
         // mock the installation metadata
-        final Path metadataPath = path.resolve(InstallationMetadata.METADATA_DIR);
+        final Path metadataPath = path.resolve(METADATA_DIR);
         Files.createDirectory(metadataPath);
-        Files.writeString(metadataPath.resolve(InstallationMetadata.MANIFEST_FILE_NAME), manifest("manifest " + fpl));
-        Files.writeString(metadataPath.resolve(InstallationMetadata.INSTALLER_CHANNELS_FILE_NAME), channel("channels " + fpl));
+        Files.writeString(metadataPath.resolve(ProsperoMetadataUtils.MANIFEST_FILE_NAME), manifest("manifest " + fpl));
+        Files.writeString(metadataPath.resolve(ProsperoMetadataUtils.INSTALLER_CHANNELS_FILE_NAME), channel("channels " + fpl));
         try (final GitStorage gitStorage = new GitStorage(path)) {
             gitStorage.record();
         }

--- a/prospero-common/src/test/java/org/wildfly/prospero/api/InstallationMetadataTest.java
+++ b/prospero-common/src/test/java/org/wildfly/prospero/api/InstallationMetadataTest.java
@@ -128,11 +128,11 @@ public class InstallationMetadataTest {
     @Test
     public void initStorageIfItDoesNotExist() throws Exception {
         base = temp.newFolder().toPath();
-        final Path metadataDir = base.resolve(InstallationMetadata.METADATA_DIR);
+        final Path metadataDir = base.resolve(ProsperoMetadataUtils.METADATA_DIR);
 
         Files.createDirectory(metadataDir);
         final ChannelManifest manifest = new ChannelManifest(null, null, null, Collections.emptyList());
-        Files.writeString(metadataDir.resolve(InstallationMetadata.MANIFEST_FILE_NAME),
+        Files.writeString(metadataDir.resolve(ProsperoMetadataUtils.MANIFEST_FILE_NAME),
                 ChannelManifestMapper.toYaml(manifest),
                 StandardOpenOption.CREATE_NEW);
         final Channel channel = createChannel(new ChannelManifestCoordinate("foo","bar"));
@@ -159,7 +159,7 @@ public class InstallationMetadataTest {
 
         installationMetadata.recordProvision(false);
 
-        assertTrue("README.txt file should exist.", Files.exists(base.resolve(InstallationMetadata.METADATA_DIR)));
+        assertTrue("README.txt file should exist.", Files.exists(base.resolve(ProsperoMetadataUtils.METADATA_DIR)));
     }
 
     @Test
@@ -240,7 +240,7 @@ public class InstallationMetadataTest {
     }
 
     private InstallationMetadata mockServer(Path base) throws IOException, MetadataException {
-        final Path metadataDir = base.resolve(InstallationMetadata.METADATA_DIR);
+        final Path metadataDir = base.resolve(ProsperoMetadataUtils.METADATA_DIR);
 
         Files.createDirectory(metadataDir);
         final ChannelManifest manifest = new ChannelManifest(null, null, null, Collections.emptyList());

--- a/prospero-common/src/test/java/org/wildfly/prospero/api/InstallationMetadataTest.java
+++ b/prospero-common/src/test/java/org/wildfly/prospero/api/InstallationMetadataTest.java
@@ -30,7 +30,7 @@ import org.wildfly.channel.ChannelManifestCoordinate;
 import org.wildfly.channel.ChannelManifestMapper;
 import org.wildfly.channel.MavenCoordinate;
 import org.wildfly.channel.Repository;
-import org.wildfly.prospero.model.ManifestVersionRecord;
+import org.wildfly.prospero.metadata.ManifestVersionRecord;
 import org.wildfly.prospero.api.exceptions.MetadataException;
 import org.wildfly.prospero.installation.git.GitStorage;
 import org.wildfly.prospero.metadata.ProsperoMetadataUtils;

--- a/prospero-common/src/test/java/org/wildfly/prospero/api/InstallationMetadataTest.java
+++ b/prospero-common/src/test/java/org/wildfly/prospero/api/InstallationMetadataTest.java
@@ -136,8 +136,8 @@ public class InstallationMetadataTest {
                 ChannelManifestMapper.toYaml(manifest),
                 StandardOpenOption.CREATE_NEW);
         final Channel channel = createChannel(new ChannelManifestCoordinate("foo","bar"));
-        final ProsperoConfig prosperoConfig = new ProsperoConfig(List.of(channel));
-        prosperoConfig.writeConfig(metadataDir);
+        final Path configFilePath = ProsperoMetadataUtils.configurationPath(base);
+        ProsperoMetadataUtils.writeChannelsConfiguration(configFilePath, List.of(channel));
 
         assertThat(base.resolve(ProsperoMetadataUtils.METADATA_DIR).resolve(".git")).doesNotExist();
 

--- a/prospero-common/src/test/java/org/wildfly/prospero/installation/git/GitStorageTest.java
+++ b/prospero-common/src/test/java/org/wildfly/prospero/installation/git/GitStorageTest.java
@@ -31,7 +31,6 @@ import org.wildfly.channel.Repository;
 import org.wildfly.prospero.model.ManifestVersionRecord;
 import org.wildfly.prospero.api.ArtifactChange;
 import org.wildfly.prospero.api.ChannelChange;
-import org.wildfly.prospero.api.InstallationMetadata;
 import org.wildfly.prospero.api.SavedState;
 import org.wildfly.prospero.metadata.ProsperoMetadataUtils;
 import org.wildfly.prospero.model.ManifestYamlSupport;
@@ -71,7 +70,7 @@ public class GitStorageTest {
 
     @Before
     public void setUp() throws Exception {
-        base = folder.newFolder().toPath().resolve(InstallationMetadata.METADATA_DIR);
+        base = folder.newFolder().toPath().resolve(ProsperoMetadataUtils.METADATA_DIR);
     }
 
     @After
@@ -108,7 +107,7 @@ public class GitStorageTest {
         gitStorage.record();
 
         setArtifact(manifest, null);
-        ProsperoMetadataUtils.writeManifest(base.resolve(InstallationMetadata.MANIFEST_FILE_NAME), manifest);
+        ProsperoMetadataUtils.writeManifest(base.resolve(ProsperoMetadataUtils.MANIFEST_FILE_NAME), manifest);
         gitStorage.record();
 
         final List<SavedState> revisions = gitStorage.getRevisions();
@@ -124,7 +123,7 @@ public class GitStorageTest {
     public void testAddedArtifact() throws Exception {
         final GitStorage gitStorage = new GitStorage(base.getParent());
 
-        ProsperoMetadataUtils.writeManifest(base.resolve(InstallationMetadata.MANIFEST_FILE_NAME), manifest);
+        ProsperoMetadataUtils.writeManifest(base.resolve(ProsperoMetadataUtils.MANIFEST_FILE_NAME), manifest);
         gitStorage.record();
 
         setArtifact(manifest, "org.test:test:1.2.3");
@@ -142,7 +141,7 @@ public class GitStorageTest {
     @Test
     public void initialRecordStoresConfigState() throws Exception {
         final GitStorage gitStorage = new GitStorage(base.getParent());
-        ProsperoMetadataUtils.writeManifest(base.resolve(InstallationMetadata.MANIFEST_FILE_NAME), manifest);
+        ProsperoMetadataUtils.writeManifest(base.resolve(ProsperoMetadataUtils.MANIFEST_FILE_NAME), manifest);
         generateProsperoConfig(List.of(new Channel("", "", null, null, null, null, null)));
 
         gitStorage.record();
@@ -150,7 +149,7 @@ public class GitStorageTest {
         // TODO: replace with gitStorage API for reading config changes
         HashSet<String> storedPaths = getPathsInCommit();
 
-        assertThat(storedPaths).containsExactlyInAnyOrder("manifest.yaml", InstallationMetadata.INSTALLER_CHANNELS_FILE_NAME);
+        assertThat(storedPaths).containsExactlyInAnyOrder("manifest.yaml", ProsperoMetadataUtils.INSTALLER_CHANNELS_FILE_NAME);
     }
 
     private void generateProsperoConfig(List<Channel> channels) throws IOException {
@@ -160,7 +159,7 @@ public class GitStorageTest {
     @Test
     public void testChangedChannel() throws Exception {
         final GitStorage gitStorage = new GitStorage(base.getParent());
-        ProsperoMetadataUtils.writeManifest(base.resolve(InstallationMetadata.MANIFEST_FILE_NAME), manifest);
+        ProsperoMetadataUtils.writeManifest(base.resolve(ProsperoMetadataUtils.MANIFEST_FILE_NAME), manifest);
         generateProsperoConfig(List.of(new Channel("channel-1", "old", null,
                 List.of(new Repository("test", "http://test.te")),
                 new ChannelManifestCoordinate("foo", "bar"),
@@ -184,7 +183,7 @@ public class GitStorageTest {
     @Test
     public void testAddedChannel() throws Exception {
         final GitStorage gitStorage = new GitStorage(base.getParent());
-        ProsperoMetadataUtils.writeManifest(base.resolve(InstallationMetadata.MANIFEST_FILE_NAME), manifest);
+        ProsperoMetadataUtils.writeManifest(base.resolve(ProsperoMetadataUtils.MANIFEST_FILE_NAME), manifest);
         final Channel channel1 = new Channel("channel-1", "old", null,
                 List.of(new Repository("test", "http://test.te")),
                 new ChannelManifestCoordinate("foo", "bar"),
@@ -211,7 +210,7 @@ public class GitStorageTest {
     @Test
     public void testRemovedChannel() throws Exception {
         final GitStorage gitStorage = new GitStorage(base.getParent());
-        ProsperoMetadataUtils.writeManifest(base.resolve(InstallationMetadata.MANIFEST_FILE_NAME), manifest);
+        ProsperoMetadataUtils.writeManifest(base.resolve(ProsperoMetadataUtils.MANIFEST_FILE_NAME), manifest);
         final Channel channel1 = new Channel("channel-1", "old", null,
                 List.of(new Repository("test", "http://test.te")),
                 new ChannelManifestCoordinate("foo", "bar"),
@@ -238,7 +237,7 @@ public class GitStorageTest {
     @Test
     public void testNoChangedChannels() throws Exception {
         final GitStorage gitStorage = new GitStorage(base.getParent());
-        ProsperoMetadataUtils.writeManifest(base.resolve(InstallationMetadata.MANIFEST_FILE_NAME), manifest);
+        ProsperoMetadataUtils.writeManifest(base.resolve(ProsperoMetadataUtils.MANIFEST_FILE_NAME), manifest);
         final Channel channel1 = new Channel("channel-1", "old", null,
                 List.of(new Repository("test", "http://test.te")),
                 new ChannelManifestCoordinate("foo", "bar"),
@@ -270,7 +269,7 @@ public class GitStorageTest {
     @Test
     public void initialRecordAdjustTimeForFolderCreationDate() throws Exception {
         final GitStorage gitStorage = new GitStorage(base.getParent());
-        ProsperoMetadataUtils.writeManifest(base.resolve(InstallationMetadata.MANIFEST_FILE_NAME), manifest);
+        ProsperoMetadataUtils.writeManifest(base.resolve(ProsperoMetadataUtils.MANIFEST_FILE_NAME), manifest);
         generateProsperoConfig(List.of(new Channel("", "", null, null, null, null, null)));
 
         // ensure there's a time gap between creation of the folder and record

--- a/prospero-common/src/test/java/org/wildfly/prospero/installation/git/GitStorageTest.java
+++ b/prospero-common/src/test/java/org/wildfly/prospero/installation/git/GitStorageTest.java
@@ -28,7 +28,7 @@ import org.wildfly.channel.Channel;
 import org.wildfly.channel.ChannelManifest;
 import org.wildfly.channel.ChannelManifestCoordinate;
 import org.wildfly.channel.Repository;
-import org.wildfly.prospero.model.ManifestVersionRecord;
+import org.wildfly.prospero.metadata.ManifestVersionRecord;
 import org.wildfly.prospero.api.ArtifactChange;
 import org.wildfly.prospero.api.ChannelChange;
 import org.wildfly.prospero.api.SavedState;
@@ -325,7 +325,7 @@ public class GitStorageTest {
         // create the manifest version record to provide version info for commit
         final ManifestVersionRecord record = new ManifestVersionRecord();
         record.addManifest(new ManifestVersionRecord.MavenManifest("foo", "bar", "1.0.0"));
-        ManifestVersionRecord.write(record, base.resolve(ProsperoMetadataUtils.CURRENT_VERSION_FILE));
+        ProsperoMetadataUtils.writeVersionRecord(base.resolve(ProsperoMetadataUtils.CURRENT_VERSION_FILE), record);
 
         gitStorage.record();
 
@@ -357,13 +357,13 @@ public class GitStorageTest {
         setArtifact(manifest, "org.test:test:1.2.3");
         ManifestVersionRecord record = new ManifestVersionRecord();
         record.addManifest(new ManifestVersionRecord.MavenManifest("foo", "bar", "1.0.0"));
-        ManifestVersionRecord.write(record, base.resolve(ProsperoMetadataUtils.CURRENT_VERSION_FILE));
+        ProsperoMetadataUtils.writeVersionRecord(base.resolve(ProsperoMetadataUtils.CURRENT_VERSION_FILE), record);
         gitStorage.record();
 
         setArtifact(manifest, "org.test:test:1.2.4");
         record = new ManifestVersionRecord();
         record.addManifest(new ManifestVersionRecord.MavenManifest("foo", "bar", "1.0.1"));
-        ManifestVersionRecord.write(record, base.resolve(ProsperoMetadataUtils.CURRENT_VERSION_FILE));
+        ProsperoMetadataUtils.writeVersionRecord(base.resolve(ProsperoMetadataUtils.CURRENT_VERSION_FILE), record);
         gitStorage.record();
 
         revertPath = gitStorage.revert(gitStorage.getRevisions().get(1));

--- a/prospero-common/src/test/java/org/wildfly/prospero/model/ManifestVersionRecordTest.java
+++ b/prospero-common/src/test/java/org/wildfly/prospero/model/ManifestVersionRecordTest.java
@@ -20,6 +20,8 @@ package org.wildfly.prospero.model;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.wildfly.prospero.metadata.ManifestVersionRecord;
+import org.wildfly.prospero.metadata.ProsperoMetadataUtils;
 
 import java.nio.file.Path;
 import java.util.List;
@@ -44,7 +46,7 @@ public class ManifestVersionRecordTest {
         manifestVersionRecord.addManifest(versionManifest);
 
         final Path installDir = temp.newFolder().toPath();
-        ManifestVersionRecord.write(manifestVersionRecord, installDir.resolve(CURRENT_VERSION_FILE));
+        ProsperoMetadataUtils.writeVersionRecord(installDir.resolve(CURRENT_VERSION_FILE), manifestVersionRecord);
 
         final Optional<ManifestVersionRecord> read = ManifestVersionRecord.read(installDir.resolve(CURRENT_VERSION_FILE));
         assertEquals(manifestVersionRecord.getSummary(), read.get().getSummary());

--- a/prospero-metadata/pom.xml
+++ b/prospero-metadata/pom.xml
@@ -18,8 +18,35 @@
             <artifactId>channel-core</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.wildfly.channel</groupId>
+            <artifactId>maven-resolver</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.galleon</groupId>
+            <artifactId>galleon-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.resolver</groupId>
+            <artifactId>maven-resolver-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-resolver-provider</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/prospero-metadata/src/main/java/org/wildfly/prospero/metadata/ManifestVersionRecord.java
+++ b/prospero-metadata/src/main/java/org/wildfly/prospero/metadata/ManifestVersionRecord.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.wildfly.prospero.model;
+package org.wildfly.prospero.metadata;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -23,8 +23,6 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
-import org.wildfly.prospero.Messages;
-import org.wildfly.prospero.api.exceptions.MetadataException;
 
 import java.io.IOException;
 import java.io.StringWriter;
@@ -178,27 +176,11 @@ public class ManifestVersionRecord {
         return sb.toString();
     }
 
-    public static void write(ManifestVersionRecord commitMessage, Path versionsFile) throws MetadataException {
-        try {
-            final String yaml = ManifestVersionRecord.toYaml(commitMessage);
-            if (Files.exists(versionsFile)) {
-                Files.delete(versionsFile);
-            }
-            Files.writeString(versionsFile, yaml);
-        } catch (IOException e) {
-            throw Messages.MESSAGES.unableToWriteFile(versionsFile, e);
-        }
-    }
-
-    public static Optional<ManifestVersionRecord> read(Path versionsFile) throws MetadataException {
-        try {
-            if (Files.exists(versionsFile)) {
-                return Optional.of(ManifestVersionRecord.fromYaml(Files.readString(versionsFile)));
-            } else {
-                return Optional.empty();
-            }
-        } catch (IOException e) {
-            throw Messages.MESSAGES.unableToReadFile(versionsFile, e);
+    public static Optional<ManifestVersionRecord> read(Path versionsFile) throws IOException {
+        if (Files.exists(versionsFile)) {
+            return Optional.of(ManifestVersionRecord.fromYaml(Files.readString(versionsFile)));
+        } else {
+            return Optional.empty();
         }
     }
 
@@ -206,7 +188,7 @@ public class ManifestVersionRecord {
         return new ObjectMapper(new YAMLFactory()).readValue(yaml, ManifestVersionRecord.class);
     }
 
-    private static String toYaml(ManifestVersionRecord manifestVersionRecord) throws IOException {
+    static String toYaml(ManifestVersionRecord manifestVersionRecord) throws IOException {
         final StringWriter stringWriter = new StringWriter();
         new ObjectMapper(new YAMLFactory()).writeValue(stringWriter, manifestVersionRecord);
         return stringWriter.toString();

--- a/prospero-metadata/src/main/java/org/wildfly/prospero/metadata/ProsperoMetadataUtils.java
+++ b/prospero-metadata/src/main/java/org/wildfly/prospero/metadata/ProsperoMetadataUtils.java
@@ -22,6 +22,7 @@ import org.wildfly.channel.ChannelManifest;
 import org.wildfly.channel.ChannelManifestMapper;
 import org.wildfly.channel.ChannelMapper;
 
+import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -45,6 +46,9 @@ public class ProsperoMetadataUtils {
     public static final String INSTALLER_CHANNELS_FILE_NAME = "installer-channels.yaml";
     public static final String MAVEN_OPTS_FILE = "maven_opts.yaml";
     public static final String CURRENT_VERSION_FILE = "manifest_version.yaml";
+    public static final String README_FILE_NAME = "README.txt";
+
+    private static final String WARNING_MESSAGE = "WARNING: The files in .installation directory should be only edited by the provisioning tool.";
 
     /**
      * Generate installer metadata inside {@code serverDir}. The generated metadata files allow the server to be
@@ -66,6 +70,7 @@ public class ProsperoMetadataUtils {
         final Path metadataDir = serverDir.resolve(METADATA_DIR);
         final Path manifestPath = metadataDir.resolve(MANIFEST_FILE_NAME);
         final Path configPath = metadataDir.resolve(INSTALLER_CHANNELS_FILE_NAME);
+        final Path readmeFile = metadataDir.resolve(README_FILE_NAME);
 
         if (Files.exists(metadataDir) && !Files.isDirectory(metadataDir)) {
             throw new IllegalArgumentException(String.format("The target path %s is not a directory.", metadataDir));
@@ -81,5 +86,10 @@ public class ProsperoMetadataUtils {
 
         Files.writeString(manifestPath, ChannelManifestMapper.toYaml(manifest), StandardCharsets.UTF_8);
         Files.writeString(configPath, ChannelMapper.toYaml(channels), StandardCharsets.UTF_8);
+
+        // Add README.txt file to .installation directory to warn the files should not be edited.
+        if (!Files.exists(readmeFile)) {
+            Files.writeString(readmeFile, WARNING_MESSAGE , StandardCharsets.UTF_8);
+        }
     }
 }

--- a/prospero-metadata/src/test/java/org/wildfly/prospero/metadata/ManifestVersionResolverTest.java
+++ b/prospero-metadata/src/test/java/org/wildfly/prospero/metadata/ManifestVersionResolverTest.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.wildfly.prospero.actions;
+package org.wildfly.prospero.metadata;
 
 import org.jboss.galleon.util.HashUtils;
 import org.junit.Rule;
@@ -29,7 +29,6 @@ import org.wildfly.channel.ChannelManifestCoordinate;
 import org.wildfly.channel.Repository;
 import org.wildfly.channel.maven.VersionResolverFactory;
 import org.wildfly.channel.spi.MavenVersionsResolver;
-import org.wildfly.prospero.model.ManifestVersionRecord;
 
 import java.net.URL;
 import java.nio.file.Path;

--- a/prospero-metadata/src/test/java/org/wildfly/prospero/metadata/ProsperoMetadataUtilsTest.java
+++ b/prospero-metadata/src/test/java/org/wildfly/prospero/metadata/ProsperoMetadataUtilsTest.java
@@ -65,7 +65,7 @@ public class ProsperoMetadataUtilsTest {
 
     @Test
     public void createWhenMetadatDirDoesntExist() throws Exception {
-        ProsperoMetadataUtils.generate(server, List.of(A_CHANNEL), A_MANIFEST);
+        ProsperoMetadataUtils.generate(server, List.of(A_CHANNEL), A_MANIFEST, null);
 
         assertTrue(Files.exists(manifestPath));
         assertTrue(Files.exists(channelPath));
@@ -77,7 +77,7 @@ public class ProsperoMetadataUtilsTest {
     @Test
     public void createWhenMetadatDirDoesExist() throws Exception {
         Files.createDirectory(server.resolve(METADATA_DIR));
-        ProsperoMetadataUtils.generate(server, List.of(A_CHANNEL), A_MANIFEST);
+        ProsperoMetadataUtils.generate(server, List.of(A_CHANNEL), A_MANIFEST, null);
 
         assertTrue(Files.exists(manifestPath));
         assertTrue(Files.exists(channelPath));
@@ -91,7 +91,7 @@ public class ProsperoMetadataUtilsTest {
         Files.createDirectory(server.resolve(METADATA_DIR));
         Files.createFile(manifestPath);
 
-        assertThrows(IllegalArgumentException.class, ()->ProsperoMetadataUtils.generate(server, List.of(A_CHANNEL), A_MANIFEST));
+        assertThrows(IllegalArgumentException.class, ()->ProsperoMetadataUtils.generate(server, List.of(A_CHANNEL), A_MANIFEST, null));
 
         assertEquals("", Files.readString(manifestPath));
         assertFalse(Files.exists(channelPath));
@@ -102,7 +102,7 @@ public class ProsperoMetadataUtilsTest {
         Files.createDirectory(server.resolve(METADATA_DIR));
         Files.createFile(channelPath);
 
-        assertThrows(IllegalArgumentException.class, ()->ProsperoMetadataUtils.generate(server, List.of(A_CHANNEL), A_MANIFEST));
+        assertThrows(IllegalArgumentException.class, ()->ProsperoMetadataUtils.generate(server, List.of(A_CHANNEL), A_MANIFEST, null));
 
         assertEquals("", Files.readString(channelPath));
         assertFalse(Files.exists(manifestPath));
@@ -112,7 +112,7 @@ public class ProsperoMetadataUtilsTest {
     public void throwErrorIfMetadataFolderIsFile() throws Exception {
         Files.createFile(server.resolve(METADATA_DIR));
 
-        assertThrows(IllegalArgumentException.class, ()->ProsperoMetadataUtils.generate(server, List.of(A_CHANNEL), A_MANIFEST));
+        assertThrows(IllegalArgumentException.class, ()->ProsperoMetadataUtils.generate(server, List.of(A_CHANNEL), A_MANIFEST, null));
 
         assertFalse(Files.exists(manifestPath));
         assertFalse(Files.exists(channelPath));

--- a/prospero-metadata/src/test/java/org/wildfly/prospero/metadata/ProsperoMetadataUtilsTest.java
+++ b/prospero-metadata/src/test/java/org/wildfly/prospero/metadata/ProsperoMetadataUtilsTest.java
@@ -40,6 +40,7 @@ import static org.junit.Assert.assertTrue;
 import static org.wildfly.prospero.metadata.ProsperoMetadataUtils.MANIFEST_FILE_NAME;
 import static org.wildfly.prospero.metadata.ProsperoMetadataUtils.METADATA_DIR;
 import static org.wildfly.prospero.metadata.ProsperoMetadataUtils.INSTALLER_CHANNELS_FILE_NAME;
+import static org.wildfly.prospero.metadata.ProsperoMetadataUtils.README_FILE_NAME;
 
 public class ProsperoMetadataUtilsTest {
 
@@ -52,12 +53,14 @@ public class ProsperoMetadataUtilsTest {
     private Path server;
     private Path manifestPath;
     private Path channelPath;
+    private Path readmeFile;
 
     @Before
     public void setUp() throws Exception {
         server = temp.newFolder().toPath();
         manifestPath = server.resolve(METADATA_DIR).resolve(MANIFEST_FILE_NAME);
         channelPath = server.resolve(METADATA_DIR).resolve(INSTALLER_CHANNELS_FILE_NAME);
+        readmeFile = server.resolve(METADATA_DIR).resolve(README_FILE_NAME);
     }
 
     @Test
@@ -66,6 +69,7 @@ public class ProsperoMetadataUtilsTest {
 
         assertTrue(Files.exists(manifestPath));
         assertTrue(Files.exists(channelPath));
+        assertTrue(Files.exists(readmeFile));
 
         assertMetadataWritten();
     }
@@ -77,6 +81,7 @@ public class ProsperoMetadataUtilsTest {
 
         assertTrue(Files.exists(manifestPath));
         assertTrue(Files.exists(channelPath));
+        assertTrue(Files.exists(readmeFile));
 
         assertMetadataWritten();
     }


### PR DESCRIPTION
- [#314] Create Readme.txt in ProsperoMetadataUtils
- [#315] Ensure ProsperoMetadataUtils is used to store prospero data
- Move metadata constants to ProsperoMetadataUtils
