### PR TITLE
Correct logging configuration in shaded prospero jar

### DIFF
--- a/prospero-cli/src/main/resources/logging.properties
+++ b/prospero-cli/src/main/resources/logging.properties
@@ -2,7 +2,7 @@
 loggers=org.wildfly.prospero
 
 logger.org.wildfly.prospero.level=INFO
-logger.org.wildfly.prospero.handlers=FILE
+#logger.org.wildfly.prospero.handlers=FILE
 
 # Root logger level
 logger.level=ERROR


### PR DESCRIPTION
Disable FILE logger to prevent creation of jboss-prospero.log
