### PR TITLE
Support repository archives in override repositories

### DIFF
--- a/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/FeaturesCommand.java
+++ b/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/FeaturesCommand.java
@@ -21,11 +21,13 @@ import org.jboss.galleon.config.ConfigId;
 import org.wildfly.channel.Repository;
 import org.wildfly.prospero.actions.FeaturesAddAction;
 import org.wildfly.prospero.api.MavenOptions;
+import org.wildfly.prospero.api.RepositoryUtils;
 import org.wildfly.prospero.cli.ActionFactory;
 import org.wildfly.prospero.cli.CliConsole;
 import org.wildfly.prospero.cli.CliMessages;
 import org.wildfly.prospero.cli.RepositoryDefinition;
 import org.wildfly.prospero.cli.ReturnCodes;
+import org.wildfly.prospero.api.TemporaryFilesManager;
 import picocli.CommandLine;
 
 import java.nio.file.Path;
@@ -72,50 +74,53 @@ public class FeaturesCommand extends AbstractParentCommand {
 
             final MavenOptions mavenOptions = parseMavenOptions();
 
-            final List<Repository> repositories = RepositoryDefinition.from(temporaryRepositories);
+            try (TemporaryFilesManager temporaryFiles = TemporaryFilesManager.getInstance()) {
+                final List<Repository> repositories = RepositoryUtils.unzipArchives(
+                        RepositoryDefinition.from(temporaryRepositories), temporaryFiles);
 
-            console.println(CliMessages.MESSAGES.featuresAddHeader(fpl, installationDir));
+                console.println(CliMessages.MESSAGES.featuresAddHeader(fpl, installationDir));
 
-            final FeaturesAddAction featuresAddAction = actionFactory.featuresAddAction(installationDir, mavenOptions, repositories, console);
+                final FeaturesAddAction featuresAddAction = actionFactory.featuresAddAction(installationDir, mavenOptions, repositories, console);
 
-            if (!featuresAddAction.isFeaturePackAvailable(fpl)) {
-                console.error(CliMessages.MESSAGES.featurePackNotFound(fpl));
-                return ReturnCodes.INVALID_ARGUMENTS;
-            }
-
-            final boolean accepted;
-            if (!skipConfirmation) {
-                accepted = console.confirm(CliMessages.MESSAGES.featuresAddPrompt(),
-                        CliMessages.MESSAGES.featuresAddPromptAccepted(),
-                        CliMessages.MESSAGES.featuresAddPromptCancelled());
-            } else {
-                console.println(CliMessages.MESSAGES.featuresAddPromptAccepted());
-                accepted = true;
-            }
-
-            if(accepted) {
-                try {
-                    featuresAddAction.addFeaturePackWithLayers(fpl, layers, parseConfigName(config));
-                } catch (FeaturesAddAction.LayerNotFoundException e) {
-                    if (!e.getSupportedLayers().isEmpty()) {
-                        console.error(CliMessages.MESSAGES.layerNotSupported(fpl, e.getLayers(), e.getSupportedLayers()));
-                    } else {
-                        console.error(CliMessages.MESSAGES.layerNotSupported(fpl));
-                    }
-                    return ReturnCodes.INVALID_ARGUMENTS;
-                } catch (FeaturesAddAction.ModelNotDefinedException e) {
-                    console.error(CliMessages.MESSAGES.modelNotSupported(fpl, e.getModel(), e.getSupportedModels()));
-                    return ReturnCodes.INVALID_ARGUMENTS;
-                } catch (FeaturesAddAction.ConfigurationNotFoundException e) {
-                    console.error(CliMessages.MESSAGES.galleonConfigNotSupported(fpl, e.getModel(), e.getName()));
+                if (!featuresAddAction.isFeaturePackAvailable(fpl)) {
+                    console.error(CliMessages.MESSAGES.featurePackNotFound(fpl));
                     return ReturnCodes.INVALID_ARGUMENTS;
                 }
+
+                final boolean accepted;
+                if (!skipConfirmation) {
+                    accepted = console.confirm(CliMessages.MESSAGES.featuresAddPrompt(),
+                            CliMessages.MESSAGES.featuresAddPromptAccepted(),
+                            CliMessages.MESSAGES.featuresAddPromptCancelled());
+                } else {
+                    console.println(CliMessages.MESSAGES.featuresAddPromptAccepted());
+                    accepted = true;
+                }
+
+                if (accepted) {
+                    try {
+                        featuresAddAction.addFeaturePackWithLayers(fpl, layers, parseConfigName(config));
+                    } catch (FeaturesAddAction.LayerNotFoundException e) {
+                        if (!e.getSupportedLayers().isEmpty()) {
+                            console.error(CliMessages.MESSAGES.layerNotSupported(fpl, e.getLayers(), e.getSupportedLayers()));
+                        } else {
+                            console.error(CliMessages.MESSAGES.layerNotSupported(fpl));
+                        }
+                        return ReturnCodes.INVALID_ARGUMENTS;
+                    } catch (FeaturesAddAction.ModelNotDefinedException e) {
+                        console.error(CliMessages.MESSAGES.modelNotSupported(fpl, e.getModel(), e.getSupportedModels()));
+                        return ReturnCodes.INVALID_ARGUMENTS;
+                    } catch (FeaturesAddAction.ConfigurationNotFoundException e) {
+                        console.error(CliMessages.MESSAGES.galleonConfigNotSupported(fpl, e.getModel(), e.getName()));
+                        return ReturnCodes.INVALID_ARGUMENTS;
+                    }
+                }
+
+                final float totalTime = (System.currentTimeMillis() - startTime) / 1000f;
+                console.println(CliMessages.MESSAGES.operationCompleted(totalTime));
+
+                return ReturnCodes.SUCCESS;
             }
-
-            final float totalTime = (System.currentTimeMillis() - startTime) / 1000f;
-            console.println(CliMessages.MESSAGES.operationCompleted(totalTime));
-
-            return ReturnCodes.SUCCESS;
         }
 
         private static ConfigId parseConfigName(String config) {

--- a/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/InstallCommand.java
+++ b/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/InstallCommand.java
@@ -38,6 +38,7 @@ import org.wildfly.prospero.api.ArtifactUtils;
 import org.wildfly.prospero.api.KnownFeaturePacks;
 import org.wildfly.prospero.api.MavenOptions;
 import org.wildfly.prospero.api.ProvisioningDefinition;
+import org.wildfly.prospero.api.RepositoryUtils;
 import org.wildfly.prospero.api.TemporaryRepositoriesHandler;
 import org.wildfly.prospero.cli.ActionFactory;
 import org.wildfly.prospero.cli.ArgumentParsingException;
@@ -46,6 +47,7 @@ import org.wildfly.prospero.cli.CliMessages;
 import org.wildfly.prospero.cli.LicensePrinter;
 import org.wildfly.prospero.cli.RepositoryDefinition;
 import org.wildfly.prospero.cli.ReturnCodes;
+import org.wildfly.prospero.api.TemporaryFilesManager;
 import org.wildfly.prospero.cli.commands.options.FeaturePackCandidates;
 import org.wildfly.prospero.cli.printers.ChannelPrinter;
 import org.wildfly.prospero.licenses.License;
@@ -174,52 +176,56 @@ public class InstallCommand extends AbstractInstallCommand {
         final MavenOptions mavenOptions = getMavenOptions();
         final GalleonProvisioningConfig provisioningConfig = provisioningDefinition.toProvisioningConfig();
         final List<Channel> channels = resolveChannels(provisioningDefinition, mavenOptions);
-        final List<Repository> shadowRepositories = RepositoryDefinition.from(this.shadowRepositories);
+        try (TemporaryFilesManager temporaryFiles = TemporaryFilesManager.getInstance()) {
+            List<Repository> repositories = RepositoryDefinition.from(this.shadowRepositories);
+            final List<Repository> shadowRepositories = RepositoryUtils.unzipArchives(repositories, temporaryFiles);
 
-        final ProvisioningAction provisioningAction = actionFactory.install(directory.toAbsolutePath(), mavenOptions,
-                console);
+            final ProvisioningAction provisioningAction = actionFactory.install(directory.toAbsolutePath(), mavenOptions,
+                    console);
 
-        if (featurePackOrDefinition.fpl.isPresent()) {
-            console.println(CliMessages.MESSAGES.installingFpl(featurePackOrDefinition.fpl.get()));
-        } else if (featurePackOrDefinition.profile.isPresent()) {
-            console.println(CliMessages.MESSAGES.installingProfile(featurePackOrDefinition.profile.get()));
-        } else if (featurePackOrDefinition.definition.isPresent()) {
-            console.println(CliMessages.MESSAGES.installingDefinition(featurePackOrDefinition.definition.get()));
-        }
+            if (featurePackOrDefinition.fpl.isPresent()) {
+                console.println(CliMessages.MESSAGES.installingFpl(featurePackOrDefinition.fpl.get()));
+            } else if (featurePackOrDefinition.profile.isPresent()) {
+                console.println(CliMessages.MESSAGES.installingProfile(featurePackOrDefinition.profile.get()));
+            } else if (featurePackOrDefinition.definition.isPresent()) {
+                console.println(CliMessages.MESSAGES.installingDefinition(featurePackOrDefinition.definition.get()));
+            }
 
-        final List<Channel> effectiveChannels = TemporaryRepositoriesHandler.overrideRepositories(channels, shadowRepositories);
-        console.println(CliMessages.MESSAGES.usingChannels());
-        final ChannelPrinter channelPrinter = new ChannelPrinter(console);
-        for (Channel channel : effectiveChannels) {
-            channelPrinter.print(channel);
-        }
 
-        console.println("");
+            final List<Channel> effectiveChannels = TemporaryRepositoriesHandler.overrideRepositories(channels, shadowRepositories);
+            console.println(CliMessages.MESSAGES.usingChannels());
+            final ChannelPrinter channelPrinter = new ChannelPrinter(console);
+            for (Channel channel : effectiveChannels) {
+                channelPrinter.print(channel);
+            }
 
-        final List<License> pendingLicenses = provisioningAction.getPendingLicenses(provisioningConfig,
-                effectiveChannels);
-        if (!pendingLicenses.isEmpty()) {
-            new LicensePrinter().print(pendingLicenses);
-            System.out.println();
-            if (acceptAgreements) {
-                System.out.println(CliMessages.MESSAGES.agreementSkipped(CliConstants.ACCEPT_AGREEMENTS));
+            console.println("");
+
+            final List<License> pendingLicenses = provisioningAction.getPendingLicenses(provisioningConfig,
+                    effectiveChannels);
+            if (!pendingLicenses.isEmpty()) {
+                new LicensePrinter().print(pendingLicenses);
                 System.out.println();
-            } else {
-                if (!console.confirm(CliMessages.MESSAGES.acceptAgreements(), "", CliMessages.MESSAGES.installationCancelled())) {
-                    return ReturnCodes.PROCESSING_ERROR;
+                if (acceptAgreements) {
+                    System.out.println(CliMessages.MESSAGES.agreementSkipped(CliConstants.ACCEPT_AGREEMENTS));
+                    System.out.println();
+                } else {
+                    if (!console.confirm(CliMessages.MESSAGES.acceptAgreements(), "", CliMessages.MESSAGES.installationCancelled())) {
+                        return ReturnCodes.PROCESSING_ERROR;
+                    }
                 }
             }
+
+            provisioningAction.provision(provisioningConfig, channels, shadowRepositories);
+
+            console.println("");
+            console.println(CliMessages.MESSAGES.installComplete(directory));
+
+            final float totalTime = (System.currentTimeMillis() - startTime) / 1000f;
+            console.println(CliMessages.MESSAGES.operationCompleted(totalTime));
+
+            return ReturnCodes.SUCCESS;
         }
-
-        provisioningAction.provision(provisioningConfig, channels, shadowRepositories);
-
-        console.println("");
-        console.println(CliMessages.MESSAGES.installComplete(directory));
-
-        final float totalTime = (System.currentTimeMillis() - startTime) / 1000f;
-        console.println(CliMessages.MESSAGES.operationCompleted(totalTime));
-
-        return ReturnCodes.SUCCESS;
     }
 
     private void checkFileExists(URL resourceUrl, String argValue) throws ArgumentParsingException {

--- a/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/UpdateCommand.java
+++ b/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/UpdateCommand.java
@@ -47,6 +47,7 @@ import org.wildfly.prospero.api.FileConflict;
 import org.wildfly.prospero.api.InstallationMetadata;
 import org.wildfly.prospero.api.KnownFeaturePacks;
 import org.wildfly.prospero.api.MavenOptions;
+import org.wildfly.prospero.api.RepositoryUtils;
 import org.wildfly.prospero.api.exceptions.OperationException;
 import org.wildfly.prospero.cli.ActionFactory;
 import org.wildfly.prospero.cli.ArgumentParsingException;
@@ -56,6 +57,7 @@ import org.wildfly.prospero.cli.DistributionInfo;
 import org.wildfly.prospero.cli.FileConflictPrinter;
 import org.wildfly.prospero.cli.RepositoryDefinition;
 import org.wildfly.prospero.cli.ReturnCodes;
+import org.wildfly.prospero.api.TemporaryFilesManager;
 import org.wildfly.prospero.galleon.FeaturePackLocationParser;
 import org.wildfly.prospero.galleon.GalleonUtils;
 import org.wildfly.prospero.metadata.ProsperoMetadataUtils;
@@ -108,14 +110,17 @@ public class UpdateCommand extends AbstractParentCommand {
             }
 
             final MavenOptions mavenOptions = parseMavenOptions();
-            final List<Repository> repositories = RepositoryDefinition.from(temporaryRepositories);
+            try (TemporaryFilesManager temporaryFiles = TemporaryFilesManager.getInstance()) {
+                final List<Repository> repositories = RepositoryUtils.unzipArchives(
+                        RepositoryDefinition.from(temporaryRepositories), temporaryFiles);
 
-            log.tracef("Perform full update");
+                log.tracef("Perform full update");
 
-            console.println(CliMessages.MESSAGES.updateHeader(installationDir));
+                console.println(CliMessages.MESSAGES.updateHeader(installationDir));
 
-            try (UpdateAction updateAction = actionFactory.update(installationDir, mavenOptions, console, repositories)) {
-                performUpdate(updateAction, yes, console, installationDir);
+                try (UpdateAction updateAction = actionFactory.update(installationDir, mavenOptions, console, repositories)) {
+                    performUpdate(updateAction, yes, console, installationDir);
+                }
             }
 
             final float totalTime = (System.currentTimeMillis() - startTime) / 1000f;
@@ -178,21 +183,24 @@ public class UpdateCommand extends AbstractParentCommand {
             final Path installationDir = determineInstallationDirectory(directory);
 
             final MavenOptions mavenOptions = parseMavenOptions();
-            final List<Repository> repositories = RepositoryDefinition.from(temporaryRepositories);
+            try (TemporaryFilesManager temporaryFiles = TemporaryFilesManager.getInstance()) {
+                final List<Repository> repositories = RepositoryUtils.unzipArchives(
+                        RepositoryDefinition.from(temporaryRepositories), temporaryFiles);
 
-            log.tracef("Generate update in %s", candidateDirectory);
+                log.tracef("Generate update in %s", candidateDirectory);
 
-            console.println(CliMessages.MESSAGES.buildUpdateCandidateHeader(installationDir));
+                console.println(CliMessages.MESSAGES.buildUpdateCandidateHeader(installationDir));
 
 
-            verifyTargetDirectoryIsEmpty(candidateDirectory);
+                verifyTargetDirectoryIsEmpty(candidateDirectory);
 
-            try (UpdateAction updateAction = actionFactory.update(installationDir,
-                    mavenOptions, console, repositories)) {
-                if (buildUpdate(updateAction, candidateDirectory, yes, console, ()->console.confirmBuildUpdates())) {
-                    console.println("");
-                    console.buildUpdatesComplete();
-                    console.println(CliMessages.MESSAGES.updateCandidateGenerated(candidateDirectory));
+                try (UpdateAction updateAction = actionFactory.update(installationDir,
+                        mavenOptions, console, repositories)) {
+                    if (buildUpdate(updateAction, candidateDirectory, yes, console, () -> console.confirmBuildUpdates())) {
+                        console.println("");
+                        console.buildUpdatesComplete();
+                        console.println(CliMessages.MESSAGES.updateCandidateGenerated(candidateDirectory));
+                    }
                 }
             }
 
@@ -278,12 +286,15 @@ public class UpdateCommand extends AbstractParentCommand {
             final Path installationDir = determineInstallationDirectory(directory);
 
             final MavenOptions mavenOptions = parseMavenOptions();
-            final List<Repository> repositories = RepositoryDefinition.from(temporaryRepositories);
 
-            console.println(CliMessages.MESSAGES.checkUpdatesHeader(installationDir));
-            try (UpdateAction updateAction = actionFactory.update(installationDir, mavenOptions, console, repositories)) {
-                final UpdateSet updateSet = updateAction.findUpdates();
-                console.updatesFound(updateSet.getArtifactUpdates());
+            try (TemporaryFilesManager temporaryFiles = TemporaryFilesManager.getInstance()) {
+                final List<Repository> repositories = RepositoryUtils.unzipArchives(
+                        RepositoryDefinition.from(temporaryRepositories), temporaryFiles);
+                console.println(CliMessages.MESSAGES.checkUpdatesHeader(installationDir));
+                try (UpdateAction updateAction = actionFactory.update(installationDir, mavenOptions, console, repositories)) {
+                    final UpdateSet updateSet = updateAction.findUpdates();
+                    console.updatesFound(updateSet.getArtifactUpdates());
+                }
 
                 final float totalTime = (System.currentTimeMillis() - startTime) / 1000f;
                 console.println("");

--- a/prospero-common/pom.xml
+++ b/prospero-common/pom.xml
@@ -108,6 +108,11 @@
         </dependency>
 
         <dependency>
+            <groupId>io.undertow</groupId>
+            <artifactId>undertow-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>

--- a/prospero-common/src/main/java/org/wildfly/prospero/ProsperoLogger.java
+++ b/prospero-common/src/main/java/org/wildfly/prospero/ProsperoLogger.java
@@ -29,6 +29,7 @@ import org.wildfly.channel.InvalidChannelMetadataException;
 import org.wildfly.prospero.actions.FeaturesAddAction;
 import org.wildfly.prospero.api.exceptions.ArtifactPromoteException;
 import org.wildfly.prospero.api.exceptions.ChannelDefinitionException;
+import org.wildfly.prospero.api.exceptions.InvalidRepositoryArchiveException;
 import org.wildfly.prospero.api.exceptions.InvalidUpdateCandidateException;
 import org.wildfly.prospero.api.exceptions.MetadataException;
 import org.wildfly.prospero.api.exceptions.NoChannelException;
@@ -369,4 +370,10 @@ public interface ProsperoLogger extends BasicLogger {
 
     @Message(id = 265, value = "Unable to create temporary file")
     ProvisioningException unableToCreateTemporaryFile(@Cause Throwable t);
+
+    @Message(id = 266, value = "Unable to extract the repository archive %s.")
+    InvalidRepositoryArchiveException unableToExtractRepositoryArchive(String archiveUrl, @Cause Throwable t);
+
+    @Message(id = 267, value = "Repository archive has to contain a single root folder with a maven-repository sub-folder.")
+    InvalidRepositoryArchiveException invalidRepositoryArchive();
 }

--- a/prospero-common/src/main/java/org/wildfly/prospero/api/RepositoryUtils.java
+++ b/prospero-common/src/main/java/org/wildfly/prospero/api/RepositoryUtils.java
@@ -17,12 +17,31 @@
 
 package org.wildfly.prospero.api;
 
+import org.apache.commons.io.IOUtils;
 import org.eclipse.aether.repository.RemoteRepository;
+import org.jboss.galleon.util.ZipUtils;
+import org.jboss.logging.Logger;
 import org.wildfly.channel.Repository;
+import org.wildfly.prospero.ProsperoLogger;
+import org.wildfly.prospero.api.exceptions.InvalidRepositoryArchiveException;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.net.URL;
+import java.net.URLConnection;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
 
 import static org.wildfly.channel.maven.VersionResolverFactory.DEFAULT_REPOSITORY_POLICY;
 
 public class RepositoryUtils {
+    private static final Logger LOG = Logger.getLogger(RepositoryUtils.class.getName());
     public static Repository toChannelRepository(RemoteRepository r) {
         return new Repository(r.getId(), r.getUrl());
     }
@@ -35,5 +54,130 @@ public class RepositoryUtils {
 
     public static RemoteRepository toRemoteRepository(Repository repository) {
         return toRemoteRepository(repository.getId(), repository.getUrl());
+    }
+
+    /**
+     * extracts repositories provided as ZIP archives and produces a list of {@code Repositories} pointing to extracted folders.
+     *
+     * @param repositories - list of repositories. Some of them might contain archives
+     * @param temporaryFiles - {@link TemporaryFilesManager} responsible for temporary files
+     * @return - list of repositories with extracted archives
+     * @throws InvalidRepositoryArchiveException - if the archive does not contain a valid repository.
+     */
+    public static List<Repository> unzipArchives(List<Repository> repositories, TemporaryFilesManager temporaryFiles) throws InvalidRepositoryArchiveException {
+        Objects.requireNonNull(repositories);
+
+        if (repositories.isEmpty()) {
+            return repositories;
+        }
+
+        final ArrayList<Repository> mappedRepositories = new ArrayList<>();
+        for (Repository repository : repositories) {
+            try {
+                if (isLocalZipFile(repository)) {
+                    if (LOG.isDebugEnabled()) {
+                        LOG.debug("Treating " + repository.getUrl() + " as a local archive.");
+                    }
+                    final Path archivePath = Path.of(URI.create(repository.getUrl()));
+                    final String newUrl = extractArchive(archivePath, temporaryFiles);
+                    if (LOG.isDebugEnabled()) {
+                        LOG.debug("Extracted " + repository.getUrl() + " to " + newUrl);
+                    }
+                    mappedRepositories.add(new Repository(repository.getId(), newUrl));
+                } else if (isRemoteZipFile(repository)) {
+                    if (LOG.isDebugEnabled()) {
+                        LOG.debug("Treating " + repository.getUrl() + " as a remote archive.");
+                    }
+                    final Path archivePath = temporaryFiles.createTempFile("prospero-repository", ".zip");
+                    if (LOG.isDebugEnabled()) {
+                        LOG.debug("Downloaded " + repository.getUrl() + " to " + archivePath);
+                    }
+                    IOUtils.copy(new URL(repository.getUrl()), archivePath.toFile());
+
+                    final String newUrl = extractArchive(archivePath, temporaryFiles);
+                    if (LOG.isDebugEnabled()) {
+                        LOG.debug("Extracted " + repository.getUrl() + " to " + newUrl);
+                    }
+                    mappedRepositories.add(new Repository(repository.getId(), newUrl));
+                } else {
+                    if (LOG.isDebugEnabled()) {
+                        LOG.debug("Treating " + repository.getUrl() + " as a repository URL.");
+                    }
+                    mappedRepositories.add(repository);
+                }
+            } catch (IOException e) {
+                throw ProsperoLogger.ROOT_LOGGER.unableToExtractRepositoryArchive(repository.getUrl(), e);
+            }
+        }
+        return mappedRepositories;
+    }
+
+    private static String extractArchive(Path archivePath, TemporaryFilesManager temporaryFiles) throws IOException, InvalidRepositoryArchiveException {
+        final Path tempRepo = temporaryFiles.createTempDirectory("prospero-repository");
+        ZipUtils.unzip(archivePath, tempRepo);
+
+        final Path mavenRepositoryFolder = findRepositoryFolder(tempRepo);
+        return mavenRepositoryFolder.toUri().toURL().toString();
+    }
+
+    private static Path findRepositoryFolder(Path tempRepo) throws InvalidRepositoryArchiveException {
+        final File[] repoChildren = tempRepo.toFile().listFiles(File::isDirectory);
+        if (repoChildren == null || repoChildren.length != 1) {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("The repository archive has to contain a single root folder. " + tempRepo);
+            }
+            throw ProsperoLogger.ROOT_LOGGER.invalidRepositoryArchive();
+        }
+        File rootFile = repoChildren[0];
+        final Path mavenRepositoryFolder = rootFile.toPath().resolve("maven-repository");
+        if (!Files.exists(mavenRepositoryFolder) || !Files.isDirectory(mavenRepositoryFolder)) {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Sub-folder maven-repository not found under the root of the archive " + mavenRepositoryFolder.getParent());
+            }
+            throw ProsperoLogger.ROOT_LOGGER.invalidRepositoryArchive();
+        }
+        return mavenRepositoryFolder;
+    }
+
+    private static boolean isLocalZipFile(Repository repository) {
+        try {
+            final URI uri = URI.create(repository.getUrl());
+            if (!uri.getPath().endsWith(".zip") || !"file".equals(uri.getScheme())) {
+                return false;
+            }
+            final Path path = Path.of(uri);
+            // try to open the archive
+            FileSystems.newFileSystem(path, (ClassLoader) null).close();
+            return true;
+        } catch (IOException e) {
+            if (LOG.isTraceEnabled()) {
+                LOG.trace(repository.getUrl() + " is not a valid zip archive, treating it as URL", e);
+            }
+            return false;
+        }
+    }
+
+    private static boolean isRemoteZipFile(Repository repository) {
+        try {
+            final URL url = new URL(repository.getUrl());
+            if (!url.getFile().endsWith(".zip")) {
+                return false;
+            }
+            // check if the content type indicates an archive
+            if (url.getProtocol().equals("http") || url.getProtocol().equals("https")) {
+                final URLConnection connection = url.openConnection();
+                if (connection instanceof HttpURLConnection) {
+                    ((HttpURLConnection) connection).setRequestMethod("HEAD");
+                    connection.connect();
+                    final String contentType = connection.getContentType();
+                    return "application/zip".equals(contentType);
+                }
+            }
+        } catch (IOException e) {
+            if (LOG.isTraceEnabled()) {
+                LOG.trace(repository.getUrl() + " unable to determine content type, treating as repository URL", e);
+            }
+        }
+        return false;
     }
 }

--- a/prospero-common/src/main/java/org/wildfly/prospero/api/TemporaryFilesManager.java
+++ b/prospero-common/src/main/java/org/wildfly/prospero/api/TemporaryFilesManager.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2024 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.prospero.api;
+
+import org.apache.commons.io.FileUtils;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Tracks created temporary files and removes them when {@code close()} is closed.
+ */
+public class TemporaryFilesManager implements AutoCloseable {
+
+    private final Set<Path> temporaryFiles = new HashSet<>();
+
+    TemporaryFilesManager() {
+
+    }
+
+    public static TemporaryFilesManager getInstance() {
+        return new TemporaryFilesManager();
+    }
+
+    public Path createTempDirectory(String prefix) throws IOException {
+        final Path tempDirectory = Files.createTempDirectory(prefix);
+        tempDirectory.toFile().deleteOnExit();
+        temporaryFiles.add(tempDirectory);
+        return tempDirectory;
+    }
+
+    public Path createTempFile(String prefix, String suffix) throws IOException {
+        final Path tempFile = Files.createTempFile(prefix, suffix);
+        tempFile.toFile().deleteOnExit();
+        temporaryFiles.add(tempFile);
+        return tempFile;
+    }
+
+    @Override
+    public void close() {
+        temporaryFiles.stream()
+                .map(Path::toFile)
+                .forEach(FileUtils::deleteQuietly);
+    }
+}

--- a/prospero-common/src/main/java/org/wildfly/prospero/api/exceptions/InvalidRepositoryArchiveException.java
+++ b/prospero-common/src/main/java/org/wildfly/prospero/api/exceptions/InvalidRepositoryArchiveException.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2024 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.prospero.api.exceptions;
+
+public class InvalidRepositoryArchiveException extends OperationException {
+    public InvalidRepositoryArchiveException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public InvalidRepositoryArchiveException(String message) {
+        super(message);
+    }
+}

--- a/prospero-common/src/test/java/org/wildfly/prospero/api/RepositoryUtilsTest.java
+++ b/prospero-common/src/test/java/org/wildfly/prospero/api/RepositoryUtilsTest.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2024 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.prospero.api;
+
+import io.undertow.Undertow;
+import io.undertow.server.handlers.resource.PathResourceManager;
+import io.undertow.util.MimeMappings;
+import org.jboss.galleon.util.ZipUtils;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.wildfly.channel.Repository;
+import org.wildfly.prospero.api.exceptions.InvalidRepositoryArchiveException;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import static io.undertow.Handlers.resource;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.Assert.assertEquals;
+
+public class RepositoryUtilsTest {
+
+    @Rule
+    public TemporaryFolder temp = new TemporaryFolder();
+
+    @Test
+    public void unzipArchiveBeforeUsingIt() throws Exception {
+        final Path repoRoot = temp.newFolder("repo").toPath();
+        final Path zipFile = createRepository(repoRoot);
+
+        final List<Repository> repositories = applyOverride(List.of(repo("temp-0", zipFile.toUri().toString())));
+
+        assertThat(Path.of(new URL(repositories.get(0).getUrl()).toURI()).resolve("test.txt"))
+                .hasContent("test text");
+    }
+
+    @Test
+    public void dontUnpackNonZipFile() throws Exception {
+        final File notZipFile = temp.newFile("fake.zip");
+
+        final List<Repository> repositories = applyOverride(List.of(repo("temp-0", notZipFile.toURI().toString())));
+
+        assertEquals(notZipFile.toURI().toString(), repositories.get(0).getUrl());
+    }
+
+    @Test
+    public void downloadAndUnzipRemoteArchive() throws Exception {
+        final Path webRoot = temp.newFolder("web-root").toPath();
+        Files.move(createRepository(webRoot), webRoot.resolve("test.zip"));
+        final Undertow server = Undertow.builder()
+                .addHttpListener(8888, "localhost")
+                .setHandler(resource(new PathResourceManager(webRoot))
+                        .setMimeMappings(MimeMappings.DEFAULT)
+                        .setDirectoryListingEnabled(true))
+                .build();
+        try {
+            server.start();
+
+            final List<Repository> repositories = applyOverride(List.of(repo("temp-0", "http://localhost:8888/test.zip")));
+
+            assertThat(Path.of(new URL(repositories.get(0).getUrl()).toURI()).resolve("test.txt"))
+                    .hasContent("test text");
+        } finally {
+            server.stop();
+        }
+    }
+
+    @Test
+    public void failIfTheArchiveHasNoFiles() throws Exception {
+        final Path repoRoot = temp.newFolder("repo-root").toPath();
+        final Path repoZip = temp.newFile("repo.zip").toPath();
+        Files.delete(repoZip);
+        ZipUtils.zip(repoRoot, repoZip);
+
+        assertThatThrownBy(()->applyOverride(List.of(repo("temp-0", repoZip.toUri().toString()))))
+                .isInstanceOf(InvalidRepositoryArchiveException.class);
+    }
+
+    @Test
+    public void failIfTheArchiveHasNoDirectories() throws Exception {
+        final Path repoRoot = temp.newFolder("repo-root").toPath();
+        Files.writeString(repoRoot.resolve("test.txt"), "test");
+        final Path repoZip = temp.newFile("repo.zip").toPath();
+        Files.delete(repoZip);
+        ZipUtils.zip(repoRoot, repoZip);
+
+        assertThatThrownBy(()->applyOverride(List.of(repo("temp-0", repoZip.toUri().toString()))))
+                .isInstanceOf(InvalidRepositoryArchiveException.class);
+    }
+
+    @Test
+    public void failIfTheArchiveHasMultipleRootDirectories() throws Exception {
+        final Path repoRoot = temp.newFolder("repo-root").toPath();
+        Files.createDirectory(repoRoot.resolve("test"));
+        Files.createDirectory(repoRoot.resolve("test2"));
+        final Path repoZip = temp.newFile("repo.zip").toPath();
+        Files.delete(repoZip);
+        ZipUtils.zip(repoRoot, repoZip);
+
+        assertThatThrownBy(()->applyOverride(List.of(repo("temp-0", repoZip.toUri().toString()))))
+                .isInstanceOf(InvalidRepositoryArchiveException.class);
+    }
+
+    @Test
+    public void failIfTheArchivesRootDirectoriesHasNoMavenRepositoryDirectory() throws Exception {
+        final Path repoRoot = temp.newFolder("repo-root").toPath();
+        Files.createDirectory(repoRoot.resolve("test"));
+        final Path repoZip = temp.newFile("repo.zip").toPath();
+        Files.delete(repoZip);
+        ZipUtils.zip(repoRoot, repoZip);
+
+        assertThatThrownBy(()->applyOverride(List.of(repo("temp-0", repoZip.toUri().toString()))))
+                .isInstanceOf(InvalidRepositoryArchiveException.class);
+    }
+
+    private Path createRepository(Path repoRoot) throws IOException {
+        Files.createDirectory(repoRoot.resolve("test-repository"));
+        Files.createDirectory(repoRoot.resolve("test-repository").resolve("maven-repository"));
+        Files.writeString(repoRoot.resolve("test-repository").resolve("maven-repository").resolve("test.txt"), "test text");
+        final Path zipFile = temp.newFile("repo.zip").toPath();
+        Files.delete(zipFile);
+        ZipUtils.zip(repoRoot, zipFile);
+        return zipFile;
+    }
+
+    private static Repository repo(String id, String url) {
+        return new Repository(id, url);
+    }
+
+    private static List<Repository> applyOverride(List<Repository> overrideRepositories) throws InvalidRepositoryArchiveException {
+        return RepositoryUtils.unzipArchives(overrideRepositories, TemporaryFilesManager.getInstance());
+    }
+}


### PR DESCRIPTION
Allow --repositories argument to consume archived repositories. The archive repository has to follow structure:

{ROOT_FOLDER}
|-maven-repository
  |-{articats}

Note, that in the `install` command only `--shade-repositories` option allows archives as the `--repositories` are used to resolve updates and should not be pointing to archives.
