### PR TITLE
If the provisioning configuration is the same as saved copy, the file is not overwritten (fix duplicate code)

### DIFF
--- a/prospero-metadata/src/main/java/org/wildfly/prospero/metadata/ProsperoMetadataUtils.java
+++ b/prospero-metadata/src/main/java/org/wildfly/prospero/metadata/ProsperoMetadataUtils.java
@@ -23,6 +23,7 @@ import org.wildfly.channel.ChannelManifest;
 import org.wildfly.channel.ChannelManifestMapper;
 import org.wildfly.channel.ChannelMapper;
 
+import java.io.BufferedReader;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -206,12 +207,30 @@ public class ProsperoMetadataUtils {
             final String content = Files.readString(provisioningFile);
             final String lineEndings = content.replaceAll("\\r\\n?", "\n");
             Files.writeString(provisioningRecordFile, lineEndings);
-        } else {
+        } else if (!isFileContentEquals(provisioningFile, provisioningRecordFile)) {
             final String content = Files.readString(provisioningFile);
             final String lineEndings = content.replaceAll("\\r\\n?", "\n");
             Files.writeString(provisioningRecordFile, lineEndings);
         }
 
+    }
+
+    static boolean isFileContentEquals(Path path1, Path path2) throws IOException {
+        try (BufferedReader bf1 = Files.newBufferedReader(path1);
+             BufferedReader bf2 = Files.newBufferedReader(path2)) {
+            String line1 = "", line2 = "";
+            while ((line1 = bf1.readLine()) != null) {
+                line2 = bf2.readLine();
+                if (!line1.equals(line2)) {
+                    return false;
+                }
+            }
+            if (bf2.readLine() == null) {
+                return true;
+            } else {
+                return false;
+            }
+        }
     }
 
     protected static void writeToFile(Path path, String text) throws IOException {

--- a/prospero-metadata/src/test/java/org/wildfly/prospero/metadata/ProsperoMetadataUtilsTest.java
+++ b/prospero-metadata/src/test/java/org/wildfly/prospero/metadata/ProsperoMetadataUtilsTest.java
@@ -132,6 +132,19 @@ public class ProsperoMetadataUtilsTest {
                 .hasContent("<provisioning></provisioning>");
     }
 
+    @Test
+    public void overrideProvisioningConfigurationIfContentNotEquals() throws Exception {
+        Files.createDirectory(server.resolve(Constants.PROVISIONED_STATE_DIR));
+        Files.writeString(server.resolve(Constants.PROVISIONED_STATE_DIR).resolve(Constants.PROVISIONING_XML), "<provisioning></provisioning>");
+        Files.createDirectory(server.resolve(METADATA_DIR));
+        Files.writeString(server.resolve(METADATA_DIR).resolve(PROVISIONING_RECORD_XML), "<provisioning>content</provisioning>");
+
+        ProsperoMetadataUtils.generate(server, List.of(A_CHANNEL), A_MANIFEST, null);
+
+        Assertions.assertThat(server.resolve(METADATA_DIR).resolve(PROVISIONING_RECORD_XML))
+                .hasContent("<provisioning></provisioning>");
+    }
+
     private void assertMetadataWritten() throws MalformedURLException {
         final Channel channel = ChannelMapper.from(channelPath.toUri().toURL());
         final ChannelManifest manifest = ChannelManifestMapper.from(manifestPath.toUri().toURL());


### PR DESCRIPTION
The Java doc on the method says it should be `If the provisioning configuration is the same as saved copy, the file is not overwritten.`

This is for 1.1.x code before the `prospero-metadata` split

Upstream PR: https://github.com/wildfly-extras/prospero-metadata/pull/11
