### PR TITLE
Detect logging.config in JAVA_OPTS

### DIFF
--- a/dist/common/src/main/resources/packages/org.jboss.prospero/content/bin/prospero.ps1
+++ b/dist/common/src/main/resources/packages/org.jboss.prospero/content/bin/prospero.ps1
@@ -282,10 +282,14 @@ Function Get-Java-Arguments {
 
     }
 
-    if ($logFileProperties){
+    if ( $JAVA_OPTS -inotmatch "logging.configuration")
+    {
+        if ($logFileProperties)
+        {
 
-        $PROG_ARGS += "-Dlogging.configuration=file:$logFileProperties"
+            $PROG_ARGS += "-Dlogging.configuration=file:$logFileProperties"
 
+        }
     }
 
     # Set default log location


### PR DESCRIPTION
Prevent prospero.ps1 script from overriding the `logging.configuration` setting if it's present in JAVA_OPTS