### PR TITLE
Re-cache the manifest after reverting without manifest version change

### DIFF
--- a/integration-tests/src/test/java/org/wildfly/prospero/it/commonapi/WfCoreTestBase.java
+++ b/integration-tests/src/test/java/org/wildfly/prospero/it/commonapi/WfCoreTestBase.java
@@ -306,4 +306,15 @@ public class WfCoreTestBase {
         system.deploy(session, deployRequest);
         Files.delete(copied);
     }
+
+    protected static void emptyLocalCache() {
+        final File[] files = localCachePath.toFile().listFiles();
+        if (files == null) {
+            return;
+        }
+
+        for (File file : files) {
+            FileUtils.deleteQuietly(file);
+        }
+    }
 }

--- a/prospero-common/src/test/java/org/wildfly/prospero/galleon/GalleonEnvironmentTest.java
+++ b/prospero-common/src/test/java/org/wildfly/prospero/galleon/GalleonEnvironmentTest.java
@@ -165,6 +165,9 @@ public class GalleonEnvironmentTest {
                 .build();
         final ChannelManifest restoreManifest = new ChannelManifest("restore manifest", null, null, Collections.emptyList());
 
+        // pretend the channel manifests cannot be resolved - we'll fall back to the reverted state either way
+        when(system.resolveArtifact(any(), any())).thenThrow(new ArtifactResolutionException(Collections.emptyList()));
+
         final URL manifestUrl;
         try (GalleonEnvironment env = GalleonEnvironment.builder(temp.newFolder().toPath(), List.of(c1, c2), msm, true)
                 .setRestoreManifest(restoreManifest)


### PR DESCRIPTION
Description:
When reverting to a state where the manifest version is not changed, and the manifest is in the cache, after the revert the manifest is removed from cache.

Reproduce
1. Install server using channel with GA manifest
2. Perform configuration changes using `prospero channel` operations e.g. add 2nd channel
3. Revert to the original step

Actual results:
The manifest is missing in .cache folder

Expected results:
The cache contains the manifest file
