### PR TITLE
Prevent an error if history contains event of unknown type

### DIFF
--- a/prospero-common/src/main/java/org/wildfly/prospero/api/SavedState.java
+++ b/prospero-common/src/main/java/org/wildfly/prospero/api/SavedState.java
@@ -23,7 +23,17 @@ import java.util.Objects;
 
 public class SavedState {
 
-    public enum Type { UPDATE, INSTALL, ROLLBACK, CONFIG_CHANGE;}
+    public enum Type {
+        UPDATE, INSTALL, ROLLBACK, CONFIG_CHANGE, UNKNOWN;
+        public static Type fromText(String text) {
+            for (Type value : Type.values()) {
+                if (value.name().equals(text)) {
+                    return value;
+                }
+            }
+            return UNKNOWN;
+        }
+    }
 
     private String hash;
     private Instant timestamp;

--- a/prospero-common/src/main/java/org/wildfly/prospero/installation/git/GitStorage.java
+++ b/prospero-common/src/main/java/org/wildfly/prospero/installation/git/GitStorage.java
@@ -81,7 +81,7 @@ public class GitStorage implements AutoCloseable {
                 final String shortMessage = revCommit.getShortMessage().trim();
                 final int endOfTypeIndex = shortMessage.indexOf(' ');
                 final String type;
-                final String msg;
+                String msg;
                 if (endOfTypeIndex < 0) {
                     type = shortMessage;
                     msg = "";
@@ -90,9 +90,13 @@ public class GitStorage implements AutoCloseable {
                     msg = shortMessage.substring(endOfTypeIndex + 1).trim();
 
                 }
+                final SavedState.Type recordType = SavedState.Type.fromText(type.toUpperCase(Locale.ROOT));
+                if (recordType == SavedState.Type.UNKNOWN) {
+                    msg = shortMessage;
+                }
                 history.add(new SavedState(revCommit.getName().substring(0,8),
                         Instant.ofEpochSecond(revCommit.getCommitTime()),
-                        SavedState.Type.valueOf(type.toUpperCase(Locale.ROOT)), msg));
+                        recordType, msg));
             }
 
             return history;


### PR DESCRIPTION
If a new version of Prospero introduced a new history event type, it
should still be possible to use older versions to view history
