### PR TITLE
Enable colour output in the Prospero messages

### DIFF
--- a/prospero-cli/src/main/java/org/wildfly/prospero/cli/CliConsole.java
+++ b/prospero-cli/src/main/java/org/wildfly/prospero/cli/CliConsole.java
@@ -28,6 +28,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.wildfly.prospero.api.Console;
 import org.wildfly.prospero.api.ProvisioningProgressEvent;
 import org.wildfly.prospero.api.ArtifactChange;
+import picocli.CommandLine;
 
 import static org.jboss.galleon.layout.ProvisioningLayoutFactory.TRACK_CONFIGS;
 import static org.jboss.galleon.layout.ProvisioningLayoutFactory.TRACK_LAYOUT_BUILD;
@@ -153,20 +154,20 @@ public class CliConsole implements Console {
 
     public void updatesFound(List<ArtifactChange> artifactUpdates) {
         if (artifactUpdates.isEmpty()) {
-            getStdOut().println(CliMessages.MESSAGES.noUpdatesFound());
+            println(CliMessages.MESSAGES.noUpdatesFound());
         } else {
-            getStdOut().println(CliMessages.MESSAGES.updatesFound());
+            println(CliMessages.MESSAGES.updatesFound());
             for (ArtifactChange artifactUpdate : artifactUpdates) {
                 final Optional<String> newVersion = artifactUpdate.getNewVersion();
                 final Optional<String> oldVersion = artifactUpdate.getOldVersion();
                 final String artifactName = artifactUpdate.getArtifactName();
 
-                getStdOut().printf("  %s%-50s    %-20s ==>  %-20s%n", artifactUpdate.isDowngrade()?"[*]":"", artifactName, oldVersion.orElse("[]"),
+                printf("  %s%-50s    %-20s ==>  %-20s%n", artifactUpdate.isDowngrade()?"[*]":"", artifactName, oldVersion.orElse("[]"),
                         newVersion.orElse("[]"));
             }
 
             if (artifactUpdates.stream().anyMatch(ArtifactChange::isDowngrade)) {
-                getStdOut().printf(CliMessages.MESSAGES.possibleDowngrade());
+                printf(CliMessages.MESSAGES.possibleDowngrade());
             }
         }
     }
@@ -242,7 +243,21 @@ public class CliConsole implements Console {
 
     @Override
     public void println(String text) {
-        getStdOut().println(text);
+        if (text == null) {
+            getStdOut().println();
+        } else {
+            final CommandLine.Help.Ansi.Text formatted = CommandLine.Help.Ansi.AUTO.new Text(text);
+            getStdOut().println(formatted.toString());
+        }
+    }
+
+    public void printf(String text, String... args) {
+        if (text == null) {
+            getStdOut().println();
+        } else {
+            final String formatted = String.format(text, (String[]) args);
+            getStdOut().print(CommandLine.Help.Ansi.AUTO.new Text(formatted));
+        }
     }
 
 }

--- a/prospero-cli/src/main/java/org/wildfly/prospero/cli/CliConsole.java
+++ b/prospero-cli/src/main/java/org/wildfly/prospero/cli/CliConsole.java
@@ -162,7 +162,7 @@ public class CliConsole implements Console {
                 final Optional<String> oldVersion = artifactUpdate.getOldVersion();
                 final String artifactName = artifactUpdate.getArtifactName();
 
-                printf("  %s%-50s    %-20s ==>  %-20s%n", artifactUpdate.isDowngrade()?"[*]":"", artifactName, oldVersion.orElse("[]"),
+                printf("  %s%-50s    %-20s ==>  %-20s%n", artifactUpdate.isDowngrade()?"@|fg(yellow) [*]|@":"", artifactName, oldVersion.orElse("[]"),
                         newVersion.orElse("[]"));
             }
 

--- a/prospero-cli/src/main/java/org/wildfly/prospero/cli/DiffPrinter.java
+++ b/prospero-cli/src/main/java/org/wildfly/prospero/cli/DiffPrinter.java
@@ -25,9 +25,11 @@ import org.wildfly.prospero.api.FeatureChange;
 public class DiffPrinter {
 
     private final String initialTab;
+    private final CliConsole console;
 
-    public DiffPrinter(String initialTab) {
+    public DiffPrinter(CliConsole console, String initialTab) {
         this.initialTab = initialTab;
+        this.console = console;
     }
 
     public void print(Diff diff) {
@@ -35,7 +37,7 @@ public class DiffPrinter {
     }
 
     private void print(Diff diff, String tab, boolean nested) {
-        System.out.print(tab);
+        console.printf(tab);
 
 
         if (diff.getChildren().isEmpty()) {
@@ -53,13 +55,13 @@ public class DiffPrinter {
         }
     }
 
-    private static void print(Diff diff, boolean nested, String text, String... args) {
+    private void print(Diff diff, boolean nested, String text, String... args) {
         if (!nested) {
             text = String.format("[%s] ", getStatus(diff)) + String.format(text, (String[]) args);
         } else {
             text = String.format(text, (String[]) args);
         }
-        System.out.print(text);
+        console.printf(text);
     }
 
     private static String getStatus(Diff diff) {

--- a/prospero-cli/src/main/java/org/wildfly/prospero/cli/LicensePrinter.java
+++ b/prospero-cli/src/main/java/org/wildfly/prospero/cli/LicensePrinter.java
@@ -24,26 +24,32 @@ import java.util.List;
 
 public class LicensePrinter {
 
+    private final CliConsole console;
+
+    public LicensePrinter(CliConsole console) {
+        this.console = console;
+    }
+
     public void print(List<License> pendingLicenses) {
         if (!pendingLicenses.isEmpty()) {
             boolean first = true;
             for (License pendingLicense : pendingLicenses) {
                 if (!first) {
-                    System.out.println();
+                    console.println("");
                 }
                 first = false;
 
-                System.out.println("===============");
-                System.out.println(pendingLicense.getTitle());
-                System.out.println("===============");
+                console.println("===============");
+                console.println(pendingLicense.getTitle());
+                console.println("===============");
                 final String text = pendingLicense.getText();
                 final String[] lines = text.split("\n");
                 for (String line : lines) {
-                    System.out.println("  " + WordUtils.wrap(line, 118, System.lineSeparator() + "  ", true));
+                    console.println("  " + WordUtils.wrap(line, 118, System.lineSeparator() + "  ", true));
                 }
-                System.out.println("===============");
+                console.println("===============");
             }
-            System.out.println();
+            console.println("");
         }
     }
 }

--- a/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/FeaturesCommand.java
+++ b/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/FeaturesCommand.java
@@ -99,7 +99,7 @@ public class FeaturesCommand extends AbstractParentCommand {
 
                 if (!pendingLicenses.isEmpty()) {
                     console.println(System.lineSeparator() + CliMessages.MESSAGES.featurePackRequiresLicense(fpl) + System.lineSeparator());
-                    new LicensePrinter().print(pendingLicenses);
+                    new LicensePrinter(console).print(pendingLicenses);
 
                     if (acceptAgreements) {
                         console.println(CliMessages.MESSAGES.agreementSkipped(CliConstants.ACCEPT_AGREEMENTS) + System.lineSeparator());

--- a/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/HistoryCommand.java
+++ b/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/HistoryCommand.java
@@ -62,7 +62,7 @@ public class HistoryCommand extends AbstractCommand {
             if (changes.isEmpty()) {
                 console.println(CliMessages.MESSAGES.noChangesFound());
             } else {
-                final DiffPrinter diffPrinter = new DiffPrinter("  ");
+                final DiffPrinter diffPrinter = new DiffPrinter(console, "  ");
                 boolean needsLineBreak = false;
                 if (!changes.getArtifactChanges().isEmpty()) {
                     console.println(CliMessages.MESSAGES.diffUpdates()+ ":");

--- a/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/InstallCommand.java
+++ b/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/InstallCommand.java
@@ -177,11 +177,11 @@ public class InstallCommand extends AbstractInstallCommand {
             final List<License> pendingLicenses = provisioningAction.getPendingLicenses(provisioningConfig,
                     effectiveChannels);
             if (!pendingLicenses.isEmpty()) {
-                new LicensePrinter().print(pendingLicenses);
-                System.out.println();
+                new LicensePrinter(console).print(pendingLicenses);
+                console.println("");
                 if (acceptAgreements) {
-                    System.out.println(CliMessages.MESSAGES.agreementSkipped(CliConstants.ACCEPT_AGREEMENTS));
-                    System.out.println();
+                    console.println(CliMessages.MESSAGES.agreementSkipped(CliConstants.ACCEPT_AGREEMENTS));
+                    console.println("");
                 } else {
                     if (!console.confirm(CliMessages.MESSAGES.acceptAgreements(), "", CliMessages.MESSAGES.installationCancelled())) {
                         return ReturnCodes.PROCESSING_ERROR;

--- a/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/PrintLicensesCommand.java
+++ b/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/PrintLicensesCommand.java
@@ -60,13 +60,13 @@ public class PrintLicensesCommand extends AbstractInstallCommand {
 
             final List<License> pendingLicenses = provisioningAction.getPendingLicenses(provisioningConfig, channels);
             if (!pendingLicenses.isEmpty()) {
-                System.out.println();
-                System.out.println(CliMessages.MESSAGES.listAgreementsHeader());
-                System.out.println();
-                new LicensePrinter().print(pendingLicenses);
+                console.println("");
+                console.println(CliMessages.MESSAGES.listAgreementsHeader());
+                console.println("");
+                new LicensePrinter(console).print(pendingLicenses);
             } else {
-                System.out.println();
-                System.out.println(CliMessages.MESSAGES.noAgreementsNeeded());
+                console.println("");
+                console.println(CliMessages.MESSAGES.noAgreementsNeeded());
             }
             return ReturnCodes.SUCCESS;
         } finally {

--- a/prospero-cli/src/main/resources/UsageMessages.properties
+++ b/prospero-cli/src/main/resources/UsageMessages.properties
@@ -237,7 +237,7 @@ prospero.install.validation.unknown_profile.details=Did you mean one of [%s]?
 
 prospero.updates.no_updates=No updates found.
 prospero.updates.header=Updates found:
-prospero.updates.downgrade.warning=%n[*] The update list contain one or more artifacts with lower versions then currently installed. Proceed with caution.%n%n
+prospero.updates.downgrade.warning=%n@|fg(yellow) [*] The update list contain one or more artifacts with lower versions then currently installed. Proceed with caution.|@%n%n
 prospero.updates.prompt=Continue with update [y/N]:
 prospero.updates.cancelled=Update cancelled
 prospero.updates.complete=Update complete!


### PR DESCRIPTION
- **[#675] Process the CLI messages using Picocli formatting to enable colours and styles**
- **[JBEAP-27082] Print downgrade warning in yellow**

Issue: https://issues.redhat.com/browse/JBEAP-27082
Upstream: #675
