### PR TITLE
Update wording of exception when installing server into non-empty folder

### DIFF
--- a/integration-tests/src/test/java/org/wildfly/prospero/it/commonapi/InstallationHistoryActionTest.java
+++ b/integration-tests/src/test/java/org/wildfly/prospero/it/commonapi/InstallationHistoryActionTest.java
@@ -390,7 +390,7 @@ public class InstallationHistoryActionTest extends WfCoreTestBase {
         final SavedState savedState = revisions.get(1);
         assertThatThrownBy(() -> historyAction.prepareRevert(savedState, mavenOptions, Collections.emptyList(), candidate))
                 .isInstanceOf(IllegalArgumentException.class)
-                .message().contains("Can't install into a non empty directory");
+                .message().contains("Can't install the server into a non empty directory");
     }
 
     private UpdateAction updateAction() throws ProvisioningException, OperationException {

--- a/integration-tests/src/test/java/org/wildfly/prospero/it/commonapi/UpdateTest.java
+++ b/integration-tests/src/test/java/org/wildfly/prospero/it/commonapi/UpdateTest.java
@@ -240,7 +240,7 @@ public class UpdateTest extends WfCoreTestBase {
                         List.of(new Repository("temp", tempRepo.toExternalForm())))
                         .buildUpdate(candidateFolder))
                 .isInstanceOf(IllegalArgumentException.class)
-                .message().contains("Can't install into a non empty directory");
+                .message().contains("Can't install the server into a non empty directory");
     }
 
     private File upgradeTestArtifactIn(File manifestFile) throws IOException, MetadataException {

--- a/prospero-common/src/main/java/org/wildfly/prospero/ProsperoLogger.java
+++ b/prospero-common/src/main/java/org/wildfly/prospero/ProsperoLogger.java
@@ -173,7 +173,7 @@ public interface ProsperoLogger extends BasicLogger {
     @Message(id = 202, value = "Invalid channel manifest definition")
     ChannelDefinitionException invalidManifest(@Cause InvalidChannelMetadataException e);
 
-    @Message(id = 203, value = "Can't install into a non empty directory '%s'. Use `update` command if you want to modify existing installation.")
+    @Message(id = 203, value = "Can't install the server into a non empty directory '%s'.")
     IllegalArgumentException cannotInstallIntoNonEmptyDirectory(Path path);
 
     @Message(id = 204, value = "Installation dir '%s' doesn't exist")


### PR DESCRIPTION
Followup on #483

Issue: https://issues.redhat.com/browse/JBEAP-25910
