### PR TITLE
[JBEAP-25770] Use linux file separator in the cache folder path

### DIFF
--- a/integration-tests/src/test/java/org/wildfly/prospero/it/commonapi/SimpleProvisionTest.java
+++ b/integration-tests/src/test/java/org/wildfly/prospero/it/commonapi/SimpleProvisionTest.java
@@ -87,8 +87,12 @@ public class SimpleProvisionTest extends WfCoreTestBase {
                 .containsExactly(MetadataTestUtils.class.getClassLoader().getResource(CHANNEL_BASE_CORE_19).toExternalForm());
 
         // verify the provisioning.xml was recorded in the .installation folder
-        assertThat(outputPath.resolve(ProsperoMetadataUtils.METADATA_DIR).resolve(ProsperoMetadataUtils.PROVISIONING_RECORD_XML))
+        final Path provisioningRecordFile = outputPath.resolve(ProsperoMetadataUtils.METADATA_DIR).resolve(ProsperoMetadataUtils.PROVISIONING_RECORD_XML);
+        assertThat(provisioningRecordFile)
                 .hasSameTextualContentAs(PathsUtils.getProvisioningXml(outputPath));
+        // verify the cache dir always uses linux file separator
+        assertThat(Files.readString(provisioningRecordFile))
+                .contains(String.format("<option name=\"jboss-resolved-artifacts-cache\" value=\"%s/%s\"/>", ProsperoMetadataUtils.METADATA_DIR, ".cache"));
     }
 
     @Test

--- a/prospero-common/src/main/java/org/wildfly/prospero/galleon/GalleonUtils.java
+++ b/prospero-common/src/main/java/org/wildfly/prospero/galleon/GalleonUtils.java
@@ -34,6 +34,7 @@ import org.jboss.logging.Logger;
 import org.wildfly.channel.UnresolvedMavenArtifactException;
 import org.wildfly.prospero.ProsperoLogger;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -65,7 +66,7 @@ public class GalleonUtils {
     public static final String STORE_INPUT_PROVISIONING_CONFIG_PROPERTY = "store-input-provisioning-config";
     public static final String STORE_INPUT_PROVISIONING_CONFIG_VALUE = "true";
     public static final String STORE_PROVISIONED_ARTIFACTS = "jboss-resolved-artifacts-cache";
-    public static final String STORE_PROVISIONED_ARTIFACTS_VALUE = ArtifactCache.CACHE_FOLDER.toString();
+    public static final String STORE_PROVISIONED_ARTIFACTS_VALUE = ArtifactCache.CACHE_FOLDER.toString().replace(File.separatorChar, '/');
 
     private static final String CLASSPATH_SCHEME = "classpath";
     private static final String FILE_SCHEME = "file";


### PR DESCRIPTION
When provisioning on Windows, the recorded path of the cache folder uses Windows file separator. That makes it not portable to Linux. Instead always use linux file separator.
