### PR TITLE
Use GAV in prospero's feature pack dependencies

### DIFF
--- a/dist/wildfly-galleon-pack/src/main/config/wildfly-user-feature-pack-build.xml
+++ b/dist/wildfly-galleon-pack/src/main/config/wildfly-user-feature-pack-build.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<build xmlns="urn:wildfly:feature-pack-build:3.0" producer="org.wildfly.prospero:prospero-wildfly-galleon-pack">
+<build xmlns="urn:wildfly:feature-pack-build:3.2" producer="org.wildfly.prospero:prospero-wildfly-galleon-pack">
   <dependencies>
     <dependency group-id="${prospero.base.feature-pack.groupId}" artifact-id="${prospero.base.feature-pack.artifactId}">
       <packages inherit="true"/>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
         <prospero.target.server>Wildfly</prospero.target.server>
         <prospero.base.feature-pack.groupId>org.wildfly</prospero.base.feature-pack.groupId>
         <prospero.base.feature-pack.artifactId>wildfly-ee-galleon-pack</prospero.base.feature-pack.artifactId>
-        <prospero.base.feature-pack.version>26.1.0.Final</prospero.base.feature-pack.version>
+        <prospero.base.feature-pack.version>30.0.0.Final</prospero.base.feature-pack.version>
         <prospero.test.base.channel.groupId>org.wildfly.channels</prospero.test.base.channel.groupId>
         <prospero.test.base.channel.artifactId>wildfly-28-test</prospero.test.base.channel.artifactId>
         <prospero.test.base.repositories>https://repo1.maven.org/maven2/,https://repository.jboss.org/nexus/content/groups/public/</prospero.test.base.repositories>


### PR DESCRIPTION
Updating schema of the feature pack build definition to use GAV in dependencies instead of Maven universe
