### PR TITLE
Upgrade installation manager api

### DIFF
--- a/integration-tests/src/test/java/org/wildfly/prospero/it/installationmanager/CreateSnapshotTest.java
+++ b/integration-tests/src/test/java/org/wildfly/prospero/it/installationmanager/CreateSnapshotTest.java
@@ -78,9 +78,9 @@ public class CreateSnapshotTest extends WfCoreTestBase {
         expected.append(" ");
         expected.append(CliConstants.Commands.UPDATE).append(" ").append(CliConstants.Commands.APPLY);
         expected.append(" ");
-        expected.append(CliConstants.DIR).append("=\"").append(outputPath.toAbsolutePath()).append("\"");
+        expected.append(CliConstants.DIR).append(" \"").append(outputPath.toAbsolutePath()).append("\"");
         expected.append(" ");
-        expected.append(CliConstants.UPDATE_DIR).append("=\"").append(Path.of("foo").toAbsolutePath()).append("\"");
+        expected.append(CliConstants.UPDATE_DIR).append(" \"").append(Path.of("foo").toAbsolutePath()).append("\"");
         expected.append(" ");
         expected.append(CliConstants.YES);
 

--- a/integration-tests/src/test/java/org/wildfly/prospero/it/installationmanager/CreateSnapshotTest.java
+++ b/integration-tests/src/test/java/org/wildfly/prospero/it/installationmanager/CreateSnapshotTest.java
@@ -24,6 +24,7 @@ import org.wildfly.installationmanager.MavenOptions;
 import org.wildfly.installationmanager.spi.InstallationManager;
 import org.wildfly.prospero.api.InstallationMetadata;
 import org.wildfly.prospero.api.ProvisioningDefinition;
+import org.wildfly.prospero.cli.DistributionInfo;
 import org.wildfly.prospero.cli.commands.CliConstants;
 import org.wildfly.prospero.it.commonapi.WfCoreTestBase;
 import org.wildfly.prospero.spi.ProsperoInstallationManager;
@@ -66,12 +67,14 @@ public class CreateSnapshotTest extends WfCoreTestBase {
     @Test
     public void generateApplyCommand() throws Exception {
         final Path channelsFile = MetadataTestUtils.prepareChannel(CHANNEL_BASE_CORE_19);
-        final StringBuffer expected = new StringBuffer("prospero");
+        final StringBuffer expected = new StringBuffer("\"")
+                .append(outputPath.resolve("bin").resolve(DistributionInfo.DIST_NAME));
         if (System.getProperty("os.name").toLowerCase(Locale.getDefault()).contains("windows")) {
             expected.append(".bat");
         } else {
             expected.append(".sh");
         }
+        expected.append("\"");
         expected.append(" ");
         expected.append(CliConstants.Commands.UPDATE).append(" ").append(CliConstants.Commands.APPLY);
         expected.append(" ");
@@ -90,7 +93,7 @@ public class CreateSnapshotTest extends WfCoreTestBase {
 
 
         final ProsperoInstallationManager manager = (ProsperoInstallationManager) new ProsperoInstallationManagerFactory().create(outputPath, new MavenOptions(MavenSessionManager.LOCAL_MAVEN_REPO, false));
-        final String command = manager.generateApplyUpdateCommand(Paths.get("foo"));
+        final String command = manager.generateApplyUpdateCommand(outputPath.resolve("bin"), Paths.get("foo"));
         assertEquals(expected.toString(), command);
     }
 }

--- a/integration-tests/test-out.log
+++ b/integration-tests/test-out.log
@@ -1,0 +1,1 @@
+No updates found.

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
         <version.org.jboss.modules>2.0.2.Final</version.org.jboss.modules>
         <version.org.jboss.xnio>3.8.7.Final</version.org.jboss.xnio>
         <version.org.wildfly.galleon-plugins>6.3.2.Final</version.org.wildfly.galleon-plugins>
-        <version.org.wildfly.installation-manager>1.0.0.Beta4</version.org.wildfly.installation-manager>
+        <version.org.wildfly.installation-manager>1.0.0.Final</version.org.wildfly.installation-manager>
         <version.org.mockito>3.12.4</version.org.mockito>
         <version.org.slf4j>2.0.6</version.org.slf4j>
         <version.org.yaml.snakeyaml>2.0</version.org.yaml.snakeyaml>

--- a/prospero-cli/src/main/java/org/wildfly/prospero/cli/spi/CliProviderImpl.java
+++ b/prospero-cli/src/main/java/org/wildfly/prospero/cli/spi/CliProviderImpl.java
@@ -40,16 +40,16 @@ public class CliProviderImpl implements CliProvider {
     @Override
     public String getApplyUpdateCommand(Path installationPath, Path candidatePath) {
         return CliConstants.Commands.UPDATE + " " + CliConstants.Commands.APPLY + " "
-                + CliConstants.DIR + "=" + escape(installationPath.toAbsolutePath()) + " "
-                + CliConstants.UPDATE_DIR + "=" + escape(candidatePath.toAbsolutePath()) + " "
+                + CliConstants.DIR + " " + escape(installationPath.toAbsolutePath()) + " "
+                + CliConstants.UPDATE_DIR + " " + escape(candidatePath.toAbsolutePath()) + " "
                 + CliConstants.YES;
     }
 
     @Override
     public String getApplyRevertCommand(Path installationPath, Path candidatePath) {
         return CliConstants.Commands.REVERT + " " + CliConstants.Commands.APPLY + " "
-                + CliConstants.DIR + "=" + escape(installationPath.toAbsolutePath()) + " "
-                + CliConstants.UPDATE_DIR + "=" + escape(candidatePath.toAbsolutePath()) + " "
+                + CliConstants.DIR + " " + escape(installationPath.toAbsolutePath()) + " "
+                + CliConstants.UPDATE_DIR + " " + escape(candidatePath.toAbsolutePath()) + " "
                 + CliConstants.YES;
     }
 

--- a/prospero-common/src/main/java/org/wildfly/prospero/spi/ProsperoInstallationManager.java
+++ b/prospero-common/src/main/java/org/wildfly/prospero/spi/ProsperoInstallationManager.java
@@ -175,25 +175,29 @@ public class ProsperoInstallationManager implements InstallationManager {
     }
 
     @Override
-    public String generateApplyUpdateCommand(Path candidatePath) throws OperationNotAvailableException {
+    public String generateApplyUpdateCommand(Path scriptHome, Path candidatePath) throws OperationNotAvailableException {
         final Optional<CliProvider> cliProviderLoader = ServiceLoader.load(CliProvider.class).findFirst();
         if (cliProviderLoader.isEmpty()) {
             throw new OperationNotAvailableException("Installation manager does not support CLI operations.");
         }
 
         final CliProvider cliProvider = cliProviderLoader.get();
-        return cliProvider.getScriptName() + " " + cliProvider.getApplyUpdateCommand(installationDir, candidatePath);
+        return escape(scriptHome.resolve(cliProvider.getScriptName())) + " " + cliProvider.getApplyUpdateCommand(installationDir, candidatePath);
     }
 
     @Override
-    public String generateApplyRevertCommand(Path candidatePath) throws OperationNotAvailableException {
+    public String generateApplyRevertCommand(Path scriptHome, Path candidatePath) throws OperationNotAvailableException {
         final Optional<CliProvider> cliProviderLoader = ServiceLoader.load(CliProvider.class).findFirst();
         if (cliProviderLoader.isEmpty()) {
             throw new OperationNotAvailableException("Installation manager does not support CLI operations.");
         }
 
         final CliProvider cliProvider = cliProviderLoader.get();
-        return cliProvider.getScriptName() + " " + cliProvider.getApplyRevertCommand(installationDir, candidatePath);
+        return escape(scriptHome.resolve(cliProvider.getScriptName())) + " " + cliProvider.getApplyRevertCommand(installationDir, candidatePath);
+    }
+
+    private String escape(Path absolutePath) {
+        return "\"" + absolutePath.toString() + "\"";
     }
 
     private static Channel mapChannel(org.wildfly.channel.Channel channel) {


### PR DESCRIPTION
- Upgrade installation Manager API to 1.0.0.Final
- Code changes to incorporate the script home path to the generate command SPI methods
- Replace the '=' with a white space when the SPI commands are generated with arguments