### PR TITLE
Correct license for jcl-over-slf4j

### DIFF
--- a/dist/common/src/main/licenses/licenses.xml
+++ b/dist/common/src/main/licenses/licenses.xml
@@ -407,8 +407,8 @@
             <artifactId>jcl-over-slf4j</artifactId>
             <licenses>
                 <license>
-                    <name>Apache License 2.0</name>
-                    <url>http://www.apache.org/licenses/LICENSE-2.0</url>
+                    <name>MIT License</name>
+                    <url>http://www.opensource.org/licenses/MIT</url>
                     <distribution>repo</distribution>
                 </license>
             </licenses>


### PR DESCRIPTION
- Correct license for jcl-over-slf4j
