### PR TITLE
[JBEAP-26882] Channel name null is accepted by remove command

### DIFF
--- a/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/channel/ChannelRemoveCommand.java
+++ b/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/channel/ChannelRemoveCommand.java
@@ -33,7 +33,9 @@ import java.util.Optional;
 @CommandLine.Command(name = CliConstants.Commands.REMOVE)
 public class ChannelRemoveCommand extends AbstractCommand {
 
-    @CommandLine.Option(names=CliConstants.CHANNEL_NAME)
+    @CommandLine.Option(
+            names=CliConstants.CHANNEL_NAME,
+            required = true)
     String channelName;
 
     @CommandLine.Option(names = CliConstants.DIR)

--- a/prospero-cli/src/test/java/org/wildfly/prospero/cli/commands/ChannelCommandTest.java
+++ b/prospero-cli/src/test/java/org/wildfly/prospero/cli/commands/ChannelCommandTest.java
@@ -271,6 +271,13 @@ public class ChannelCommandTest extends AbstractConsoleTest {
         Assert.assertEquals(ReturnCodes.INVALID_ARGUMENTS, exitCode);
     }
 
+    @Test
+    public void testRemoveEmptyChannel() {
+        int exitCode = commandLine.execute(CliConstants.Commands.CHANNEL, CliConstants.Commands.REMOVE,
+                CliConstants.DIR, dir.toString());
+        Assert.assertEquals(ReturnCodes.INVALID_ARGUMENTS, exitCode);
+    }
+
     private static Channel createChannel(String name, ChannelManifestCoordinate coord) throws MalformedURLException {
         return new Channel(name, "", null,
                 List.of(new Repository("test", "http://test.org")),


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/JBEAP-26882
Upstream: #658
