### PR TITLE
[JBEAP-26951] Do not add manifest stream to the generated manifest when reverting

### DIFF
--- a/integration-tests/src/test/java/org/wildfly/prospero/it/cli/CacheManifestTest.java
+++ b/integration-tests/src/test/java/org/wildfly/prospero/it/cli/CacheManifestTest.java
@@ -46,6 +46,7 @@ import org.wildfly.prospero.cli.CliConsole;
 import org.wildfly.prospero.galleon.ArtifactCache;
 import org.wildfly.prospero.it.commonapi.WfCoreTestBase;
 import org.wildfly.prospero.it.utils.TestRepositoryUtils;
+import org.wildfly.prospero.metadata.ProsperoMetadataUtils;
 import org.wildfly.prospero.test.MetadataTestUtils;
 
 import java.io.File;
@@ -210,6 +211,9 @@ public class CacheManifestTest extends WfCoreTestBase {
         assertThat(outputPath.resolve(ArtifactCache.CACHE_FOLDER).resolve("artifacts.txt"))
                 .content()
                 .contains("org.test.channels:wf-core-base:yaml:manifest:1.0.0");
+        assertThat(outputPath.resolve(ProsperoMetadataUtils.METADATA_DIR).resolve(ProsperoMetadataUtils.MANIFEST_FILE_NAME))
+                .content()
+                .doesNotContain("wf-core-base");
     }
 
     @Test

--- a/prospero-common/src/main/java/org/wildfly/prospero/galleon/GalleonEnvironment.java
+++ b/prospero-common/src/main/java/org/wildfly/prospero/galleon/GalleonEnvironment.java
@@ -18,7 +18,6 @@
 package org.wildfly.prospero.galleon;
 
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.lang3.StringUtils;
 import org.eclipse.aether.DefaultRepositorySystemSession;
 import org.eclipse.aether.RepositorySystem;
 import org.jboss.galleon.Constants;
@@ -115,8 +114,7 @@ public class GalleonEnvironment implements AutoCloseable {
             // they have to be in the maven cache for later version resolution
             final ManifestVersionRecord manifestVersions = new ManifestVersionRecord("1.0.0",
                     builder.restoredManifestVersions, Collections.emptyList(), Collections.emptyList());
-            storeOriginalChannelManifestAsResolved(builder, factory);
-            populateMavenCacheWithManifests(manifestVersions.getMavenManifests(), channelSession);
+            storeOriginalChannelManifestAsResolved(builder, factory, manifestVersions.getMavenManifests());
         }
 
         if (restoreManifest.isEmpty()) {
@@ -146,10 +144,30 @@ public class GalleonEnvironment implements AutoCloseable {
         layoutFactory.setProgressCallback(TRACK_JB_ARTIFACTS_RESOLVE, callback);
     }
 
-    private static void storeOriginalChannelManifestAsResolved(Builder builder, MavenVersionsResolver.Factory factory) {
-        try {
-            // attempt to resolve the manifests we're reverting to. Doing so will record the manifest in the ResolvedArtifactsStore
-            new ChannelSession(builder.channels, factory).close();
+    private static void storeOriginalChannelManifestAsResolved(Builder builder, MavenVersionsResolver.Factory factory,
+                                                               List<ManifestVersionRecord.MavenManifest> mavenManifests) {
+
+        // attempt to resolve the manifests we're reverting to. Doing so will record the manifest in the ResolvedArtifactsStore
+        try (ChannelSession tempSession = new ChannelSession(builder.channels, factory)) {
+            for (ManifestVersionRecord.MavenManifest mavenManifest : mavenManifests) {
+                try {
+                    if (LOG.isTraceEnabled()) {
+                        LOG.tracef("Trying to resolve %s.", mavenManifest);
+                    }
+                    // don't use the GalleonEnvironment#channelSession - we don't want to inject those into recorded manifest, just local maven cache
+                    tempSession.resolveDirectMavenArtifact(
+                            mavenManifest.getGroupId(),
+                            mavenManifest.getArtifactId(),
+                            ChannelManifest.EXTENSION,
+                            ChannelManifest.CLASSIFIER,
+                            mavenManifest.getVersion()
+                    );
+                } catch (ArtifactTransferException e) {
+                    // catch the error here so we can ignore it
+                    ProsperoLogger.ROOT_LOGGER.debugf(e, "Unable to resolve manifest %s:%s:%s for maven cache",
+                            mavenManifest.getGroupId(), mavenManifest.getArtifactId(), mavenManifest.getVersion());
+                }
+            }
         } catch (ArtifactTransferException e) {
             // ignore; we just won't cache this manifest later
             LOG.debug("Unable to resolve restored manifest", e);
@@ -234,38 +252,6 @@ public class GalleonEnvironment implements AutoCloseable {
             FileUtils.deleteQuietly(restoreManifestPath.toFile());
         }
         provisioningManager.close();
-    }
-
-    /*
-     * Attempts to populate current's {@code channelSession} maven cache with the maven manifest artifacts.
-     * Used when the provisioning is by-passing the manifest resolution (e.g. during revert when it's using old
-     * provisioned manifest)
-     */
-    static void populateMavenCacheWithManifests(List<ManifestVersionRecord.MavenManifest> mavenManifests, ChannelSession channelSession) {
-        Objects.requireNonNull(mavenManifests);
-        Objects.requireNonNull(channelSession);
-
-        if (LOG.isDebugEnabled()) {
-            LOG.debugf("Resolving manifests %s to prepopulate maven cache.", StringUtils.join(mavenManifests, ","));
-        }
-
-        for (ManifestVersionRecord.MavenManifest mavenManifest : mavenManifests) {
-            try {
-                if (LOG.isTraceEnabled()) {
-                    LOG.tracef("Trying to resolve %s.", mavenManifest);
-                }
-                channelSession.resolveDirectMavenArtifact(
-                        mavenManifest.getGroupId(),
-                        mavenManifest.getArtifactId(),
-                        ChannelManifest.EXTENSION,
-                        ChannelManifest.CLASSIFIER,
-                        mavenManifest.getVersion()
-                );
-            } catch (ArtifactTransferException e) {
-                ProsperoLogger.ROOT_LOGGER.debugf(e, "Unable to resolve manifest %s:%s:%s for maven cache",
-                        mavenManifest.getGroupId(), mavenManifest.getArtifactId(), mavenManifest.getVersion());
-            }
-        }
     }
 
     public static Builder builder(Path installDir, List<Channel> channels, MavenSessionManager mavenSessionManager) {

--- a/prospero-common/src/test/java/org/wildfly/prospero/galleon/GalleonEnvironmentTest.java
+++ b/prospero-common/src/test/java/org/wildfly/prospero/galleon/GalleonEnvironmentTest.java
@@ -163,10 +163,9 @@ public class GalleonEnvironmentTest {
         final Channel c2 = new Channel.Builder()
                 .setManifestCoordinate("group", "artifactTwo", "1.0.0")
                 .build();
-        final ChannelManifest restoreManifest = new ChannelManifest("restore manifest", null, null, Collections.emptyList());
-
         // pretend the channel manifests cannot be resolved - we'll fall back to the reverted state either way
         when(system.resolveArtifact(any(), any())).thenThrow(new ArtifactResolutionException(Collections.emptyList()));
+        final ChannelManifest restoreManifest = new ChannelManifest("restore manifest", null, null, Collections.emptyList());
 
         final URL manifestUrl;
         try (GalleonEnvironment env = GalleonEnvironment.builder(temp.newFolder().toPath(), List.of(c1, c2), msm)


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/JBEAP-26951
Upstream: #634
