### PR TITLE
[JBEAP-24913, #580] Add the --rm option to the SPI apply update and revert commands

### DIFF
--- a/integration-tests/src/test/java/org/wildfly/prospero/it/installationmanager/CreateSnapshotTest.java
+++ b/integration-tests/src/test/java/org/wildfly/prospero/it/installationmanager/CreateSnapshotTest.java
@@ -84,6 +84,8 @@ public class CreateSnapshotTest extends WfCoreTestBase {
         expected.append(CliConstants.CANDIDATE_DIR).append(" \"").append(Path.of("foo").toAbsolutePath()).append("\"");
         expected.append(" ");
         expected.append(CliConstants.YES);
+        expected.append(" ");
+        expected.append(CliConstants.REMOVE);
 
         final ProvisioningDefinition provisioningDefinition = defaultWfCoreDefinition()
                 .setChannelCoordinates(channelsFile.toString())
@@ -115,6 +117,8 @@ public class CreateSnapshotTest extends WfCoreTestBase {
         expected.append(CliConstants.CANDIDATE_DIR).append(" \"").append(Path.of("foo").toAbsolutePath()).append("\"");
         expected.append(" ");
         expected.append(CliConstants.YES);
+        expected.append(" ");
+        expected.append(CliConstants.REMOVE);
 
         final ProvisioningDefinition provisioningDefinition = defaultWfCoreDefinition()
                 .setChannelCoordinates(channelsFile.toString())

--- a/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/CliConstants.java
+++ b/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/CliConstants.java
@@ -106,4 +106,6 @@ public final class CliConstants {
 
     public static final String LAYERS = "--layers";
     public static final String TARGET_CONFIG = "--target-config";
+    public static final String REMOVE = "--rm";
+    public static final String SKIP_CONFLICTS = "--y";
 }

--- a/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/RevertCommand.java
+++ b/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/RevertCommand.java
@@ -139,6 +139,9 @@ public class RevertCommand extends AbstractParentCommand {
         @CommandLine.Option(names = CliConstants.CANDIDATE_DIR, required = true)
         Path candidateDirectory;
 
+        @CommandLine.Option(names = CliConstants.REMOVE)
+        boolean remove;
+
         @CommandLine.Option(names = {CliConstants.Y, CliConstants.YES})
         boolean yes;
 
@@ -160,6 +163,7 @@ public class RevertCommand extends AbstractParentCommand {
             applyCandidate(console, applyCandidateAction, yes);
             final float totalTime = (System.currentTimeMillis() - startTime) / 1000f;
             console.println(CliMessages.MESSAGES.operationCompleted(totalTime));
+            applyCandidateAction.removeUpdateCandidate(remove);
             return SUCCESS;
         }
     }

--- a/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/UpdateCommand.java
+++ b/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/UpdateCommand.java
@@ -192,6 +192,12 @@ public class UpdateCommand extends AbstractParentCommand {
         @CommandLine.Option(names = CliConstants.CANDIDATE_DIR, required = true)
         Path candidateDir;
 
+        @CommandLine.Option(names = CliConstants.REMOVE)
+        boolean remove;
+
+        @CommandLine.Option(names = CliConstants.SKIP_CONFLICTS)
+        boolean skipConflicts;
+
         @CommandLine.Option(names = {CliConstants.Y, CliConstants.YES})
         boolean yes;
 
@@ -221,8 +227,10 @@ public class UpdateCommand extends AbstractParentCommand {
             }
 
             console.updatesFound(applyCandidateAction.findUpdates().getArtifactUpdates());
-            final List<FileConflict> conflicts = applyCandidateAction.getConflicts();
-            FileConflictPrinter.print(conflicts, console);
+            if(!skipConflicts) {
+                final List<FileConflict> conflicts = applyCandidateAction.getConflicts();
+                FileConflictPrinter.print(conflicts, console);
+            }
 
             // there always should be updates, so confirm update
             if (!yes && !console.confirm(CliMessages.MESSAGES.continueWithUpdate(), CliMessages.MESSAGES.applyingUpdates(), CliMessages.MESSAGES.updateCancelled())) {
@@ -235,6 +243,7 @@ public class UpdateCommand extends AbstractParentCommand {
 
             final float totalTime = (System.currentTimeMillis() - startTime) / 1000f;
             console.println(CliMessages.MESSAGES.operationCompleted(totalTime));
+            applyCandidateAction.removeUpdateCandidate(remove);
 
             return ReturnCodes.SUCCESS;
         }

--- a/prospero-cli/src/main/java/org/wildfly/prospero/cli/spi/CliProviderImpl.java
+++ b/prospero-cli/src/main/java/org/wildfly/prospero/cli/spi/CliProviderImpl.java
@@ -53,7 +53,8 @@ public class CliProviderImpl implements CliProvider {
         return CliConstants.Commands.UPDATE + " " + CliConstants.Commands.APPLY + " "
                 + CliConstants.DIR + " " + escape(installationPath.toAbsolutePath()) + " "
                 + CliConstants.CANDIDATE_DIR + " " + escape(candidatePath.toAbsolutePath()) + " "
-                + CliConstants.YES;
+                + CliConstants.YES + " "
+                + CliConstants.REMOVE;
     }
 
     @Override
@@ -61,7 +62,8 @@ public class CliProviderImpl implements CliProvider {
         return CliConstants.Commands.REVERT + " " + CliConstants.Commands.APPLY + " "
                 + CliConstants.DIR + " " + escape(installationPath.toAbsolutePath()) + " "
                 + CliConstants.CANDIDATE_DIR + " " + escape(candidatePath.toAbsolutePath()) + " "
-                + CliConstants.YES;
+                + CliConstants.YES + " "
+                + CliConstants.REMOVE;
     }
 
     private String escape(Path absolutePath) {

--- a/prospero-common/src/main/java/org/wildfly/prospero/actions/ApplyCandidateAction.java
+++ b/prospero-common/src/main/java/org/wildfly/prospero/actions/ApplyCandidateAction.java
@@ -244,6 +244,22 @@ public class ApplyCandidateAction {
         }
     }
 
+    public void removeUpdateCandidate(boolean remove){
+        if (remove){
+            removeCandidate(updateDir.toFile());
+        }
+    }
+
+     boolean removeCandidate(File updateDir) {
+        File[] allContents = updateDir.listFiles();
+        if (allContents != null) {
+            for (File file : allContents) {
+                removeCandidate(file);
+            }
+        }
+        return updateDir.delete();
+    }
+
     /**
      * list artifacts changed between base and candidate servers.
      *
@@ -682,6 +698,8 @@ public class ApplyCandidateAction {
         }
         return pathKey;
     }
+
+
 
     private static void glnew(final Path updateFile, Path installationFile) throws ProvisioningException {
         try {


### PR DESCRIPTION
Builds on top of #579

Add the --rm option to get SPI generated commands

Upstream: #582
Issue: https://issues.redhat.com/browse/JBEAP-24913