### PR TITLE
587 Allow execution of the jboss-eap-installation-manager.sh from inside of the bin/ directory

### DIFF
--- a/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/AbstractCommand.java
+++ b/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/AbstractCommand.java
@@ -66,7 +66,11 @@ public abstract class AbstractCommand implements Callable<Integer> {
     }
 
     protected static Path determineInstallationDirectory(Optional<Path> directoryOption) throws ArgumentParsingException {
-        Path installationDirectory = directoryOption.orElse(currentDir()).toAbsolutePath();
+        return determineInstallationDirectory(directoryOption, currentDir());
+    }
+
+    static Path determineInstallationDirectory(Optional<Path> directoryOption, Path currentDir) throws ArgumentParsingException {
+        Path installationDirectory = directoryOption.orElse(currentDir).toAbsolutePath();
 
         // Check if the directory option was provided
         if (directoryOption.isPresent()) {

--- a/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/UpdateCommand.java
+++ b/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/UpdateCommand.java
@@ -236,7 +236,9 @@ public class UpdateCommand extends AbstractParentCommand {
 
             final Path installationDir = determineInstallationDirectory(directory);
 
-            verifyDirectoryContainsInstallation(candidateDir);
+            if(!verifyDirectoryContainsInstallation(candidateDir)){
+                throw CliMessages.MESSAGES.invalidInstallationDir(candidateDir);
+            }
 
             console.println(CliMessages.MESSAGES.updateHeader(installationDir));
 

--- a/prospero-cli/src/test/java/org/wildfly/prospero/cli/commands/AbstractCommandTest.java
+++ b/prospero-cli/src/test/java/org/wildfly/prospero/cli/commands/AbstractCommandTest.java
@@ -1,0 +1,48 @@
+package org.wildfly.prospero.cli.commands;
+
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.wildfly.prospero.cli.ArgumentParsingException;
+import org.wildfly.prospero.test.MetadataTestUtils;
+import java.nio.file.Path;
+import java.util.Optional;
+
+public class AbstractCommandTest {
+
+    public static final String A_PROSPERO_FP = UpdateCommand.PROSPERO_FP_GA + ":1.0.0";
+
+    private Path installationDir;
+    private Path invalidDir;
+
+    @Rule
+    public TemporaryFolder tempFolder = new TemporaryFolder();
+
+    @Before
+    public void setUp() throws Exception {
+
+        installationDir = tempFolder.newFolder().toPath();
+        MetadataTestUtils.createInstallationMetadata(installationDir);
+        MetadataTestUtils.createGalleonProvisionedState(installationDir, A_PROSPERO_FP);
+
+        invalidDir = tempFolder.newFolder().toPath();
+    }
+
+    @Test
+    public void testValidInstallationDir() throws Exception {
+        Assert.assertEquals(installationDir, AbstractCommand.determineInstallationDirectory(Optional.empty(), installationDir));
+    }
+
+    @Test
+    public void testValidInstallationSubdirectory() throws Exception {
+        Assert.assertEquals(installationDir, AbstractCommand.determineInstallationDirectory(Optional.empty(), installationDir.resolve("bin")));
+    }
+
+    @Test(expected = ArgumentParsingException.class)
+    public void testInvalidInstallationDir() throws Exception {
+        AbstractCommand.determineInstallationDirectory(Optional.empty(), invalidDir);
+    }
+}


### PR DESCRIPTION
Issue: https://github.com/wildfly-extras/prospero/issues/587