### PR TITLE
Require a channel resolution if the feature pack FPL doesn't include a version

### DIFF
--- a/dist/standalone-galleon-pack/pom.xml
+++ b/dist/standalone-galleon-pack/pom.xml
@@ -679,6 +679,7 @@
                         <configuration>
                           <resources-dir>${basedir}/target/resources</resources-dir>
                           <generate-channel-manifest>true</generate-channel-manifest>
+                          <wildfly-channel-resolution-mode>${prospero.channel.resolution.mode}</wildfly-channel-resolution-mode>
                         </configuration>
                     </execution>
                 </executions>

--- a/dist/wildfly-galleon-pack/pom.xml
+++ b/dist/wildfly-galleon-pack/pom.xml
@@ -457,6 +457,7 @@
               <generate-channel-manifest>true</generate-channel-manifest>
               <configFile>target/wildfly-user-feature-pack-build.xml</configFile>
               <add-feature-packs-as-required-manifests>false</add-feature-packs-as-required-manifests>
+              <wildfly-channel-resolution-mode>${prospero.channel.resolution.mode}</wildfly-channel-resolution-mode>
             </configuration>
           </execution>
         </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,7 @@
         <prospero.test.base.repositories>https://repo1.maven.org/maven2/,https://repository.jboss.org/nexus/content/groups/public/</prospero.test.base.repositories>
         <prospero.repo.id>central</prospero.repo.id>
         <prospero.repo.url>https://repo1.maven.org/maven2/</prospero.repo.url>
+        <prospero.channel.resolution.mode>NOT_REQUIRED</prospero.channel.resolution.mode>
 
         <version.io.undertow>2.3.5.Final</version.io.undertow>
         <version.commons-codec>1.15</version.commons-codec>

--- a/prospero-common/src/main/java/org/wildfly/prospero/galleon/ChannelMavenArtifactRepositoryManager.java
+++ b/prospero-common/src/main/java/org/wildfly/prospero/galleon/ChannelMavenArtifactRepositoryManager.java
@@ -100,6 +100,12 @@ public class ChannelMavenArtifactRepositoryManager implements MavenRepoManager, 
     private boolean fpRequireChannel(MavenArtifact artifact) throws Exception {
         boolean requireChannel = false;
         if (artifact.getVersion() != null && artifact.getExtension() != null && artifact.getExtension().equalsIgnoreCase("zip")) {
+            if (artifact.getVersion().equals(artifact.getExtension())) {
+                // the requested FPL was in form groupId:artifactId::zip - galleon converts the version wrong
+                // TODO: fix in Galleon and change to check if version is null
+                return true;
+            }
+
             org.wildfly.channel.MavenArtifact mavenArtifact = channelSession.
                     resolveDirectMavenArtifact(artifact.getGroupId(),
                             artifact.getArtifactId(),

--- a/prospero-common/src/test/java/org/wildfly/prospero/galleon/ChannelMavenArtifactRepositoryManagerTest.java
+++ b/prospero-common/src/test/java/org/wildfly/prospero/galleon/ChannelMavenArtifactRepositoryManagerTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2023 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.prospero.galleon;
+
+import org.jboss.galleon.universe.maven.MavenArtifact;
+import org.jboss.galleon.universe.maven.MavenUniverseException;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.wildfly.channel.ChannelSession;
+import org.wildfly.channel.UnresolvedMavenArtifactException;
+
+import static org.junit.Assert.assertThrows;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ChannelMavenArtifactRepositoryManagerTest {
+
+    @Mock
+    private ChannelSession session;
+
+    private ChannelMavenArtifactRepositoryManager repositoryManager;
+
+    @Before
+    public void setUp() throws Exception {
+        repositoryManager = new ChannelMavenArtifactRepositoryManager(session);
+    }
+
+    @Test
+    public void testRequireChannelResolutionWhenFeaturePackVersionIsNotSpecified() throws Exception {
+        when(session.resolveMavenArtifact("foo", "bar", "zip", "", null))
+                .thenThrow(UnresolvedMavenArtifactException.class);
+
+
+        final MavenArtifact artifact = new MavenArtifact();
+        artifact.setGroupId("foo");
+        artifact.setArtifactId("bar");
+        // Galleon glitch
+        artifact.setVersion("zip");
+        artifact.setExtension("zip");
+        assertThrows(MavenUniverseException.class, ()->repositoryManager.resolve(artifact));
+    }
+}


### PR DESCRIPTION
- Add resolution mode to generated galleon-packs
- Require a channel resolution if the feature pack FPL doesn't include a version

If the required FPL doesn't contain a version (e.g. org.wildfly:wildfly-galleon-pack::zip), the resolver will attempt to download the pack to check if it requires channel resolution. This will cause error as the artifact cannot be resolved without a version.
