### PR TITLE
[JBEAP-26535] Prevent prospero WF feature pack from inheriting configs

### DIFF
--- a/dist/wildfly-galleon-pack/src/main/config/wildfly-user-feature-pack-build.xml
+++ b/dist/wildfly-galleon-pack/src/main/config/wildfly-user-feature-pack-build.xml
@@ -26,6 +26,7 @@
   <dependencies>
     <dependency group-id="${prospero.base.feature-pack.groupId}" artifact-id="${prospero.base.feature-pack.artifactId}">
       <packages inherit="true"/>
+      <default-configs inherit="false"/>
     </dependency>
   </dependencies>
   <default-packages>


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/JBEAP-26535

@jfdenise could you take a look at this? Are there any issues with not inheriting the default configuration in prospero galleon feature pack?