### PR TITLE
Improve error message when a command is not matched

### DIFF
--- a/prospero-cli/src/main/java/org/wildfly/prospero/cli/CliMain.java
+++ b/prospero-cli/src/main/java/org/wildfly/prospero/cli/CliMain.java
@@ -67,6 +67,8 @@ public class CliMain {
 
     public static CommandLine createCommandLine(CliConsole console, ActionFactory actionFactory) {
         CommandLine commandLine = new CommandLine(new MainCommand(console));
+        // override main command name - this cannot be done via annotation as the value needs to be loaded at runtime
+        commandLine.setCommandName(DistributionInfo.DIST_NAME);
 
         commandLine.addSubcommand(new InstallCommand(console, actionFactory));
         final UpdateCommand updateCommand = new UpdateCommand(console, actionFactory);
@@ -93,6 +95,9 @@ public class CliMain {
 
         commandLine.setUsageHelpAutoWidth(true);
         commandLine.setExecutionExceptionHandler(new ExecutionExceptionHandler(console));
+
+        final CommandLine.IParameterExceptionHandler rootParameterExceptionHandler = commandLine.getParameterExceptionHandler();
+        commandLine.setParameterExceptionHandler(new UnknownCommandParameterExceptionHandler(rootParameterExceptionHandler, System.err));
 
         return commandLine;
     }

--- a/prospero-cli/src/main/java/org/wildfly/prospero/cli/CliMessages.java
+++ b/prospero-cli/src/main/java/org/wildfly/prospero/cli/CliMessages.java
@@ -17,6 +17,7 @@
 
 package org.wildfly.prospero.cli;
 
+import org.apache.commons.lang3.StringUtils;
 import org.jboss.galleon.Constants;
 import org.wildfly.prospero.actions.ApplyCandidateAction;
 import org.wildfly.prospero.cli.commands.CliConstants;
@@ -24,6 +25,7 @@ import org.wildfly.prospero.metadata.ProsperoMetadataUtils;
 
 import java.io.File;
 import java.nio.file.Path;
+import java.util.List;
 import java.util.Locale;
 import java.util.ResourceBundle;
 
@@ -523,5 +525,20 @@ public interface CliMessages {
 
     default String parsingError(String path) {
         return format(bundle.getString("prospero.general.error.galleon.parse"), path);
+    }
+
+    default String unknownCommand(String commandString) {
+        return format(bundle.getString("prospero.general.error.unknown_command"), commandString);
+    }
+
+    default String commandSuggestions(List<String> suggestions) {
+        if (suggestions.size() == 1) {
+            return format(bundle.getString("prospero.general.error.unknown_command.suggestion_single"),
+                    suggestions.iterator().next());
+        } else {
+            String connector = format(" %s ", bundle.getString("prospero.general.error.unknown_command.or"));
+            return format(bundle.getString("prospero.general.error.unknown_command.suggestion_multiple"),
+                    StringUtils.join(suggestions, connector));
+        }
     }
 }

--- a/prospero-cli/src/main/java/org/wildfly/prospero/cli/UnknownCommandParameterExceptionHandler.java
+++ b/prospero-cli/src/main/java/org/wildfly/prospero/cli/UnknownCommandParameterExceptionHandler.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2023 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.prospero.cli;
+
+import org.apache.commons.lang3.StringUtils;
+import picocli.CommandLine;
+
+import java.io.PrintStream;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Custom handler for argument parsing.
+ * Treats unmatched positional parameters as unknown commands.
+ */
+class UnknownCommandParameterExceptionHandler implements CommandLine.IParameterExceptionHandler {
+    protected static final String COMMAND_SEPARATOR = " ";
+    private final CommandLine.IParameterExceptionHandler delegate;
+    private final PrintStream writer;
+
+    public UnknownCommandParameterExceptionHandler(CommandLine.IParameterExceptionHandler delegate, PrintStream writer) {
+        this.delegate = delegate;
+        this.writer = writer;
+    }
+
+    @Override
+    public int handleParseException(CommandLine.ParameterException ex, String[] args) throws Exception {
+        if (ex instanceof CommandLine.UnmatchedArgumentException) {
+            final CommandLine.UnmatchedArgumentException argEx = (CommandLine.UnmatchedArgumentException) ex;
+
+            if (argEx.isUnknownOption()) {
+                return delegate.handleParseException(ex, args);
+            }
+
+            if (!currentCommandHasSubcommands(argEx)) {
+                return delegate.handleParseException(ex, args);
+            }
+
+            final CommandLine.Help.ColorScheme colorScheme = CommandLine.Help.defaultColorScheme(CommandLine.Help.Ansi.AUTO);
+            final String commandName = argEx.getCommandLine().getCommandSpec().name();
+            final String fullCommand = commandName + COMMAND_SEPARATOR + StringUtils.join(argEx.getUnmatched(), COMMAND_SEPARATOR);
+            writer.println(colorScheme.errorText(CliMessages.MESSAGES.unknownCommand(fullCommand)));
+
+            final List<String> suggestions = argEx.getSuggestions();
+            if (suggestions.isEmpty()) {
+                argEx.getCommandLine().usage(writer);
+            } else {
+                writer.printf(CliMessages.MESSAGES.commandSuggestions(prefix(commandName, suggestions)));
+            }
+            return ReturnCodes.INVALID_ARGUMENTS;
+        }
+        return delegate.handleParseException(ex, args);
+    }
+
+    private static boolean currentCommandHasSubcommands(CommandLine.UnmatchedArgumentException argEx) {
+        return !argEx.getCommandLine().getParseResult().commandSpec().subcommands().isEmpty();
+    }
+
+    private List<String> prefix(String commandName, List<String> commandSuggestions) {
+        return commandSuggestions.stream().map(s -> commandName + COMMAND_SEPARATOR + s).collect(Collectors.toList());
+    }
+}

--- a/prospero-cli/src/main/resources/UsageMessages.properties
+++ b/prospero-cli/src/main/resources/UsageMessages.properties
@@ -298,6 +298,10 @@ prospero.general.validation.local_repo.not_directory=Repository path `%s` is a f
 prospero.general.validation.repo_format=Repository definition [%s] is invalid. The definition format should be [id::url]
 prospero.general.error.missing_file=Required file at `%s` cannot be opened.
 prospero.general.error.galleon.parse=Failed to parse provisioning configuration: %s
+prospero.general.error.unknown_command=Unknown command `%s`
+prospero.general.error.unknown_command.suggestion_multiple=Did you mean one of: %s?%n
+prospero.general.error.unknown_command.suggestion_single=Did you mean: %s?%n
+prospero.general.error.unknown_command.or=or
 
 
 prospero.channels.custom.validation.exists=Custom repository `%s` already exist.

--- a/prospero-cli/src/test/java/org/wildfly/prospero/cli/CliMainTest.java
+++ b/prospero-cli/src/test/java/org/wildfly/prospero/cli/CliMainTest.java
@@ -54,7 +54,7 @@ public class CliMainTest extends AbstractConsoleTest {
     public void errorOnUnknownOperation() {
         int exitCode = commandLine.execute("foo");
         assertEquals(ReturnCodes.INVALID_ARGUMENTS, exitCode);
-        assertTrue(getErrorOutput().contains("Unmatched argument at index 0: 'foo'"));
+        assertTrue(getErrorOutput().contains("Unknown command `" + DistributionInfo.DIST_NAME + " foo`"));
     }
 
 }

--- a/prospero-cli/src/test/java/org/wildfly/prospero/cli/UnknownCommandParameterExceptionHandlerTest.java
+++ b/prospero-cli/src/test/java/org/wildfly/prospero/cli/UnknownCommandParameterExceptionHandlerTest.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright 2023 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.prospero.cli;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import picocli.CommandLine;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+@RunWith(MockitoJUnitRunner.class)
+public class UnknownCommandParameterExceptionHandlerTest {
+
+    @Mock
+    private CommandLine.IParameterExceptionHandler delegate;
+    private ByteArrayOutputStream out;
+    private UnknownCommandParameterExceptionHandler handler;
+
+    @Before
+    public void setUp() {
+        out = new ByteArrayOutputStream();
+        handler = new UnknownCommandParameterExceptionHandler(delegate, new PrintStream(out));
+    }
+
+    @Test
+    public void nonParameterExceptionIsHandledByDelegate() throws Exception {
+        final CommandLine.ParameterException ex = mock(CommandLine.ParameterException.class);
+        final String[] args = {};
+        handler.handleParseException(ex, args);
+
+        verify(delegate).handleParseException(ex, args);
+    }
+
+    @Test
+    public void unmatchedOptionIsPassedToDelegate() throws Exception {
+        final CommandLine.UnmatchedArgumentException ex = new CommandLine.UnmatchedArgumentException(new CommandLine(new TestCommand()), List.of("--boo"));
+        final String[] args = {"--boo"};
+        handler.handleParseException(ex, args);
+
+        verify(delegate).handleParseException(ex, args);
+    }
+
+    @Test
+    public void unmatchedArgumentShowsSuggestion_OneMatched() throws Exception {
+        final CommandLine commandLine = new CommandLine(new RootCommand());
+        commandLine.addSubcommand(new TestCommand());
+        commandLine.getSubcommands().get("test").addSubcommand(new TestSubCommand());
+
+        final CommandLine.UnmatchedArgumentException ex = getException(commandLine, "test", "sup");
+
+        handler.handleParseException(ex, new String[]{"test", "sup"});
+
+        assertThat(out.toString(StandardCharsets.UTF_8))
+                .contains("Unknown command `test sup`")
+                .contains("Did you mean: test sub?");
+    }
+
+    @Test
+    public void unmatchedArgumentShowsSuggestion_MultipleMatched() throws Exception {
+        final CommandLine commandLine = new CommandLine(new RootCommand());
+        commandLine.addSubcommand(new TestCommand());
+        commandLine.getSubcommands().get("test").addSubcommand(new TestSubCommand());
+        commandLine.getSubcommands().get("test").addSubcommand(new TestSubCommandTwo());
+
+
+        final CommandLine.UnmatchedArgumentException ex = getException(commandLine, "test", "sup");
+        handler.handleParseException(ex, new String[]{"test sup"});
+
+        assertThat(out.toString(StandardCharsets.UTF_8))
+                .contains("Unknown command `test sup`")
+                .contains("Did you mean one of: test sub or test sub2?");
+    }
+
+    @Test
+    public void unmatchedArgumentShowsHelp_NoMatched() throws Exception {
+        final CommandLine commandLine = new CommandLine(new RootCommand());
+        commandLine.addSubcommand(new TestCommand());
+        commandLine.getSubcommands().get("test").addSubcommand(new TestSubCommand());
+        commandLine.getSubcommands().get("test").addSubcommand(new TestSubCommandTwo());
+
+        final CommandLine.UnmatchedArgumentException ex = getException(commandLine, "test", "idontexist");
+        final String[] args = {"test", "idontexist"};
+        handler.handleParseException(ex, args);
+
+        assertThat(out.toString(StandardCharsets.UTF_8))
+                .contains("Unknown command `test idontexist`")
+                .contains("Usage: root test [--foo=<option>]")
+                .doesNotContain("Did you mean one of");
+    }
+
+    @Test
+    public void unmatchedArgumentInCommandsWithoutSubcommandsArePassedToDelegate() throws Exception {
+        final CommandLine commandLine = new CommandLine(new RootCommand());
+        commandLine.addSubcommand(new TestCommand());
+        commandLine.getSubcommands().get("test").addSubcommand(new TestSubCommand());
+        commandLine.getSubcommands().get("test").addSubcommand(new TestSubCommandTwo());
+
+        commandLine.getSubcommands().get("test").usage(System.out);
+
+        final CommandLine.UnmatchedArgumentException ex = getException(commandLine, "test", "sub", "idontexist");
+
+        final String[] args = {"test", "sub", "idontexist"};
+        handler.handleParseException(ex, args);
+
+        verify(delegate).handleParseException(ex, args);
+    }
+
+    private static CommandLine.UnmatchedArgumentException getException(CommandLine commandLine, String... args) {
+        final CommandLine.UnmatchedArgumentException ex;
+        try {
+            commandLine.parseArgs(args);
+            throw new RuntimeException("Expecting parse to fail");
+        } catch (CommandLine.UnmatchedArgumentException e) {
+            ex = e;
+        }
+        return ex;
+    }
+
+    @CommandLine.Command(name = "root")
+    private class RootCommand {
+
+    }
+
+    @CommandLine.Command(name = "test")
+    private class TestCommand {
+
+        @CommandLine.Option(names = "--foo")
+        private String option;
+    }
+
+    @CommandLine.Command(name = "sub")
+    private class TestSubCommand {
+
+    }
+
+    @CommandLine.Command(name = "sub2")
+    private class TestSubCommandTwo {
+
+    }
+}


### PR DESCRIPTION
When a fixed position argument is not correct, but a suggested value can be computed a generic error message is shown:

```
prospero.sh revart
Unmatched argument at index 0: 'revart'
Did you mean: ${prospero.dist.name} revert?
```

Two things to notice:

1. Sort of useless "Unmatched argument at index 0: 'revart'" message
2. ${prospero.dist.name} token not replaced



This PR introduces a custom handler for UnmatchedArgumentException that produces a more specific error message ("Unknown command: `revart`, Did you mean ...?") and fixes the MainCommand name
