### PR TITLE
In bulk resolve mode, version of the artifact needs to be set first before resolved file

### DIFF
--- a/prospero-common/src/main/java/org/wildfly/prospero/galleon/MavenArtifactMapper.java
+++ b/prospero-common/src/main/java/org/wildfly/prospero/galleon/MavenArtifactMapper.java
@@ -86,7 +86,8 @@ public class MavenArtifactMapper {
         Objects.requireNonNull(resolvedArtifact.getFile());
         Objects.requireNonNull(resolvedArtifact.getVersion());
 
-        artifact.setPath(resolvedArtifact.getFile().toPath());
+        // set the version BEFORE file - depended on by galleon-plugin to correctly report artifact resolution
         artifact.setVersion(resolvedArtifact.getVersion());
+        artifact.setPath(resolvedArtifact.getFile().toPath());
     }
 }


### PR DESCRIPTION
The MavenArtifact#setFile is used by galleon-plugins as trigger to report artifact as resolved. If the version is not set before that call, wrong version of artifact will be reported.
