### PR TITLE
Hidden shadow repositories option

### DIFF
--- a/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/CliConstants.java
+++ b/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/CliConstants.java
@@ -73,6 +73,7 @@ public final class CliConstants {
     public static final String CHANNEL = "--channel";
     public static final String CHANNELS = "--channels";
     public static final String REPOSITORIES = "--repositories";
+    public static final String SHADE_REPOSITORIES = "--shade-repositories";
     public static final String DEFINITION = "--definition";
     public static final String DIR = "--dir";
     public static final String FPL = "--fpl";

--- a/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/InstallCommand.java
+++ b/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/InstallCommand.java
@@ -18,11 +18,13 @@
 package org.wildfly.prospero.cli.commands;
 
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
 import org.jboss.galleon.config.ProvisioningConfig;
 import org.wildfly.channel.Channel;
+import org.wildfly.channel.Repository;
 import org.wildfly.prospero.actions.ProvisioningAction;
 import org.wildfly.prospero.api.KnownFeaturePacks;
 import org.wildfly.prospero.api.MavenOptions;
@@ -31,6 +33,7 @@ import org.wildfly.prospero.cli.ActionFactory;
 import org.wildfly.prospero.cli.CliConsole;
 import org.wildfly.prospero.cli.CliMessages;
 import org.wildfly.prospero.cli.LicensePrinter;
+import org.wildfly.prospero.cli.RepositoryDefinition;
 import org.wildfly.prospero.cli.ReturnCodes;
 import org.wildfly.prospero.cli.commands.options.FeaturePackCandidates;
 import org.wildfly.prospero.licenses.License;
@@ -54,6 +57,14 @@ public class InstallCommand extends AbstractInstallCommand {
             order = 8
     )
     boolean acceptAgreements;
+
+    @CommandLine.Option(
+            names = CliConstants.SHADE_REPOSITORIES,
+            split = ",",
+            hidden = true
+    )
+    List<String> shadowRepositories = new ArrayList<>();
+
 
     static class FeaturePackOrDefinition {
         @CommandLine.Option(
@@ -129,7 +140,8 @@ public class InstallCommand extends AbstractInstallCommand {
             }
         }
 
-        provisioningAction.provision(provisioningConfig, channels);
+        final List<Repository> shadowRepositories = RepositoryDefinition.from(this.shadowRepositories);
+        provisioningAction.provision(provisioningConfig, channels, shadowRepositories);
 
         final float totalTime = (System.currentTimeMillis() - startTime) / 1000f;
         console.println(CliMessages.MESSAGES.operationCompleted(totalTime));


### PR DESCRIPTION
When provisioning a server it's sometimes useful to provision from a different repository than the server should be subscribed to

For example follwing allow to build a server with artifacts available in staging repository, but subscribed to repositories defined in channels

```
./prospero install --profile wildfly --channel <CHANNEL> --shade-repositories=https://stage.repository
```

