### PR TITLE
Fix NPE when manifest is omitted and when candidate contains new components

### DIFF
--- a/prospero-common/src/main/java/org/wildfly/prospero/actions/ApplyCandidateAction.java
+++ b/prospero-common/src/main/java/org/wildfly/prospero/actions/ApplyCandidateAction.java
@@ -277,7 +277,7 @@ public class ApplyCandidateAction {
 
         for (String key : candidateMap.keySet()) {
             if (!baseMap.containsKey(key)) {
-                changes.add(ArtifactChange.added(baseMap.get(key)));
+                changes.add(ArtifactChange.added(candidateMap.get(key)));
             }
         }
 

--- a/prospero-common/src/main/java/org/wildfly/prospero/api/Diff.java
+++ b/prospero-common/src/main/java/org/wildfly/prospero/api/Diff.java
@@ -19,6 +19,7 @@ package org.wildfly.prospero.api;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 
 public class Diff {
@@ -92,5 +93,18 @@ public class Diff {
                 ", children=" + children +
                 ", status=" + status +
                 '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Diff diff = (Diff) o;
+        return Objects.equals(name, diff.name) && Objects.equals(oldValue, diff.oldValue) && Objects.equals(newValue, diff.newValue) && Objects.equals(children, diff.children) && status == diff.status;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, oldValue, newValue, children, status);
     }
 }

--- a/prospero-common/src/main/java/org/wildfly/prospero/galleon/ChannelManifestSubstitutor.java
+++ b/prospero-common/src/main/java/org/wildfly/prospero/galleon/ChannelManifestSubstitutor.java
@@ -38,6 +38,10 @@ public class ChannelManifestSubstitutor {
 
     public Channel substitute(Channel channel) throws MetadataException {
         ChannelManifestCoordinate channelManifestCoordinate = channel.getManifestCoordinate();
+        if (channelManifestCoordinate == null) {
+            return channel;
+        }
+
         if (channelManifestCoordinate.getUrl() == null) {
             return channel;
         } else {

--- a/prospero-common/src/test/java/org/wildfly/prospero/galleon/ChannelManifestSubstitutorTest.java
+++ b/prospero-common/src/test/java/org/wildfly/prospero/galleon/ChannelManifestSubstitutorTest.java
@@ -17,7 +17,6 @@
 
 package org.wildfly.prospero.galleon;
 
-import org.junit.Assert;
 import org.junit.Test;
 import org.wildfly.channel.Channel;
 import org.wildfly.channel.ChannelManifestCoordinate;
@@ -29,6 +28,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
+import static org.junit.Assert.assertEquals;
+
 public class ChannelManifestSubstitutorTest {
     @Test
     public void testChannelManifestSubstituted() throws MalformedURLException, MetadataException {
@@ -39,7 +40,7 @@ public class ChannelManifestSubstitutorTest {
                 ChannelManifestCoordinate.create(url, null), null, null);
         Channel substitutedChannel = substitutor.substitute(channel);
         System.clearProperty("propName");
-        Assert.assertEquals(expected, substitutedChannel.getManifestCoordinate().getUrl().toString());
+        assertEquals(expected, substitutedChannel.getManifestCoordinate().getUrl().toString());
     }
 
     @Test
@@ -49,6 +50,15 @@ public class ChannelManifestSubstitutorTest {
         Channel channel = new Channel("channel1", "", null, List.of(new Repository("test", "http://test.org")),
                 ChannelManifestCoordinate.create(url, null), null, null);
         Channel substitutedChannel = substitutor.substitute(channel);
-        Assert.assertEquals(url, substitutedChannel.getManifestCoordinate().getUrl().toString());
+        assertEquals(url, substitutedChannel.getManifestCoordinate().getUrl().toString());
+    }
+
+    @Test
+    public void testChannelWithoutManifestNotSubstituted() throws Exception {
+        final ChannelManifestSubstitutor substitutor = new ChannelManifestSubstitutor(Collections.emptyMap());
+        Channel channel = new Channel("channel1", "", null, List.of(new Repository("test", "http://test.org")),
+                null, null, null);
+        Channel substitutedChannel = substitutor.substitute(channel);
+        assertEquals(channel, substitutedChannel);
     }
 }


### PR DESCRIPTION
- NPE when update candidate adds a new component
- [#410] NPE when manifest is omitted
