### PR TITLE
Avoid closing Provisioning object if it was not used

### DIFF
--- a/prospero-common/src/main/java/org/wildfly/prospero/galleon/GalleonFeaturePackAnalyzer.java
+++ b/prospero-common/src/main/java/org/wildfly/prospero/galleon/GalleonFeaturePackAnalyzer.java
@@ -127,9 +127,9 @@ public class GalleonFeaturePackAnalyzer {
         // no data will be actually written out, but we need a path to init the Galleon
         final Path tempInstallationPath = Files.createTempDirectory("temp");
         final Set<String> fps = new HashSet<>();
-        try (GalleonEnvironment galleonEnv = galleonEnvWithFpMapper(tempInstallationPath, installedDir, fps, provisioningConfig);
-             Provisioning provisioning = galleonEnv.getProvisioning()) {
-            provisioning.getProvisioningRuntime(provisioningConfig).close();
+        try (GalleonEnvironment galleonEnv = galleonEnvWithFpMapper(tempInstallationPath, installedDir, fps, provisioningConfig)) {
+            // calling this for a side effect of resolving feature pack artifacts
+            galleonEnv.getProvisioning().getProvisioningRuntime(provisioningConfig).close();
             return fps;
         } finally {
             FileUtils.deleteQuietly(tempInstallationPath.toFile());


### PR DESCRIPTION
Running `prospero install --profile wildfly` results in logging of an error "Error releasing classloader Releasing usage of core 6.0.1.Final although no usage".

The server is generated correctly, the error is related to Galleon 6.0.0 upgrade.
