### PR TITLE
[JBEAP-25577] maven-assembly-plugin set tarLongFileMode to posix

### DIFF
--- a/dist/docs/pom.xml
+++ b/dist/docs/pom.xml
@@ -65,6 +65,7 @@
               <descriptors>
                 <descriptor>scripts/assembly-docs.xml</descriptor>
               </descriptors>
+              <tarLongFileMode>posix</tarLongFileMode>
             </configuration>
           </execution>
         </executions>


### PR DESCRIPTION
fix "user id '1000620000' is too big ( > 2097151 )"

Upstream: #470
Issue: https://issues.redhat.com/browse/JBEAP-25577
