### PR TITLE
Split --fpl argument into --profile and --fpl

### DIFF
--- a/integration-tests/src/test/java/org/wildfly/prospero/it/ExecutionUtils.java
+++ b/integration-tests/src/test/java/org/wildfly/prospero/it/ExecutionUtils.java
@@ -52,7 +52,7 @@ public class ExecutionUtils {
         String[] execArray = mergeArrays(new String[] {script.toString()}, execution.args);
         Process process = new ProcessBuilder(execArray)
                 .redirectErrorStream(true)
-                .redirectOutput(new File("test-out.log"))
+                .redirectOutput(new File("target/test-out.log"))
                 .start();
 
         if (!process.waitFor(execution.timeLimit, execution.timeUnit)) {

--- a/integration-tests/test-out.log
+++ b/integration-tests/test-out.log
@@ -1,1 +1,0 @@
-No updates found.

--- a/prospero-cli/src/main/java/org/wildfly/prospero/cli/CliMessages.java
+++ b/prospero-cli/src/main/java/org/wildfly/prospero/cli/CliMessages.java
@@ -398,4 +398,9 @@ public interface CliMessages {
     default IllegalArgumentException nonEmptyTargetFolder() {
         return new IllegalArgumentException(bundle.getString("prospero.updates.build.validation.dir.not_empty"));
     }
+
+    default ArgumentParsingException unknownInstallationProfile(String profileName, String candidates) {
+        return new ArgumentParsingException(String.format(bundle.getString("prospero.install.validation.unknown_profile"), profileName),
+                String.format(bundle.getString("prospero.install.validation.unknown_profile.details"), candidates));
+    }
 }

--- a/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/AbstractInstallCommand.java
+++ b/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/AbstractInstallCommand.java
@@ -103,6 +103,7 @@ public abstract class AbstractInstallCommand extends AbstractCommand {
     protected ProvisioningDefinition buildDefinition() throws MetadataException, NoChannelException, ArgumentParsingException {
         final ProvisioningDefinition provisioningDefinition = ProvisioningDefinition.builder()
                 .setFpl(featurePackOrDefinition.fpl.orElse(null))
+                .setProfile(featurePackOrDefinition.profile.orElse(null))
                 .setManifest(manifestCoordinate.orElse(null))
                 .setChannelCoordinates(channelCoordinates)
                 .setOverrideRepositories(RepositoryDefinition.from(remoteRepositories))

--- a/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/CliConstants.java
+++ b/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/CliConstants.java
@@ -59,6 +59,8 @@ public final class CliConstants {
 
     // Parameter and option labels:
 
+    public static final String PROFILE = "--profile";
+    public static final String PROFILE_REFERENCE = "<installation-profile>";
     public static final String CHANNEL_REFERENCE = "<channel-reference>";
     public static final String CHANNEL_MANIFEST_REFERENCE = "<manifest-reference>";
     public static final String FEATURE_PACK_REFERENCE = "<feature-pack-reference>";

--- a/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/InstallCommand.java
+++ b/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/InstallCommand.java
@@ -57,11 +57,19 @@ public class InstallCommand extends AbstractInstallCommand {
 
     static class FeaturePackOrDefinition {
         @CommandLine.Option(
-                names = CliConstants.FPL,
-                paramLabel = CliConstants.FEATURE_PACK_REFERENCE,
+                names = CliConstants.PROFILE,
+                paramLabel = CliConstants.PROFILE_REFERENCE,
                 completionCandidates = FeaturePackCandidates.class,
                 required = true,
                 order = 1
+        )
+        Optional<String> profile;
+
+        @CommandLine.Option(
+                names = CliConstants.FPL,
+                paramLabel = CliConstants.FEATURE_PACK_REFERENCE,
+                required = true,
+                order = 2
         )
         Optional<String> fpl;
 
@@ -69,7 +77,7 @@ public class InstallCommand extends AbstractInstallCommand {
                 names = CliConstants.DEFINITION,
                 paramLabel = CliConstants.PATH,
                 required = true,
-                order = 2
+                order = 3
         )
         Optional<Path> definition;
     }
@@ -83,10 +91,14 @@ public class InstallCommand extends AbstractInstallCommand {
         final long startTime = System.currentTimeMillis();
 
         // following is checked by picocli, adding this to avoid IDE warnings
-        assert featurePackOrDefinition.definition.isPresent() || featurePackOrDefinition.fpl.isPresent();
-        if (featurePackOrDefinition.definition.isEmpty() && !isStandardFpl(featurePackOrDefinition.fpl.get())
-                && channelCoordinates.isEmpty() && manifestCoordinate.isEmpty()) {
+        assert featurePackOrDefinition.definition.isPresent() || featurePackOrDefinition.fpl.isPresent() || featurePackOrDefinition.profile.isPresent();
+
+        if (featurePackOrDefinition.profile.isEmpty() && channelCoordinates.isEmpty() && manifestCoordinate.isEmpty()) {
             throw CliMessages.MESSAGES.channelsMandatoryWhenCustomFpl(String.join(",", KnownFeaturePacks.getNames()));
+        }
+
+        if (featurePackOrDefinition.profile.isPresent() && !isStandardFpl(featurePackOrDefinition.profile.get())) {
+            throw CliMessages.MESSAGES.unknownInstallationProfile(featurePackOrDefinition.profile.get(), String.join(",", KnownFeaturePacks.getNames()));
         }
 
         if (!channelCoordinates.isEmpty() && manifestCoordinate.isPresent()) {

--- a/prospero-cli/src/main/resources/UsageMessages.properties
+++ b/prospero-cli/src/main/resources/UsageMessages.properties
@@ -33,12 +33,13 @@ usage.optionListHeading = %nOptions:%n
 prospero.usage.customSynopsis=             @|bold ${prospero.dist.name}|@ [@|fg(yellow) -hv|@] [COMMAND]
 
 prospero.install.usage.header = Installs a new instance of the application server.
-prospero.install.usage.customSynopsis.0 =             @|bold ${prospero.dist.name} install|@ @|fg(yellow) --fpl|@=@|italic <predefined-name>|@ [@|fg(yellow) OPTION|@]...
-prospero.install.usage.customSynopsis.1 = \u0020 or:  @|bold ${prospero.dist.name} install|@ @|fg(yellow) --fpl|@=@|italic <predefined-name>|@ @|fg(yellow) --manifest|@=@|italic <URL/GAV/path>|@ @|fg(yellow) --repositories|@=@|italic <URL>[,...]|@ [@|fg(yellow) OPTION|@]...
-prospero.install.usage.customSynopsis.2 = \u0020 or:  @|bold ${prospero.dist.name} install|@ @|fg(yellow) --fpl|@=@|italic <URL/GA>|@ @|fg(yellow) --channel|@=@|italic <path>|@ [@|fg(yellow) OPTION|@]...
-prospero.install.usage.customSynopsis.3 = \u0020        (to install a feature pack)
-prospero.install.usage.customSynopsis.4 = \u0020 or:  @|bold ${prospero.dist.name} install|@ @|fg(yellow) --definition|@=@|italic <path>|@ [@|fg(yellow) OPTION|@]...
-prospero.install.usage.customSynopsis.5 = \u0020        (to install from a Galleon `@|bold provisioning.xml|@` file)
+prospero.install.usage.customSynopsis.0 =             @|bold ${prospero.dist.name} install|@ @|fg(yellow) --profile|@=@|italic <predefined-name>|@ [@|fg(yellow) OPTION|@]...
+prospero.install.usage.customSynopsis.1 = \u0020 or:  @|bold ${prospero.dist.name} install|@ @|fg(yellow) --profile|@=@|italic <predefined-name>|@ @|fg(yellow) --manifest|@=@|italic <URL/GAV/path>|@ @|fg(yellow) --repositories|@=@|italic <URL>[,...]|@ [@|fg(yellow) OPTION|@]...
+prospero.install.usage.customSynopsis.2 = \u0020        (to install an installation profile)
+prospero.install.usage.customSynopsis.3 = \u0020 or:  @|bold ${prospero.dist.name} install|@ @|fg(yellow) --fpl|@=@|italic <GA>|@ @|fg(yellow) --channel|@=@|italic <path>|@ [@|fg(yellow) OPTION|@]...
+prospero.install.usage.customSynopsis.4 = \u0020        (to install a feature pack)
+prospero.install.usage.customSynopsis.5 = \u0020 or:  @|bold ${prospero.dist.name} install|@ @|fg(yellow) --definition|@=@|italic <path>|@ [@|fg(yellow) OPTION|@]...
+prospero.install.usage.customSynopsis.6 = \u0020        (to install from a Galleon `@|bold provisioning.xml|@` file)
 
 prospero.update.usage.header  = Updates a server instance with the latest patches.
 prospero.update.usage.description.0 = Update operation can be run either as a one-step (@|bold perform|@) or two-step (@|bold prepare|@+@|bold apply|@) operation.
@@ -143,8 +144,12 @@ dir = Location of the existing application server. If not specified, current wor
 prospero.install.dir = Target directory where the application server will be provisioned.
 
 dry-run = Print components that can be upgraded, but do not perform the upgrades.
-fpl = Location of the feature pack. This can be a feature pack "GA" like "org.wildfly:wildfly-ee-galleon-pack", or one of \
-  pre-defined feature pack names: \ [${COMPLETION-CANDIDATES}].
+fpl.0 = Maven coordinates of a Galleon feature pack. The specified feature pack is installed \
+  with default layers and packages.
+fpl.1 = When you use this option, you should also specify the @|bold --channels|@ or a combination of @|bold --manifest|@ \
+  and @|bold --repositories|@ options.
+profile.0 = Installation profile. The profiles contain complete provisioning configurations required to install a server.
+profile.1 = Available profiles are: [${COMPLETION-CANDIDATES}]
 help = Displays the help information for this command.
 prospero.help = Displays the help information for the command.
 local-cache = Path to the local Maven repository cache. It overrides the default Maven repository at ~/.m2/repository.
@@ -204,8 +209,11 @@ prospero.install.progress.examples.done=JBoss examples installed.
 prospero.install.progress.versions=Resolving versions
 prospero.install.progress.versions.done=Versions resolved.
 prospero.install.progress.applying_changes=APPLYING CHANGES
-prospero.install.validation.unknown_fpl=The chosen FPL is not a known configuration - did you mean one of [%s]?
-prospero.install.validation.unknown_fpl.details=If you want to install a custom FPL, make sure a valid channels configuration including repositories and manifest is provided.
+prospero.install.validation.unknown_fpl=Incomplete installation configuration.
+prospero.install.validation.unknown_fpl.details=Either a --channels or a combination of --manifest and --repositories is \
+  needed when using a custom feature pack.
+prospero.install.validation.unknown_profile=Unknown profile [%s]
+prospero.install.validation.unknown_profile.details=Did you mean one of [%s]?
 
 prospero.updates.no_updates=No updates found.
 prospero.updates.header=Updates found:

--- a/prospero-cli/src/test/java/org/wildfly/prospero/cli/commands/InstallCommandTest.java
+++ b/prospero-cli/src/test/java/org/wildfly/prospero/cli/commands/InstallCommandTest.java
@@ -106,8 +106,8 @@ public class InstallCommandTest extends AbstractMavenCommandTest {
         int exitCode = commandLine.execute(CliConstants.Commands.INSTALL, CliConstants.DIR, "test");
         assertEquals(ReturnCodes.INVALID_ARGUMENTS, exitCode);
         assertTrue(getErrorOutput().contains(String.format(
-                "Missing required argument (specify one of these): (%s=%s | %s=%s)",
-                CliConstants.FPL, CliConstants.FEATURE_PACK_REFERENCE, CliConstants.DEFINITION, CliConstants.PATH)));
+                "Missing required argument (specify one of these): (%s=%s | %s=%s | %s=%s)",
+                CliConstants.PROFILE, CliConstants.PROFILE_REFERENCE, CliConstants.FPL, CliConstants.FEATURE_PACK_REFERENCE, CliConstants.DEFINITION, CliConstants.PATH)));
     }
 
     @Test
@@ -123,7 +123,7 @@ public class InstallCommandTest extends AbstractMavenCommandTest {
     public void errorIfChannelsIsNotValid() throws Exception {
         final File channelsFile = temporaryFolder.newFile();
         Files.writeString(channelsFile.toPath(), "schemaVersion: 2.0.0\n");
-        int exitCode = commandLine.execute(CliConstants.Commands.INSTALL, CliConstants.DIR, "test", CliConstants.FPL, KNOWN_FPL,
+        int exitCode = commandLine.execute(CliConstants.Commands.INSTALL, CliConstants.DIR, "test", CliConstants.PROFILE, KNOWN_FPL,
                 CliConstants.CHANNELS, channelsFile.getAbsolutePath());
         assertEquals(ReturnCodes.PROCESSING_ERROR, exitCode);
         assertTrue("output: " + getErrorOutput(), getErrorOutput().contains(ProsperoLogger.ROOT_LOGGER
@@ -148,7 +148,7 @@ public class InstallCommandTest extends AbstractMavenCommandTest {
 
     @Test
     public void callProvisionOnInstallKnownCommand() throws Exception {
-        int exitCode = commandLine.execute(CliConstants.Commands.INSTALL, CliConstants.DIR, "test", CliConstants.FPL, KNOWN_FPL);
+        int exitCode = commandLine.execute(CliConstants.Commands.INSTALL, CliConstants.DIR, "test", CliConstants.PROFILE, KNOWN_FPL);
         commandLine.getOut();
         commandLine.getErr();
 
@@ -165,7 +165,7 @@ public class InstallCommandTest extends AbstractMavenCommandTest {
         Channel channel = createChannel("dev", "wildfly-channel", "http://test.test", "org.wildfly");
         MetadataTestUtils.writeChannels(channelsFile.toPath(), List.of(channel));
 
-        int exitCode = commandLine.execute(CliConstants.Commands.INSTALL, CliConstants.DIR, "test", CliConstants.FPL, KNOWN_FPL,
+        int exitCode = commandLine.execute(CliConstants.Commands.INSTALL, CliConstants.DIR, "test", CliConstants.PROFILE, KNOWN_FPL,
                 CliConstants.CHANNELS, channelsFile.getAbsolutePath());
 
         assertEquals(ReturnCodes.SUCCESS, exitCode);
@@ -272,7 +272,7 @@ public class InstallCommandTest extends AbstractMavenCommandTest {
     @Override
     protected String[] getDefaultArguments() {
         return new String[]{CliConstants.Commands.INSTALL, CliConstants.DIR, "test",
-                CliConstants.FPL, KNOWN_FPL};
+                CliConstants.PROFILE, KNOWN_FPL};
     }
 
     private static Channel createChannel(String test, String test1, String url, String groupId) {

--- a/prospero-common/src/main/java/org/wildfly/prospero/ProsperoLogger.java
+++ b/prospero-common/src/main/java/org/wildfly/prospero/ProsperoLogger.java
@@ -307,6 +307,9 @@ public interface ProsperoLogger extends BasicLogger {
     @Message(id = 247, value = "Invalid channel definition")
     ChannelDefinitionException invalidChannel(@Cause InvalidChannelMetadataException e);
 
-    @Message(id = 248, value = "Provided FPL has invalid format `%s`.")
+    @Message(id = 248, value = "Provided feature pack location has invalid format `%s`. Expected <groupId:artifactId>")
     String invalidFpl(String fplText);
+
+    @Message(id = 249, value = "Unrecognized profile %s, did you mean one of [%s]")
+    IllegalArgumentException unknownInstallationProfile(String profileName, String options);
 }

--- a/prospero-common/src/main/java/org/wildfly/prospero/api/ProvisioningDefinition.java
+++ b/prospero-common/src/main/java/org/wildfly/prospero/api/ProvisioningDefinition.java
@@ -91,8 +91,12 @@ public class ProvisioningDefinition {
         this.overrideRepositories.addAll(builder.overrideRepositories);
         this.channelCoordinates.addAll(builder.channelCoordinates);
 
-        if (builder.fpl.isPresent() && KnownFeaturePacks.isWellKnownName(builder.fpl.get())) { // if known FP name
-            KnownFeaturePack featurePackInfo = KnownFeaturePacks.getByName(builder.fpl.get());
+        if (builder.profile.isPresent()) {
+
+            if (!KnownFeaturePacks.isWellKnownName(builder.profile.get())) { // if known FP name
+                throw ProsperoLogger.ROOT_LOGGER.unknownInstallationProfile(builder.profile.get(), String.join(",", KnownFeaturePacks.getNames()));
+            }
+            KnownFeaturePack featurePackInfo = KnownFeaturePacks.getByName(builder.profile.get());
             this.fpl = null;
             this.definition = featurePackInfo.getGalleonConfiguration();
             if (this.channelCoordinates.isEmpty()) { // no channels provided by user
@@ -102,7 +106,7 @@ public class ProvisioningDefinition {
                 } else if (!featurePackInfo.getChannels().isEmpty()) { // if no manifest given, use channels from known FP
                     this.channels = featurePackInfo.getChannels();
                 } else {
-                    throw ProsperoLogger.ROOT_LOGGER.fplDefinitionDoesntContainChannel(builder.fpl.get());
+                    throw ProsperoLogger.ROOT_LOGGER.fplDefinitionDoesntContainChannel(builder.profile.get());
                 }
             }
         } else {
@@ -238,6 +242,7 @@ public class ProvisioningDefinition {
         private List<Repository> overrideRepositories = Collections.emptyList();
         private Optional<ChannelManifestCoordinate> manifest = Optional.empty();
         private List<ChannelCoordinate> channelCoordinates = Collections.emptyList();
+        private Optional<String> profile = Optional.empty();
 
         public ProvisioningDefinition build() throws MetadataException, NoChannelException {
             return new ProvisioningDefinition(this);
@@ -275,6 +280,11 @@ public class ProvisioningDefinition {
 
         public Builder setDefinitionFile(URI provisionDefinition) {
             this.definitionFile = Optional.ofNullable(provisionDefinition);
+            return this;
+        }
+
+        public Builder setProfile(String profile) {
+            this.profile = Optional.ofNullable(profile);
             return this;
         }
     }

--- a/prospero-common/src/test/java/org/wildfly/prospero/api/ProvisioningDefinitionTest.java
+++ b/prospero-common/src/test/java/org/wildfly/prospero/api/ProvisioningDefinitionTest.java
@@ -61,7 +61,7 @@ public class ProvisioningDefinitionTest {
 
     @Test
     public void setChannelWithFileUrl() throws Exception {
-        final ProvisioningDefinition.Builder builder = new ProvisioningDefinition.Builder().setFpl(EAP_FPL);
+        final ProvisioningDefinition.Builder builder = new ProvisioningDefinition.Builder().setProfile(EAP_FPL);
 
         builder.setManifest("file:/tmp/foo.bar");
         final ProvisioningDefinition definition = builder.build();
@@ -77,7 +77,7 @@ public class ProvisioningDefinitionTest {
 
     @Test
     public void setChannelWithHttpUrl() throws Exception {
-        final ProvisioningDefinition.Builder builder = new ProvisioningDefinition.Builder().setFpl(EAP_FPL);
+        final ProvisioningDefinition.Builder builder = new ProvisioningDefinition.Builder().setProfile(EAP_FPL);
 
         builder.setManifest("http://localhost/foo.bar");
         final ProvisioningDefinition definition = builder.build();
@@ -93,7 +93,7 @@ public class ProvisioningDefinitionTest {
 
     @Test
     public void setChannelWithLocalFilePath() throws Exception {
-        final ProvisioningDefinition.Builder builder = new ProvisioningDefinition.Builder().setFpl(EAP_FPL);
+        final ProvisioningDefinition.Builder builder = new ProvisioningDefinition.Builder().setProfile(EAP_FPL);
 
         builder.setManifest("tmp/foo.bar");
         final ProvisioningDefinition definition = builder.build();
@@ -110,7 +110,7 @@ public class ProvisioningDefinitionTest {
     @Test
     public void addAdditionalRemoteRepos() throws Exception {
         final ProvisioningDefinition.Builder builder = new ProvisioningDefinition.Builder()
-                .setFpl(EAP_FPL)
+                .setProfile(EAP_FPL)
                 .setOverrideRepositories(Arrays.asList(
                         new Repository("temp-repo-0", "http://test.repo1"),
                         new Repository("temp-repo-1", "http://test.repo2")));
@@ -161,8 +161,8 @@ public class ProvisioningDefinitionTest {
     }
 
     @Test
-    public void knownFplWithoutChannel() throws Exception {
-        final ProvisioningDefinition.Builder builder = new ProvisioningDefinition.Builder().setFpl("no-channel");
+    public void knownProfileWithoutChannel() throws Exception {
+        final ProvisioningDefinition.Builder builder = new ProvisioningDefinition.Builder().setProfile("no-channel");
 
         try {
             ProvisioningDefinition definition = builder.build();
@@ -174,8 +174,8 @@ public class ProvisioningDefinitionTest {
     }
 
     @Test
-    public void knownFplWithMultipleChannels() throws Exception {
-        final ProvisioningDefinition.Builder builder = new ProvisioningDefinition.Builder().setFpl("multi-channel");
+    public void knownProfileWithMultipleChannels() throws Exception {
+        final ProvisioningDefinition.Builder builder = new ProvisioningDefinition.Builder().setProfile("multi-channel");
 
         final ProvisioningDefinition def = builder.build();
         assertThat(def.resolveChannels(VERSION_RESOLVER_FACTORY).stream().map(c -> c.getManifestCoordinate().getMaven()))
@@ -185,9 +185,9 @@ public class ProvisioningDefinitionTest {
     }
 
     @Test
-    public void knownFplWithBothManifestAndRepositories() throws Exception {
+    public void knownProfileWithBothManifestAndRepositories() throws Exception {
         final ProvisioningDefinition.Builder builder = new ProvisioningDefinition.Builder()
-                .setFpl("multi-channel")
+                .setProfile("multi-channel")
                 .setManifest("file:/tmp/foo.bar")
                 .setOverrideRepositories(Arrays.asList(
                         new Repository("temp-repo-0", "http://test.repo1"),
@@ -208,7 +208,7 @@ public class ProvisioningDefinitionTest {
     }
 
     @Test
-    public void knownFplWithConfig() throws Exception {
+    public void knownProfileWithConfig() throws Exception {
         final File file = temp.newFile();
 
         MetadataTestUtils.writeChannels(file.toPath(), List.of(new Channel("test", null, null,
@@ -216,7 +216,7 @@ public class ProvisioningDefinitionTest {
                 new ChannelManifestCoordinate("new.test", "gav"),
                 null, null)));
 
-        ProvisioningDefinition def = new ProvisioningDefinition.Builder().setFpl("multi-channel")
+        ProvisioningDefinition def = new ProvisioningDefinition.Builder().setProfile("multi-channel")
                 .setChannelCoordinates(file.toPath().toString()).build();
 
         VersionResolverFactory versionResolverFactory = new VersionResolverFactory(null, null);
@@ -236,11 +236,20 @@ public class ProvisioningDefinitionTest {
     public void resolveInvalidChannelThrowsException() throws Exception {
         final File channel = temp.newFile();
         Files.writeString(channel.toPath(), "schemaVersion: 2.0.0");
-        final ProvisioningDefinition def = new ProvisioningDefinition.Builder().setFpl("multi-channel")
+        final ProvisioningDefinition def = new ProvisioningDefinition.Builder().setProfile("multi-channel")
                 .setChannelCoordinates(channel.toURI().toString())
                 .build();
 
         assertThrows(ChannelDefinitionException.class, ()-> def.resolveChannels(null));
+    }
+
+    @Test
+    public void unknownProfileNameThrowsException() throws Exception {
+        final ProvisioningDefinition.Builder builder = new ProvisioningDefinition.Builder().setProfile("idontexist");
+
+        assertThrows(IllegalArgumentException.class, ()-> {
+            builder.build();
+        });
     }
 
     private void verifyFeaturePackLocation(ProvisioningDefinition definition) throws ProvisioningException, XMLStreamException {


### PR DESCRIPTION
The `--fpl` argument usage is confusing - currently it indicates either a "known-configuration" or a feature pack location. 

Splitting it into `--profile` (known-configurations) and `--fpl` (feature packs) should improve UX.

```
$ ./prospero install -h
(...)
Installation source:
      --profile=<installation-profile>
                             Installation profile. The profiles provide a complete provisioning configuration needed to install a server.
                             Available profiles are: [wildfly]
      --fpl=<feature-pack-reference>
                             Maven coordinate of Galleon feature pack. A selected feature pack will be installed with default layers and packages.
                             The --channels or a combination of --manifest and --repositories needs to be provided to use this option.
      --definition=<path>    Galleon provisioning XML definition file path.
```