### PR TITLE
[JBEAP-27255] Return the status of java execution in bat script

### DIFF
--- a/dist/common/src/main/resources/packages/org.jboss.prospero/content/bin/prospero.bat
+++ b/dist/common/src/main/resources/packages/org.jboss.prospero/content/bin/prospero.bat
@@ -252,3 +252,4 @@ if %errorlevel% equ 10 (
 if "x%NOPAUSE%" == "x" pause
 
 :END_NO_PAUSE
+exit /b %errorlevel%


### PR DESCRIPTION
Upstream: #688
Issue: https://issues.redhat.com/browse/JBEAP-27255
