### PR TITLE
[JBEAP-25910] Check that folder is empty before creating candidate through the API.

### DIFF
--- a/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/AbstractCommand.java
+++ b/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/AbstractCommand.java
@@ -106,7 +106,11 @@ public abstract class AbstractCommand implements Callable<Integer> {
         if (Files.exists(absPath)) {
             return Files.isWritable(absPath);
         } else {
-            return isWritable(absPath.getParent());
+            if (absPath.getParent() == null) {
+                return false;
+            } else {
+                return isWritable(absPath.getParent());
+            }
         }
     }
 }

--- a/prospero-common/src/main/java/org/wildfly/prospero/ProsperoLogger.java
+++ b/prospero-common/src/main/java/org/wildfly/prospero/ProsperoLogger.java
@@ -347,4 +347,7 @@ public interface ProsperoLogger extends BasicLogger {
 
     @Message(id = 259, value = "Requested configuration %s/%s is not available in the feature packs.")
     String galleonConfigNotFound(String model, String name);
+
+    @Message(id = 260, value = "The selected folder %s cannot be created.")
+    IllegalArgumentException dirMustBeWritable(Path directory);
 }

--- a/prospero-common/src/main/java/org/wildfly/prospero/actions/InstallFolderUtils.java
+++ b/prospero-common/src/main/java/org/wildfly/prospero/actions/InstallFolderUtils.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2023 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.prospero.actions;
+
+import org.wildfly.prospero.ProsperoLogger;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+class InstallFolderUtils {
+
+    static void verifyIsWritable(Path directory) {
+        if (!isWritable(directory)) {
+            throw ProsperoLogger.ROOT_LOGGER.dirMustBeWritable(directory);
+        }
+    }
+
+    static void verifyIsEmptyDir(Path directory) {
+        if (directory.toFile().isFile()) {
+            // file exists and is a regular file
+            throw ProsperoLogger.ROOT_LOGGER.dirMustBeDirectory(directory);
+        }
+        if (!isEmptyDirectory(directory)) {
+            throw ProsperoLogger.ROOT_LOGGER.cannotInstallIntoNonEmptyDirectory(directory);
+        }
+    }
+
+    private static boolean isWritable(final Path path) {
+        Path absPath = path.toAbsolutePath();
+        if (Files.exists(absPath)) {
+            return Files.isWritable(absPath);
+        } else {
+            if (absPath.getParent() == null) {
+                return false;
+            } else {
+                return isWritable(absPath.getParent());
+            }
+        }
+    }
+
+    private static boolean isEmptyDirectory(Path directory) {
+        String[] list = directory.toFile().list();
+        return list == null || list.length == 0;
+    }
+}

--- a/prospero-common/src/main/java/org/wildfly/prospero/actions/InstallationHistoryAction.java
+++ b/prospero-common/src/main/java/org/wildfly/prospero/actions/InstallationHistoryAction.java
@@ -92,6 +92,12 @@ public class InstallationHistoryAction {
 
     public void prepareRevert(SavedState savedState, MavenOptions mavenOptions, List<Repository> overrideRepositories, Path targetDir)
             throws OperationException, ProvisioningException {
+        if (Files.exists(targetDir)) {
+            InstallFolderUtils.verifyIsEmptyDir(targetDir);
+        } else {
+            InstallFolderUtils.verifyIsWritable(targetDir);
+        }
+
         try (InstallationMetadata metadata = InstallationMetadata.loadInstallation(installation)) {
             ProsperoLogger.ROOT_LOGGER.revertCandidateStarted(installation);
 

--- a/prospero-common/src/main/java/org/wildfly/prospero/actions/ProvisioningAction.java
+++ b/prospero-common/src/main/java/org/wildfly/prospero/actions/ProvisioningAction.java
@@ -43,6 +43,7 @@ import org.wildfly.prospero.galleon.ChannelMavenArtifactRepositoryManager;
 
 import java.io.IOException;
 import java.net.MalformedURLException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -246,18 +247,11 @@ public class ProvisioningAction {
     }
 
     private static void verifyInstallDir(Path directory) {
-        if (directory.toFile().isFile()) {
-            // file exists and is a regular file
-            throw ProsperoLogger.ROOT_LOGGER.dirMustBeDirectory(directory);
+        if (Files.exists(directory)) {
+            InstallFolderUtils.verifyIsEmptyDir(directory);
+        } else {
+            InstallFolderUtils.verifyIsWritable(directory);
         }
-        if (!isEmptyDirectory(directory)) {
-            throw ProsperoLogger.ROOT_LOGGER.cannotInstallIntoNonEmptyDirectory(directory);
-        }
-    }
-
-    private static boolean isEmptyDirectory(Path directory) {
-        String[] list = directory.toFile().list();
-        return list == null || list.length == 0;
     }
 
     private ArtifactResolutionException wrapAetherException(org.eclipse.aether.resolution.ArtifactResolutionException e) throws ArtifactResolutionException {

--- a/prospero-common/src/main/java/org/wildfly/prospero/actions/UpdateAction.java
+++ b/prospero-common/src/main/java/org/wildfly/prospero/actions/UpdateAction.java
@@ -104,10 +104,17 @@ public class UpdateAction implements AutoCloseable {
      * @throws OperationException
      */
     public boolean buildUpdate(Path targetDir) throws ProvisioningException, OperationException {
+        if (Files.exists(targetDir)) {
+            InstallFolderUtils.verifyIsEmptyDir(targetDir);
+        } else {
+            InstallFolderUtils.verifyIsWritable(targetDir);
+        }
+
         if (findUpdates().isEmpty()) {
             ProsperoLogger.ROOT_LOGGER.noUpdatesFound(installDir);
             return false;
         }
+
         ProsperoLogger.ROOT_LOGGER.updateCandidateStarted(installDir);
         try (PrepareCandidateAction prepareCandidateAction = new PrepareCandidateAction(installDir, mavenSessionManager, prosperoConfig);
              GalleonEnvironment galleonEnv = getGalleonEnv(targetDir)) {


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/JBEAP-25910
Upstream: #482
