### PR TITLE
Handle installation directory being a symbolic link

### DIFF
--- a/prospero-common/src/main/java/org/wildfly/prospero/ProsperoLogger.java
+++ b/prospero-common/src/main/java/org/wildfly/prospero/ProsperoLogger.java
@@ -386,4 +386,7 @@ public interface ProsperoLogger extends BasicLogger {
 
     @Message(id = 270, value = "Unable to compare the hash content between the installation %s and candidate installation %s.")
     MetadataException unableToCompareHashDirs(Path installationDir, Path updateDir, @Cause Exception e);
+
+    @Message(id = 271, value = "Unable to evaluate symbolic link %s.")
+    RuntimeException unableToEvaluateSymbolicLink(Path symlink, @Cause IOException e);
 }

--- a/prospero-common/src/main/java/org/wildfly/prospero/actions/ApplyCandidateAction.java
+++ b/prospero-common/src/main/java/org/wildfly/prospero/actions/ApplyCandidateAction.java
@@ -125,7 +125,8 @@ public class ApplyCandidateAction {
     public ApplyCandidateAction(Path installationDir, Path updateDir)
             throws ProvisioningException, OperationException {
         this.updateDir = updateDir;
-        this.installationDir = installationDir;
+        this.installationDir = InstallFolderUtils.toRealPath(installationDir);
+        updateDir = InstallFolderUtils.toRealPath(updateDir);
 
         try {
             this.systemPaths = SystemPaths.load(updateDir);

--- a/prospero-common/src/main/java/org/wildfly/prospero/actions/FeaturesAddAction.java
+++ b/prospero-common/src/main/java/org/wildfly/prospero/actions/FeaturesAddAction.java
@@ -97,9 +97,10 @@ public class FeaturesAddAction {
                       List<Repository> repositories, Console console, CandidateActionsFactory candidateActionsFactory,
                       FeaturePackTemplateManager featurePackTemplateManager)
             throws MetadataException, ProvisioningException {
-        this.installDir = installDir;
+        this.installDir = InstallFolderUtils.toRealPath(installDir);
+
         this.console = console;
-        this.metadata = InstallationMetadata.loadInstallation(installDir);
+        this.metadata = InstallationMetadata.loadInstallation(this.installDir);
         this.prosperoConfig = addTemporaryRepositories(repositories);
 
         final MavenOptions mergedOptions = prosperoConfig.getMavenOptions().merge(mavenOptions);
@@ -133,6 +134,8 @@ public class FeaturesAddAction {
             throws ProvisioningException, OperationException {
         verifyFeaturePackCoord(featurePackCoord);
         Objects.requireNonNull(defaultConfigNames);
+
+        candidatePath = InstallFolderUtils.toRealPath(candidatePath);
 
         FeaturePackLocation fpl = FeaturePackLocationParser.resolveFpl(featurePackCoord);
 

--- a/prospero-common/src/main/java/org/wildfly/prospero/actions/InstallFolderUtils.java
+++ b/prospero-common/src/main/java/org/wildfly/prospero/actions/InstallFolderUtils.java
@@ -19,6 +19,7 @@ package org.wildfly.prospero.actions;
 
 import org.wildfly.prospero.ProsperoLogger;
 
+import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
@@ -37,6 +38,42 @@ class InstallFolderUtils {
         }
         if (!isEmptyDirectory(directory)) {
             throw ProsperoLogger.ROOT_LOGGER.cannotInstallIntoNonEmptyDirectory(directory);
+        }
+    }
+
+    /**
+     * convert the {@code symlink} to a real path. If any of the parent folders are a symlink, they will be
+     * converted to real path as well.
+     *
+     * @param symlink
+     * @return
+     */
+    static Path toRealPath(Path symlink) {
+        /*
+         * There's an issue when trying to copy artifacts to a folder that is symlink
+         * This only happens when the last segment of path is symlink itself, but to be consistent, we replace the
+         * symlink anywhere in the path. This way we know we're always operating on a real path from this point on.
+         */
+        Path path = symlink;
+
+        // find a symlink (if any) in the path and its parents
+        while (path != null && !(Files.exists(path) && Files.isSymbolicLink(path))) {
+            path = path.getParent();
+        }
+
+        // if no symlinks were found we got to the root of the path (null) and we don't need to anything
+        if (path == null) {
+            return symlink;
+        } else {
+            // get the subfolder path between the symlink and the actual path
+            final Path relativized = path.relativize(symlink);
+            try {
+                // evaluate the symlink and append the relative path to get back to the starting folder
+                return path.toRealPath().resolve(relativized);
+            } catch (IOException e) {
+                // we know the file at path does exist, so if we got an exception here, that's an I/O error
+                throw ProsperoLogger.ROOT_LOGGER.unableToEvaluateSymbolicLink(symlink, e);
+            }
         }
     }
 

--- a/prospero-common/src/main/java/org/wildfly/prospero/actions/InstallationExportAction.java
+++ b/prospero-common/src/main/java/org/wildfly/prospero/actions/InstallationExportAction.java
@@ -30,7 +30,7 @@ public class InstallationExportAction {
     private final Path installationDir;
 
     public InstallationExportAction(Path installationDir) {
-        this.installationDir = installationDir;
+        this.installationDir = InstallFolderUtils.toRealPath(installationDir);
     }
 
     public static void main(String[] args) throws Exception {
@@ -44,6 +44,8 @@ public class InstallationExportAction {
         if (!installationDir.toFile().exists()) {
             throw ProsperoLogger.ROOT_LOGGER.installationDirDoesNotExist(installationDir);
         }
+
+        exportPath = InstallFolderUtils.toRealPath(exportPath);
 
         try (InstallationMetadata metadataBundle = InstallationMetadata.loadInstallation(installationDir)) {
 

--- a/prospero-common/src/main/java/org/wildfly/prospero/actions/InstallationHistoryAction.java
+++ b/prospero-common/src/main/java/org/wildfly/prospero/actions/InstallationHistoryAction.java
@@ -51,7 +51,7 @@ public class InstallationHistoryAction {
     private final Console console;
 
     public InstallationHistoryAction(Path installation, Console console) {
-        this.installation = installation;
+        this.installation = InstallFolderUtils.toRealPath(installation);
         this.console = console;
     }
 
@@ -110,6 +110,8 @@ public class InstallationHistoryAction {
         } else {
             InstallFolderUtils.verifyIsWritable(targetDir);
         }
+
+        targetDir = InstallFolderUtils.toRealPath(targetDir);
 
         try (InstallationMetadata metadata = InstallationMetadata.loadInstallation(installation)) {
             ProsperoLogger.ROOT_LOGGER.revertCandidateStarted(installation);

--- a/prospero-common/src/main/java/org/wildfly/prospero/actions/InstallationRestoreAction.java
+++ b/prospero-common/src/main/java/org/wildfly/prospero/actions/InstallationRestoreAction.java
@@ -48,7 +48,7 @@ public class InstallationRestoreAction {
     private final MavenSessionManager mavenSessionManager;
 
     public InstallationRestoreAction(Path installDir, MavenOptions mavenOptions, Console console) throws ProvisioningException {
-        this.installDir = installDir;
+        this.installDir = InstallFolderUtils.toRealPath(installDir);
         this.mavenSessionManager = new MavenSessionManager(mavenOptions);
         this.console = console;
     }

--- a/prospero-common/src/main/java/org/wildfly/prospero/actions/MetadataAction.java
+++ b/prospero-common/src/main/java/org/wildfly/prospero/actions/MetadataAction.java
@@ -36,6 +36,7 @@ public class MetadataAction implements AutoCloseable {
     private final InstallationMetadata installationMetadata;
 
     public MetadataAction(Path installation) throws MetadataException {
+        installation = InstallFolderUtils.toRealPath(installation);
         this.installationMetadata = InstallationMetadata.loadInstallation(installation);
     }
 

--- a/prospero-common/src/main/java/org/wildfly/prospero/actions/ProvisioningAction.java
+++ b/prospero-common/src/main/java/org/wildfly/prospero/actions/ProvisioningAction.java
@@ -73,7 +73,7 @@ public class ProvisioningAction {
     private final MavenOptions mvnOptions;
 
     public ProvisioningAction(Path installDir, MavenOptions mvnOptions, Console console) throws ProvisioningException {
-        this.installDir = installDir;
+        this.installDir = InstallFolderUtils.toRealPath(installDir);
         this.console = console;
         this.mvnOptions = mvnOptions;
         this.mavenSessionManager = new MavenSessionManager(mvnOptions);

--- a/prospero-common/src/main/java/org/wildfly/prospero/actions/UpdateAction.java
+++ b/prospero-common/src/main/java/org/wildfly/prospero/actions/UpdateAction.java
@@ -55,8 +55,8 @@ public class UpdateAction implements AutoCloseable {
 
     public UpdateAction(Path installDir, MavenOptions mavenOptions, Console console, List<Repository> overrideRepositories)
             throws OperationException, ProvisioningException {
-        this.metadata = InstallationMetadata.loadInstallation(installDir);
-        this.installDir = installDir;
+        this.installDir = InstallFolderUtils.toRealPath(installDir);
+        this.metadata = InstallationMetadata.loadInstallation(this.installDir);
         this.console = console;
         this.prosperoConfig = addTemporaryRepositories(overrideRepositories);
         this.mavenOptions = prosperoConfig.getMavenOptions().merge(mavenOptions);
@@ -110,6 +110,8 @@ public class UpdateAction implements AutoCloseable {
         } else {
             InstallFolderUtils.verifyIsWritable(targetDir);
         }
+
+        targetDir = InstallFolderUtils.toRealPath(targetDir);
 
         final UpdateSet updateSet = findUpdates();
         if (updateSet.isEmpty()) {

--- a/prospero-common/src/test/java/org/wildfly/prospero/actions/InstallFolderUtilsTest.java
+++ b/prospero-common/src/test/java/org/wildfly/prospero/actions/InstallFolderUtilsTest.java
@@ -1,0 +1,65 @@
+package org.wildfly.prospero.actions;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class InstallFolderUtilsTest {
+
+    @Rule
+    public TemporaryFolder temp = new TemporaryFolder();
+
+    @Test
+    public void testSymlinkIsConvertedToRealPath() throws Exception {
+        final Path realPath = createFolder();
+        final Path link = Files.createSymbolicLink(temp.newFolder().toPath().resolve("link"), realPath);
+
+        assertThat(InstallFolderUtils.toRealPath(link))
+                .isEqualTo(realPath);
+    }
+
+    @Test
+    public void testSymlinkNonExistingSubfolderIsConvertedToRealPath() throws Exception {
+        final Path realPath = createFolder();
+        final Path link = Files.createSymbolicLink(temp.newFolder().toPath().resolve("link"), realPath);
+
+        assertThat(InstallFolderUtils.toRealPath(link.resolve("test/foo")))
+                .isEqualTo(realPath.resolve("test/foo"));
+    }
+
+    @Test
+    public void testSymlinkSubfolderIsConvertedToRealPath() throws Exception {
+        final Path realPath = createFolder();
+        Files.createDirectories(realPath.resolve("test/foo"));
+        final Path link = Files.createSymbolicLink(temp.newFolder().toPath().resolve("link"), realPath);
+
+        assertThat(InstallFolderUtils.toRealPath(link.resolve("test/foo")))
+                .isEqualTo(realPath.resolve("test/foo"));
+    }
+
+    @Test
+    public void testNonExistingFolderIsNotConverted() throws Exception {
+        final Path folder = temp.newFolder().toPath().toRealPath().resolve("link");
+
+        assertThat(InstallFolderUtils.toRealPath(folder))
+                .isEqualTo(folder);
+    }
+
+    @Test
+    public void testExistingFolderIsNotConverted() throws Exception {
+        final Path folder = temp.newFolder().toPath().toRealPath();
+
+        assertThat(InstallFolderUtils.toRealPath(folder))
+                .isEqualTo(folder);
+    }
+
+    private Path createFolder() throws IOException {
+        return temp.newFolder("real").toPath().toRealPath();
+    }
+}


### PR DESCRIPTION
When specified Wildfly installation directory (JBOSS_HOME) is a symbolic link, applying update fails with "ERROR: java.nio.file.FileAlreadyExistsException: <specified-path-of-JBOSS_HOME-directory>".

Actually, it fails only when applying updates to files directly under the link (e.g. copying jboss-modules.jar), so other files under modules directory are appearantly updated succeessfully before the ERROR message.