### PR TITLE
Remove dist-common module from dependencies included in standalone FP

### DIFF
--- a/dist/common/pom.xml
+++ b/dist/common/pom.xml
@@ -7,7 +7,7 @@
 
   <modelVersion>4.0.0</modelVersion>
   <artifactId>prospero-dist-common</artifactId>
-  <packaging>jar</packaging>
+  <packaging>pom</packaging>
 
   <properties>
       <prospero.script.path>packages/org.jboss.prospero/content/bin/</prospero.script.path>
@@ -39,10 +39,38 @@
             </resource>
         </resources>
         <plugins>
+        <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-resources-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>copy-sources</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>copy-resources</goal>
+                        </goals>
+                        <configuration>
+                            <resources>
+                                <resource>
+                                  <directory>${project.basedir}/src/main/resources</directory>
+                                </resource>
+                            </resources>
+                            <outputDirectory>${project.build.outputDirectory}</outputDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-antrun-plugin</artifactId>
                 <executions>
+                    <execution>
+                        <id>copy-sources</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                    </execution>
                     <execution>
                         <id>generate-sources</id>
                         <phase>compile</phase>
@@ -57,30 +85,6 @@
                         <goals>
                             <goal>run</goal>
                         </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-assembly-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>assemble</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>single</goal>
-                        </goals>
-                        <configuration>
-                            <descriptors>
-                                <descriptor>assembly.xml</descriptor>
-                            </descriptors>
-                            <recompressZippedFiles>true</recompressZippedFiles>
-                            <finalName>${project.build.finalName}</finalName>
-                            <appendAssemblyId>false</appendAssemblyId>
-                            <outputDirectory>${project.build.directory}</outputDirectory>
-                            <workDirectory>${project.build.directory}/assembly/work</workDirectory>
-                            <tarLongFileMode>posix</tarLongFileMode>
-                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -30,6 +30,7 @@
             <dependency>
                 <groupId>org.wildfly.prospero</groupId>
                 <artifactId>prospero-dist-common</artifactId>
+                <type>pom</type>
                 <version>${project.version}</version>
             </dependency>
             <dependency>

--- a/dist/standalone-galleon-pack/pom.xml
+++ b/dist/standalone-galleon-pack/pom.xml
@@ -54,6 +54,7 @@
         <dependency>
             <groupId>org.wildfly.prospero</groupId>
             <artifactId>prospero-dist-common</artifactId>
+            <type>pom</type>
             <scope>provided</scope>
             <exclusions>
                 <exclusion>
@@ -512,17 +513,6 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
             <scope>provided</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-
-        <dependency>
-            <groupId>org.wildfly.galleon-plugins</groupId>
-            <artifactId>wildfly-config-gen</artifactId>
             <exclusions>
                 <exclusion>
                     <groupId>*</groupId>

--- a/dist/wildfly-galleon-pack/pom.xml
+++ b/dist/wildfly-galleon-pack/pom.xml
@@ -59,6 +59,7 @@
     <dependency>
       <groupId>org.wildfly.prospero</groupId>
       <artifactId>prospero-dist-common</artifactId>
+      <type>pom</type>
       <scope>provided</scope>
       <exclusions>
         <exclusion>


### PR DESCRIPTION
Prevent the prospero-dist-common jar appearing in manifest

The prospero-dist-common module holds some common configuration for generated feature packs and is not needed at runtime
