### PR TITLE
[JBEAP-26885] Add required files to the invalidInstallationDir message

### DIFF
--- a/prospero-cli/src/main/java/org/wildfly/prospero/cli/CliMessages.java
+++ b/prospero-cli/src/main/java/org/wildfly/prospero/cli/CliMessages.java
@@ -216,8 +216,10 @@ public interface CliMessages {
     }
 
     default String requiredMetadata() {
-        return format(bundle.getString("prospero.update.invalid.path.details"), Constants.PROVISIONED_STATE_DIR,
-                ProsperoMetadataUtils.METADATA_DIR + File.separator + ProsperoMetadataUtils.INSTALLER_CHANNELS_FILE_NAME);
+        return format(bundle.getString("prospero.update.invalid.path.details"),
+                List.of(ProsperoMetadataUtils.METADATA_DIR + File.separator + ProsperoMetadataUtils.INSTALLER_CHANNELS_FILE_NAME,
+                        ProsperoMetadataUtils.METADATA_DIR + File.separator + ProsperoMetadataUtils.MANIFEST_FILE_NAME,
+                        Constants.PROVISIONED_STATE_DIR + File.separator + Constants.PROVISIONING_XML));
     }
 
     default String forgottenDirArgQuestion() {

--- a/prospero-cli/src/main/resources/UsageMessages.properties
+++ b/prospero-cli/src/main/resources/UsageMessages.properties
@@ -282,7 +282,7 @@ prospero.updates.build.validation.dir.not_empty=Selected destination path (%s) n
 prospero.updates.list.header=Checking available updates for %s%n
 
 prospero.update.invalid.path=Path `%s` does not contain a server installation provisioned by the %s.
-prospero.update.invalid.path.details=Server installation needs to contain a `%s` folder and an `%s` file.
+prospero.update.invalid.path.details=Server installation needs to contain following files: `%s`.
 
 prospero.update.self.validation.unknown.installation=Unable to perform self-update - unable to determine installed feature packs.
 prospero.update.self.validation.feature_pack=Unable to perform self-update - folder `%s` contains unexpected feature packs.

--- a/prospero-common/src/main/java/org/wildfly/prospero/ProsperoLogger.java
+++ b/prospero-common/src/main/java/org/wildfly/prospero/ProsperoLogger.java
@@ -39,6 +39,7 @@ import java.io.IOException;
 import java.net.URI;
 import java.net.URL;
 import java.nio.file.Path;
+import java.util.List;
 
 @MessageLogger(projectCode = "PRSP")
 public interface ProsperoLogger extends BasicLogger {
@@ -233,8 +234,8 @@ public interface ProsperoLogger extends BasicLogger {
     @Message(id = 221, value = "Unable to write file at [%s]")
     MetadataException unableToWriteFile(Path path, @Cause Exception e);
 
-    @Message(id = 222, value = "Path `%s` does not contain a server installation provisioned by prospero.")
-    IllegalArgumentException invalidInstallationDir(Path path);
+    @Message(id = 222, value = "Path `%s` does not contain a server installation provisioned by prospero. Missing required files: %s")
+    IllegalArgumentException invalidInstallationDir(Path path, List<Path> missingFolders);
 
     @Message(id = 223, value = "Unable to access history store at [%s]")
     MetadataException unableToAccessHistoryStorage(Path path, @Cause Exception e);


### PR DESCRIPTION
Add details of missing files when the installation directory doesn't contain all required metadata
