### PR TITLE
Rollback changes in case of unsucessful apply stage

### DIFF
--- a/dist/docs/guide/process/index.adoc
+++ b/dist/docs/guide/process/index.adoc
@@ -47,3 +47,9 @@ During "*apply changes*" phase of updates, any processes using server's resource
 To reduce server downtime, the update operation can be performed in two steps - `prepare` and `apply`. In the first step, a candidate update server is provisioned in a new directory. The second step, compares the changes between the candidate and the base server and applies them to the base server.
 
 If the update is split into separate steps, the `prepare` step can be performed while the server is running. See <<Working with update candidates>> for details.
+
+#### Update backup
+
+The only time changes to the server are applied is during the `apply` phase of the update. To avoid leaving the server in a corrupted state, before any changes are written out, the current state of the server is preserved in an `<SERVER_ROOT>/.update.old` folder.
+
+Should an error occur during the operation, Prospero will attempt to restore the state from the backup. If that is not possible, or the update process was either canceled or crashed, the backup folder will be preserved and manual restore can be performed.

--- a/integration-tests/src/test/java/org/wildfly/prospero/it/cli/ApplyUpdateTest.java
+++ b/integration-tests/src/test/java/org/wildfly/prospero/it/cli/ApplyUpdateTest.java
@@ -18,6 +18,9 @@
 package org.wildfly.prospero.it.cli;
 
 import org.apache.commons.io.FileUtils;
+import org.assertj.core.internal.BinaryDiff;
+import org.assertj.core.internal.Diff;
+import org.assertj.core.util.diff.Delta;
 import org.jboss.galleon.util.ZipUtils;
 import org.junit.Before;
 import org.junit.Rule;
@@ -34,12 +37,20 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.wildfly.prospero.it.ExecutionUtils.isWindows;
 import static org.wildfly.prospero.test.MetadataTestUtils.upgradeStreamInManifest;
 
 @SuppressWarnings("OptionalGetWithoutIsPresent")
@@ -170,7 +181,7 @@ public class ApplyUpdateTest extends CliTestBase  {
         // apply update-candidate
         ExecutionUtils.prosperoExecution(CliConstants.Commands.UPDATE, CliConstants.Commands.APPLY,
                         CliConstants.CANDIDATE_DIR, candidateLink.toAbsolutePath().toString(),
-                        CliConstants.Y,
+                        CliConstants.Y, CliConstants.VERBOSE,
                         CliConstants.DIR, targetDir.getAbsolutePath())
                 .execute()
                 .assertReturnCode(ReturnCodes.SUCCESS);
@@ -179,6 +190,156 @@ public class ApplyUpdateTest extends CliTestBase  {
         wildflyCliStream = getInstalledArtifact(resolvedUpgradeArtifact.getArtifactId(), targetDir.toPath());
         assertEquals(WfCoreTestBase.UPGRADE_VERSION, wildflyCliStream.get().getVersion());
     }
+
+    @Test
+    public void failedApplyCandidate_ShouldRevertAllFileChanges() throws Exception {
+        final Path manifestPath = temp.newFile().toPath();
+        final Path provisionConfig = temp.newFile().toPath();
+        final Path updatePath = tempDir.newFolder("update-candidate").toPath();
+        MetadataTestUtils.copyManifest("manifests/wfcore-base.yaml", manifestPath);
+        MetadataTestUtils.prepareChannel(provisionConfig, List.of(manifestPath.toUri().toURL()), defaultRemoteRepositories());
+
+        install(provisionConfig, targetDir.toPath());
+
+        upgradeStreamInManifest(manifestPath, resolvedUpgradeArtifact);
+
+        final URL temporaryRepo = mockTemporaryRepo(true);
+
+        // generate update-candidate
+        ExecutionUtils.prosperoExecution(CliConstants.Commands.UPDATE, CliConstants.Commands.PREPARE,
+                        CliConstants.REPOSITORIES, temporaryRepo.toString(),
+                        CliConstants.CANDIDATE_DIR, updatePath.toAbsolutePath().toString(),
+                        CliConstants.Y,
+                        CliConstants.DIR, targetDir.getAbsolutePath())
+                .execute()
+                .assertReturnCode(ReturnCodes.SUCCESS);
+
+        // verify the original server has not been modified
+        Optional<Stream> wildflyCliStream = getInstalledArtifact(resolvedUpgradeArtifact.getArtifactId(), targetDir.toPath());
+        assertEquals(WfCoreTestBase.BASE_VERSION, wildflyCliStream.get().getVersion());
+
+
+        final File originalServer = temp.newFolder("server-copy");
+        FileUtils.copyDirectory(targetDir,originalServer);
+        final Path protectedPath = targetDir.toPath().resolve(".installation");
+        try {
+            // lock a resource that would be modified to force the apply to fail
+            lockPath(protectedPath, false);
+
+            // apply update-candidate
+            ExecutionUtils.prosperoExecution(CliConstants.Commands.UPDATE, CliConstants.Commands.APPLY,
+                            CliConstants.CANDIDATE_DIR, updatePath.toAbsolutePath().toString(),
+                            CliConstants.Y, CliConstants.VERBOSE,
+                            CliConstants.DIR, targetDir.getAbsolutePath())
+                    .execute()
+                    .assertReturnCode(ReturnCodes.PROCESSING_ERROR)
+                    .assertErrorContains("java.nio.file.AccessDeniedException");
+        } finally {
+            lockPath(protectedPath, true);
+        }
+
+        assertNoChanges(originalServer.toPath(), targetDir.toPath());
+    }
+
+    private static void lockPath(Path protectedPath, boolean writable) {
+        if (isWindows()) {
+            // On Windows we can't set a directory to be read-only so we have to set a single file.
+            // in this case manifest.yaml will have to be updated
+            assertTrue("Unable to set the read-only file permissions", protectedPath.resolve("manifest.yaml").toFile().setWritable(writable));
+        } else {
+            // On Linux for a change setting a file to be read-only doesn't prevent it from being overwritten
+            assertTrue("Unable to set the read-only file permissions", protectedPath.toFile().setWritable(writable));
+        }
+    }
+
+    private static class FileChange {
+        Path expected;
+        Path actual;
+
+        public FileChange(Path expected, Path actual) {
+            this.expected = expected;
+            this.actual = actual;
+        }
+    }
+
+    private void assertNoChanges(Path originalServer, Path targetDir) throws IOException {
+        final List<FileChange> changes = new ArrayList<>();
+        final BinaryDiff binaryDiff = new BinaryDiff();
+
+        // get a list of files present only in the expected server or ones present in both but with different content
+        Files.walkFileTree(originalServer, new SimpleFileVisitor<>() {
+            @Override
+            public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+                final Path relative = originalServer.relativize(file);
+                final Path actualFile = targetDir.resolve(relative);
+                if (!Files.exists(actualFile)) {
+                    changes.add(new FileChange(file, null));
+                } else if (binaryDiff.diff(actualFile, Files.readAllBytes(file)).hasDiff()) {
+                    changes.add(new FileChange(file, actualFile));
+                }
+                return FileVisitResult.CONTINUE;
+            }
+
+            @Override
+            public FileVisitResult postVisitDirectory(Path dir, IOException exc) throws IOException {
+                final Path relative = originalServer.relativize(dir);
+                final Path actualFile = targetDir.resolve(relative);
+                if (!Files.exists(actualFile)) {
+                    changes.add(new FileChange(dir, null));
+                }
+                return FileVisitResult.CONTINUE;
+            }
+        });
+
+        // get a list of files present only in the actual server
+        Files.walkFileTree(targetDir, new SimpleFileVisitor<>() {
+            @Override
+            public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+                final Path relative = targetDir.relativize(file);
+                final Path expectedFile = originalServer.resolve(relative);
+                if (!Files.exists(expectedFile)) {
+                    changes.add(new FileChange(null, file));
+                }
+                return FileVisitResult.CONTINUE;
+            }
+
+            @Override
+            public FileVisitResult postVisitDirectory(Path dir, IOException exc) throws IOException {
+                final Path relative = targetDir.relativize(dir);
+                final Path expectedFile = originalServer.resolve(relative);
+                if (!Files.exists(expectedFile)) {
+                    changes.add(new FileChange(null, dir));
+                }
+                return FileVisitResult.CONTINUE;
+            }
+        });
+
+        if (!changes.isEmpty()) {
+            final StringBuilder sb = new StringBuilder("Expected folders to be the same, but:\n");
+            final Diff textDiff = new Diff();
+
+            for (FileChange change : changes) {
+                if (change.actual == null) {
+                    sb.append(" [R] ").append(originalServer.relativize(change.expected)).append("\n");
+                } else if (change.expected == null) {
+                    sb.append(" [A] ").append(targetDir.relativize(change.actual)).append("\n");
+                } else {
+                    sb.append(" [M] ").append(targetDir.relativize(change.actual)).append("\n");
+                    final String fileName = change.actual.toString();
+                    if (fileName.endsWith("xml") || fileName.endsWith("txt") || fileName.endsWith("yaml")) {
+                        final List<Delta<String>> diff = textDiff.diff(change.actual, StandardCharsets.UTF_8, change.expected, StandardCharsets.UTF_8);
+                        diff.forEach(d->{
+                            sb.append("    Line ").append(d.lineNumber()).append(":").append("\n");
+                            sb.append("      - ").append(String.join("\n      - ", d.getOriginal().getLines())).append("\n");
+                            sb.append("      + ").append(String.join("\n      + ", d.getRevised().getLines())).append("\n");
+                        });
+                    }
+                }
+            }
+            fail(sb.toString());
+        }
+    }
+
 
     private Path createRepositoryArchive(URL temporaryRepo) throws URISyntaxException, IOException {
         final Path repoPath = Path.of(temporaryRepo.toURI());

--- a/integration-tests/src/test/java/org/wildfly/prospero/it/utils/DirectoryComparator.java
+++ b/integration-tests/src/test/java/org/wildfly/prospero/it/utils/DirectoryComparator.java
@@ -1,0 +1,120 @@
+package org.wildfly.prospero.it.utils;
+
+import org.assertj.core.internal.BinaryDiff;
+import org.assertj.core.internal.Diff;
+import org.assertj.core.util.diff.Delta;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.fail;
+
+public class DirectoryComparator {
+    private static final BinaryDiff BINARY_DIFF = new BinaryDiff();
+
+    private static class FileChange {
+        final Path expected;
+        final Path actual;
+
+        public FileChange(Path expected, Path actual) {
+            this.expected = expected;
+            this.actual = actual;
+        }
+    }
+
+    public static void assertNoChanges(Path originalServer, Path targetDir) throws IOException {
+        final List<FileChange> changes = new ArrayList<>();
+
+        // get a list of files present only in the expected server or ones present in both but with different content
+        Files.walkFileTree(originalServer, listAddedAndModifiedFiles(originalServer, targetDir, changes));
+
+        // get a list of files present only in the actual server
+        Files.walkFileTree(targetDir, listRemovedFiles(originalServer, targetDir, changes));
+
+        if (!changes.isEmpty()) {
+            fail(describeChanges(originalServer, targetDir, changes));
+        }
+    }
+
+    private static String describeChanges(Path originalServer, Path targetDir, List<FileChange> changes) throws IOException {
+        final StringBuilder sb = new StringBuilder("Expected folders to be the same, but:\n");
+        final Diff textDiff = new Diff();
+
+        for (FileChange change : changes) {
+            if (change.actual == null) {
+                sb.append(" [R] ").append(originalServer.relativize(change.expected)).append("\n");
+            } else if (change.expected == null) {
+                sb.append(" [A] ").append(targetDir.relativize(change.actual)).append("\n");
+            } else {
+                sb.append(" [M] ").append(targetDir.relativize(change.actual)).append("\n");
+                final String fileName = change.actual.toString();
+                if (fileName.endsWith("xml") || fileName.endsWith("txt") || fileName.endsWith("yaml")) {
+                    final List<Delta<String>> diff = textDiff.diff(change.actual, StandardCharsets.UTF_8, change.expected, StandardCharsets.UTF_8);
+                    diff.forEach(d->{
+                        sb.append("    Line ").append(d.lineNumber()).append(":").append("\n");
+                        sb.append("      - ").append(String.join("\n      - ", d.getOriginal().getLines())).append("\n");
+                        sb.append("      + ").append(String.join("\n      + ", d.getRevised().getLines())).append("\n");
+                    });
+                }
+            }
+        }
+        return sb.toString();
+    }
+
+    private static SimpleFileVisitor<Path> listRemovedFiles(Path originalServer, Path targetDir, List<FileChange> changes) {
+        return new SimpleFileVisitor<>() {
+            @Override
+            public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+                final Path relative = targetDir.relativize(file);
+                final Path expectedFile = originalServer.resolve(relative);
+                if (!Files.exists(expectedFile)) {
+                    changes.add(new FileChange(null, file));
+                }
+                return FileVisitResult.CONTINUE;
+            }
+
+            @Override
+            public FileVisitResult postVisitDirectory(Path dir, IOException exc) throws IOException {
+                final Path relative = targetDir.relativize(dir);
+                final Path expectedFile = originalServer.resolve(relative);
+                if (!Files.exists(expectedFile)) {
+                    changes.add(new FileChange(null, dir));
+                }
+                return FileVisitResult.CONTINUE;
+            }
+        };
+    }
+
+    private static SimpleFileVisitor<Path> listAddedAndModifiedFiles(Path originalServer, Path targetDir, List<FileChange> changes) {
+        return new SimpleFileVisitor<>() {
+            @Override
+            public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+                final Path relative = originalServer.relativize(file);
+                final Path actualFile = targetDir.resolve(relative);
+                if (!Files.exists(actualFile)) {
+                    changes.add(new FileChange(file, null));
+                } else if (BINARY_DIFF.diff(actualFile, Files.readAllBytes(file)).hasDiff()) {
+                    changes.add(new FileChange(file, actualFile));
+                }
+                return FileVisitResult.CONTINUE;
+            }
+
+            @Override
+            public FileVisitResult postVisitDirectory(Path dir, IOException exc) throws IOException {
+                final Path relative = originalServer.relativize(dir);
+                final Path actualFile = targetDir.resolve(relative);
+                if (!Files.exists(actualFile)) {
+                    changes.add(new FileChange(dir, null));
+                }
+                return FileVisitResult.CONTINUE;
+            }
+        };
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
         <version.org.codehaus.plexus-interpolation>1.27</version.org.codehaus.plexus-interpolation>
         <version.org.codehaus.plexus-utils>3.5.0</version.org.codehaus.plexus-utils>
         <version.org.jboss.staxmapper>1.5.0.Final</version.org.jboss.staxmapper>
-        <version.org.jboss.galleon>6.0.1.Final</version.org.jboss.galleon>
+        <version.org.jboss.galleon>6.0.2.Final</version.org.jboss.galleon>
         <version.org.eclipse.jgit>6.9.0.202403050737-r</version.org.eclipse.jgit>
         <version.com.fasterxml.jackson>2.15.4</version.com.fasterxml.jackson>
         <version.org.jboss.logmanager>2.1.19.Final</version.org.jboss.logmanager>

--- a/prospero-cli/src/main/java/org/wildfly/prospero/cli/CliMessages.java
+++ b/prospero-cli/src/main/java/org/wildfly/prospero/cli/CliMessages.java
@@ -700,4 +700,12 @@ public interface CliMessages {
     default OperationException sizeOfChannel(Path channelFile) {
         return new OperationException(format(bundle.getString("prospero.channels.error.morethanonechannel.found"), channelFile));
     }
+
+    default String candidateApplyRollbackSuccess() {
+        return bundle.getString("prospero.candidate.apply.error.rolled_back.desc");
+    }
+
+    default String candidateApplyRollbackFailure(Path backup) {
+        return format(bundle.getString("prospero.candidate.apply.error.rollback_error.desc"), backup);
+    }
 }

--- a/prospero-cli/src/main/java/org/wildfly/prospero/cli/ExecutionExceptionHandler.java
+++ b/prospero-cli/src/main/java/org/wildfly/prospero/cli/ExecutionExceptionHandler.java
@@ -24,6 +24,7 @@ import org.wildfly.channel.ArtifactCoordinate;
 import org.wildfly.channel.ChannelMetadataCoordinate;
 import org.wildfly.channel.Repository;
 import org.wildfly.prospero.api.ArtifactUtils;
+import org.wildfly.prospero.api.exceptions.ApplyCandidateException;
 import org.wildfly.prospero.api.exceptions.ArtifactResolutionException;
 import org.wildfly.prospero.api.exceptions.ChannelDefinitionException;
 import org.wildfly.prospero.api.exceptions.MetadataException;
@@ -104,6 +105,16 @@ public class ExecutionExceptionHandler implements CommandLine.IExecutionExceptio
                 if (ex.getCause() != null && (ex.getCause() instanceof MarkedYAMLException || ex.getCause() instanceof JsonMappingException)) {
                     console.error(ex.getCause().getLocalizedMessage());
                 }
+            } else if (ex instanceof ApplyCandidateException) {
+                ApplyCandidateException ace = (ApplyCandidateException) ex;
+                console.error(System.lineSeparator() + ace.getMessage());
+
+                if (ace.isRollbackSuccessful()) {
+                    console.error(System.lineSeparator() + CliMessages.MESSAGES.candidateApplyRollbackSuccess());
+                } else {
+                    console.error(System.lineSeparator() + CliMessages.MESSAGES.candidateApplyRollbackFailure(ace.getBackupPath()));
+                }
+
             } else {
                 console.error(CliMessages.MESSAGES.errorHeader(ex.getLocalizedMessage()));
             }

--- a/prospero-cli/src/main/resources/UsageMessages.properties
+++ b/prospero-cli/src/main/resources/UsageMessages.properties
@@ -407,3 +407,6 @@ prospero.install.list.profile.no_profiles.header=No installation profiles availa
 prospero.install.list.profile=Profile:\u0020
 prospero.install.list.profile.subscribe.channels=Subscribed channels:\u0020
 prospero.install.list.profile.featurePacks=Installed feature packs:\u0020
+
+prospero.candidate.apply.error.rolled_back.desc=The incomplete update changes have been rolled back. Please resolve above error and try to perform update again.
+prospero.candidate.apply.error.rollback_error.desc=Unable to restore the incomplete update changes. The server might have been left in a corrupted state, please check the backup of the server at %s.

--- a/prospero-common/src/main/java/org/wildfly/prospero/ProsperoLogger.java
+++ b/prospero-common/src/main/java/org/wildfly/prospero/ProsperoLogger.java
@@ -389,4 +389,7 @@ public interface ProsperoLogger extends BasicLogger {
 
     @Message(id = 271, value = "Unable to evaluate symbolic link %s.")
     RuntimeException unableToEvaluateSymbolicLink(Path symlink, @Cause IOException e);
+
+    @Message(id = 272, value = "Failed to apply the candidate changes due to: %s")
+    String failedToApplyCandidate(String reason);
 }

--- a/prospero-common/src/main/java/org/wildfly/prospero/actions/ApplyCandidateAction.java
+++ b/prospero-common/src/main/java/org/wildfly/prospero/actions/ApplyCandidateAction.java
@@ -18,6 +18,7 @@ package org.wildfly.prospero.actions;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.AccessDeniedException;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -179,7 +180,7 @@ public class ApplyCandidateAction {
         final FsDiff diffs = findChanges();
         ApplyStageBackup backup = null;
         try {
-            backup = new ApplyStageBackup(installationDir);
+            backup = new ApplyStageBackup(installationDir, updateDir);
             backup.recordAll();
 
             ProsperoLogger.ROOT_LOGGER.debug("Update backup generated in " + installationDir.resolve(ApplyStageBackup.BACKUP_FOLDER));
@@ -723,6 +724,9 @@ public class ApplyCandidateAction {
                 if (dir.equals(skipInstallationGalleon) || dir.equals(skipInstallationInstallation) || dir.equals(installationDir.resolve(ApplyStageBackup.BACKUP_FOLDER))) {
                     return FileVisitResult.SKIP_SUBTREE;
                 }
+                if (!Files.isReadable(dir)) {
+                    return FileVisitResult.SKIP_SUBTREE;
+                }
                 if (!dir.equals(installationDir)) {
                     Path relative = installationDir.relativize(dir);
                     Path target = updateDir.resolve(relative);
@@ -752,6 +756,21 @@ public class ApplyCandidateAction {
                     }
                 }
                 return FileVisitResult.CONTINUE;
+            }
+
+            @Override
+            public FileVisitResult visitFileFailed(Path file, IOException exc) throws IOException {
+                if (exc instanceof AccessDeniedException) {
+                    Path relative = installationDir.relativize(file);
+                    Path target = updateDir.resolve(relative);
+                    // TODO: check it's not in the Galleon hashes
+                    if (Files.exists(target)) {
+                        throw exc;
+                    }
+                    return FileVisitResult.SKIP_SUBTREE;
+                } else {
+                    throw exc;
+                }
             }
         });
         return Collections.unmodifiableList(conflicts);

--- a/prospero-common/src/main/java/org/wildfly/prospero/actions/ApplyCandidateAction.java
+++ b/prospero-common/src/main/java/org/wildfly/prospero/actions/ApplyCandidateAction.java
@@ -48,6 +48,7 @@ import org.wildfly.prospero.api.FileConflict;
 import org.wildfly.prospero.api.InstallationMetadata;
 import org.wildfly.prospero.api.MavenOptions;
 import org.wildfly.prospero.api.SavedState;
+import org.wildfly.prospero.api.TemporaryFilesManager;
 import org.wildfly.prospero.api.exceptions.InvalidUpdateCandidateException;
 import org.wildfly.prospero.api.exceptions.MetadataException;
 import org.wildfly.prospero.api.exceptions.OperationException;
@@ -175,31 +176,46 @@ public class ApplyCandidateAction {
             throw ex;
         }
 
-        FsDiff diffs = findChanges();
-        try {
-            ProsperoLogger.ROOT_LOGGER.applyingCandidate(operation.text.toLowerCase(Locale.ROOT), updateDir);
-            ProsperoLogger.ROOT_LOGGER.candidateChanges(
-                    findUpdates().getArtifactUpdates().stream().map(ArtifactChange::prettyPrint).collect(Collectors.joining("; "))
+        final FsDiff diffs = findChanges();
+        try (TemporaryFilesManager temp = TemporaryFilesManager.getInstance()) {
+            ApplyStageBackup backup = null;
+            try {
+                backup = new ApplyStageBackup(installationDir, temp.createTempDirectory("prospero-apply-backup"));
+                ProsperoLogger.ROOT_LOGGER.applyingCandidate(operation.text.toLowerCase(Locale.ROOT), updateDir);
+                ProsperoLogger.ROOT_LOGGER.candidateChanges(
+                        findUpdates().getArtifactUpdates().stream().map(ArtifactChange::prettyPrint).collect(Collectors.joining("; "))
+                );
+
+                final List<FileConflict> conflicts = doApplyUpdate(diffs, backup);
+
+                if (conflicts.isEmpty()) {
+                    ProsperoLogger.ROOT_LOGGER.noCandidateConflicts();
+                } else {
+                    ProsperoLogger.ROOT_LOGGER.candidateConflicts(
+                            conflicts.stream().map(FileConflict::prettyPrint).collect(Collectors.joining("; "))
                     );
+                    for (FileConflict conflict : conflicts) {
+                        ProsperoLogger.ROOT_LOGGER.info(conflict.prettyPrint());
+                    }
+                }
 
-            final List<FileConflict> conflicts = doApplyUpdate(diffs);
-
-            if (conflicts.isEmpty()) {
-                ProsperoLogger.ROOT_LOGGER.noCandidateConflicts();
-            } else {
-                ProsperoLogger.ROOT_LOGGER.candidateConflicts(
-                        conflicts.stream().map(FileConflict::prettyPrint).collect(Collectors.joining("; "))
-                        );
-                for (FileConflict conflict : conflicts) {
-                    ProsperoLogger.ROOT_LOGGER.info(conflict.prettyPrint());
+                updateMetadata(operation, backup);
+                ProsperoLogger.ROOT_LOGGER.candidateApplied(operation.text, installationDir);
+                return conflicts;
+            } catch (IOException ex) {
+                try {
+                    if (backup != null) {
+                        backup.restore();
+                    }
+                } catch (IOException e) {
+                    throw new ProvisioningException("Unable to restore the server from a backup.", e);
+                }
+                throw new ProvisioningException("Unable to apply the candidate changes.", ex);
+            } finally {
+                if (backup != null) {
+                    backup.close();
                 }
             }
-
-            updateMetadata(operation);
-            ProsperoLogger.ROOT_LOGGER.candidateApplied(operation.text, installationDir);
-            return conflicts;
-        } catch (IOException ex) {
-            throw new ProvisioningException(ex);
         }
     }
 
@@ -386,21 +402,21 @@ public class ApplyCandidateAction {
 
     }
 
-    private void updateMetadata(Type operation) throws ProvisioningException, MetadataException {
-        try {
-            copyCurrentVersions();
-            Path installationGalleonPath = PathsUtils.getProvisionedStateDir(installationDir);
-            Path updateGalleonPath = PathsUtils.getProvisionedStateDir(updateDir);
-            IoUtils.recursiveDelete(installationGalleonPath);
-            IoUtils.copy(updateGalleonPath, installationGalleonPath, true);
-            // after the galleon data is copied, persist a copy of provisioning.xml and record it
-            ProsperoMetadataUtils.recordProvisioningDefinition(installationDir);
-            writeProsperoMetadata(operation);
-            updateInstallationCache();
-            updateAcceptedLicences();
-        } catch (IOException ex) {
-            throw new ProvisioningException(ex);
-        }
+    private void updateMetadata(Type operation, ApplyStageBackup backup) throws IOException, MetadataException {
+        // add all files in .installation folder to the backup set
+        backup.record(installationDir.resolve(METADATA_DIR));
+        copyCurrentVersions();
+        Path installationGalleonPath = PathsUtils.getProvisionedStateDir(installationDir);
+        Path updateGalleonPath = PathsUtils.getProvisionedStateDir(updateDir);
+        // add all files in .galleon folder to the backup set
+        backup.record(installationGalleonPath);
+        IoUtils.recursiveDelete(installationGalleonPath);
+        IoUtils.copy(updateGalleonPath, installationGalleonPath, true);
+        // after the galleon data is copied, persist a copy of provisioning.xml and record it
+        ProsperoMetadataUtils.recordProvisioningDefinition(installationDir);
+        writeProsperoMetadata(operation);
+        updateInstallationCache();
+        updateAcceptedLicences();
     }
 
     private void updateAcceptedLicences() throws MetadataException {
@@ -500,7 +516,8 @@ public class ApplyCandidateAction {
         return conflictList;
     }
 
-    private void addFsEntry(Path updateDir, FsEntry added, SystemPaths systemPaths, List<FileConflict> conflictList)
+    private void addFsEntry(Path updateDir, FsEntry added, SystemPaths systemPaths,
+                            List<FileConflict> conflictList)
             throws ProvisioningException {
         final Path target = updateDir.resolve(added.getRelativePath());
         if (ProsperoLogger.ROOT_LOGGER.isDebugEnabled()) {
@@ -598,14 +615,14 @@ public class ApplyCandidateAction {
         return Collections.unmodifiableList(conflicts);
     }
 
-    private List<FileConflict> doApplyUpdate(FsDiff fsDiff) throws IOException, ProvisioningException {
+    private List<FileConflict> doApplyUpdate(FsDiff fsDiff, ApplyStageBackup backup) throws IOException, ProvisioningException {
         List<FileConflict> conflicts = new ArrayList<>();
         // Handles user added/removed/modified files
         conflicts.addAll(handleRemovedFiles(fsDiff));
         conflicts.addAll(handleAddedFiles(fsDiff));
         conflicts.addAll(handleModifiedFiles(fsDiff));
 
-        resolveFileConflicts(conflicts);
+        resolveFileConflicts(conflicts, backup);
 
         // Handles files added/removed/modified in the update.
         Path skipUpdateGalleon = PathsUtils.getProvisionedStateDir(updateDir);
@@ -630,6 +647,7 @@ public class ApplyCandidateAction {
                         if (ProsperoLogger.ROOT_LOGGER.isDebugEnabled()) {
                             ProsperoLogger.ROOT_LOGGER.debug("Copying updated file " + relative + " to the installation");
                         }
+                        backup.record(installationFile);
                         IoUtils.copy(file, installationFile);
                     }
                 }
@@ -677,6 +695,7 @@ public class ApplyCandidateAction {
                     if (ProsperoLogger.ROOT_LOGGER.isDebugEnabled()) {
                         ProsperoLogger.ROOT_LOGGER.debug("Deleting the file " + relative + " that doesn't exist in the update");
                     }
+                    backup.record(file);
                     IoUtils.recursiveDelete(file);
                 }
                 return FileVisitResult.CONTINUE;
@@ -719,6 +738,7 @@ public class ApplyCandidateAction {
                         if (ProsperoLogger.ROOT_LOGGER.isDebugEnabled()) {
                             ProsperoLogger.ROOT_LOGGER.debug("Deleting the directory " + relative + " that doesn't exist in the update");
                         }
+                        backup.record(dir);
                         IoUtils.recursiveDelete(dir);
                         return FileVisitResult.SKIP_SUBTREE;
                     }
@@ -729,7 +749,7 @@ public class ApplyCandidateAction {
         return Collections.unmodifiableList(conflicts);
     }
 
-    private void resolveFileConflicts(List<FileConflict> conflicts) throws IOException, ProvisioningException {
+    private void resolveFileConflicts(List<FileConflict> conflicts, ApplyStageBackup backup) throws IOException, ProvisioningException {
         // apply conflict resolution
         for (FileConflict conflict : conflicts) {
             final Path target = updateDir.resolve(conflict.getRelativePath());
@@ -744,22 +764,22 @@ public class ApplyCandidateAction {
                 if (ProsperoLogger.ROOT_LOGGER.isTraceEnabled()) {
                     ProsperoLogger.ROOT_LOGGER.trace("Resolving file conflict: backing up user changes and applying update changes: " + conflict);
                 }
-                glold(current, target);
+                glold(current, target, backup);
             } else if (conflict.getUpdateChange() == FileConflict.Change.ADDED && conflict.getResolution() == FileConflict.Resolution.USER) {
                 if (ProsperoLogger.ROOT_LOGGER.isTraceEnabled()) {
                     ProsperoLogger.ROOT_LOGGER.trace("Resolving file conflict: preserving user changes and backing up update changes: " + conflict);
                 }
-                glnew(target, current);
+                glnew(target, current, backup);
             } else if (conflict.getUpdateChange() == FileConflict.Change.MODIFIED && conflict.getResolution() == FileConflict.Resolution.UPDATE) {
                 if (ProsperoLogger.ROOT_LOGGER.isTraceEnabled()) {
                     ProsperoLogger.ROOT_LOGGER.trace("Resolving file conflict: backing up user changes and applying update changes: " + conflict);
                 }
-                glold(current, target);
+                glold(current, target, backup);
             } else if (conflict.getUpdateChange() == FileConflict.Change.MODIFIED && conflict.getResolution() == FileConflict.Resolution.USER) {
                 if (ProsperoLogger.ROOT_LOGGER.isTraceEnabled()) {
                     ProsperoLogger.ROOT_LOGGER.trace("Resolving file conflict: preserving user changes and backing up update changes: " + conflict);
                 }
-                glnew(target, current);
+                glnew(target, current, backup);
             } else {
                 ProsperoLogger.ROOT_LOGGER.debug("Unknown conflict type: " + conflict);
             }
@@ -793,20 +813,29 @@ public class ApplyCandidateAction {
 
 
 
-    private static void glnew(final Path updateFile, Path installationFile) throws ProvisioningException {
+    private static void glnew(final Path updateFile, Path installationFile, ApplyStageBackup backup) throws ProvisioningException {
+        final Path glnewFile = installationFile.getParent().resolve(installationFile.getFileName() + Constants.DOT_GLNEW);
         try {
-            IoUtils.copy(updateFile, installationFile.getParent().resolve(installationFile.getFileName() + Constants.DOT_GLNEW));
+            if (backup != null) {
+                backup.record(glnewFile);
+                IoUtils.copy(updateFile, glnewFile);
+            }
         } catch (IOException e) {
-            throw new ProvisioningException("Failed to persist " + installationFile.getParent().resolve(installationFile.getFileName() + Constants.DOT_GLNEW), e);
+            throw new ProvisioningException("Failed to persist " + glnewFile, e);
         }
     }
 
-    private static void glold(Path installationFile, final Path target) throws ProvisioningException {
+    private static void glold(Path installationFile, final Path target, ApplyStageBackup backup) throws ProvisioningException {
+        final Path gloldFile = installationFile.getParent().resolve(installationFile.getFileName() + Constants.DOT_GLOLD);
         try {
-            IoUtils.copy(installationFile, installationFile.getParent().resolve(installationFile.getFileName() + Constants.DOT_GLOLD));
-            IoUtils.copy(target, installationFile);
+            if (backup != null) {
+                backup.record(gloldFile);
+                IoUtils.copy(installationFile, gloldFile);
+                backup.record(installationFile);
+                IoUtils.copy(target, installationFile);
+            }
         } catch (IOException e) {
-            throw new ProvisioningException("Failed to persist " + target.getParent().resolve(target.getFileName() + Constants.DOT_GLOLD), e);
+            throw new ProvisioningException("Failed to persist " + gloldFile, e);
         }
     }
 

--- a/prospero-common/src/main/java/org/wildfly/prospero/actions/ApplyCandidateAction.java
+++ b/prospero-common/src/main/java/org/wildfly/prospero/actions/ApplyCandidateAction.java
@@ -48,6 +48,7 @@ import org.wildfly.prospero.api.FileConflict;
 import org.wildfly.prospero.api.InstallationMetadata;
 import org.wildfly.prospero.api.MavenOptions;
 import org.wildfly.prospero.api.SavedState;
+import org.wildfly.prospero.api.exceptions.ApplyCandidateException;
 import org.wildfly.prospero.api.exceptions.InvalidUpdateCandidateException;
 import org.wildfly.prospero.api.exceptions.MetadataException;
 import org.wildfly.prospero.api.exceptions.OperationException;
@@ -208,16 +209,20 @@ public class ApplyCandidateAction {
             backup.close();
             return conflicts;
         } catch (IOException ex) {
+            boolean backupRestored = false;
             try {
                 if (backup != null) {
                     backup.restore();
                     // remove close the backup if the restore was successful. If there were any errors, we want to keep the backup untouched.
                     backup.close();
+                    backupRestored = true;
                 }
             } catch (IOException e) {
                 ProsperoLogger.ROOT_LOGGER.error("Unable to restore the server from a backup, preserving the backup.", e);
             }
-            throw new ProvisioningException("Unable to apply the candidate changes.", ex);
+            final String msg = ex.getLocalizedMessage() == null ? ex.getMessage() : ex.getLocalizedMessage();
+            throw new ApplyCandidateException(ProsperoLogger.ROOT_LOGGER.failedToApplyCandidate(msg),
+                    backupRestored, installationDir.resolve(ApplyStageBackup.BACKUP_FOLDER), ex);
         }
     }
 

--- a/prospero-common/src/main/java/org/wildfly/prospero/actions/ApplyCandidateAction.java
+++ b/prospero-common/src/main/java/org/wildfly/prospero/actions/ApplyCandidateAction.java
@@ -48,7 +48,6 @@ import org.wildfly.prospero.api.FileConflict;
 import org.wildfly.prospero.api.InstallationMetadata;
 import org.wildfly.prospero.api.MavenOptions;
 import org.wildfly.prospero.api.SavedState;
-import org.wildfly.prospero.api.TemporaryFilesManager;
 import org.wildfly.prospero.api.exceptions.InvalidUpdateCandidateException;
 import org.wildfly.prospero.api.exceptions.MetadataException;
 import org.wildfly.prospero.api.exceptions.OperationException;
@@ -177,45 +176,48 @@ public class ApplyCandidateAction {
         }
 
         final FsDiff diffs = findChanges();
-        try (TemporaryFilesManager temp = TemporaryFilesManager.getInstance()) {
-            ApplyStageBackup backup = null;
-            try {
-                backup = new ApplyStageBackup(installationDir, temp.createTempDirectory("prospero-apply-backup"));
-                ProsperoLogger.ROOT_LOGGER.applyingCandidate(operation.text.toLowerCase(Locale.ROOT), updateDir);
-                ProsperoLogger.ROOT_LOGGER.candidateChanges(
-                        findUpdates().getArtifactUpdates().stream().map(ArtifactChange::prettyPrint).collect(Collectors.joining("; "))
+        ApplyStageBackup backup = null;
+        try {
+            backup = new ApplyStageBackup(installationDir);
+            backup.recordAll();
+
+            ProsperoLogger.ROOT_LOGGER.debug("Update backup generated in " + installationDir.resolve(ApplyStageBackup.BACKUP_FOLDER));
+
+            ProsperoLogger.ROOT_LOGGER.applyingCandidate(operation.text.toLowerCase(Locale.ROOT), updateDir);
+            ProsperoLogger.ROOT_LOGGER.candidateChanges(
+                    findUpdates().getArtifactUpdates().stream().map(ArtifactChange::prettyPrint).collect(Collectors.joining("; "))
+            );
+
+            final List<FileConflict> conflicts = doApplyUpdate(diffs);
+
+            if (conflicts.isEmpty()) {
+                ProsperoLogger.ROOT_LOGGER.noCandidateConflicts();
+            } else {
+                ProsperoLogger.ROOT_LOGGER.candidateConflicts(
+                        conflicts.stream().map(FileConflict::prettyPrint).collect(Collectors.joining("; "))
                 );
-
-                final List<FileConflict> conflicts = doApplyUpdate(diffs, backup);
-
-                if (conflicts.isEmpty()) {
-                    ProsperoLogger.ROOT_LOGGER.noCandidateConflicts();
-                } else {
-                    ProsperoLogger.ROOT_LOGGER.candidateConflicts(
-                            conflicts.stream().map(FileConflict::prettyPrint).collect(Collectors.joining("; "))
-                    );
-                    for (FileConflict conflict : conflicts) {
-                        ProsperoLogger.ROOT_LOGGER.info(conflict.prettyPrint());
-                    }
-                }
-
-                updateMetadata(operation, backup);
-                ProsperoLogger.ROOT_LOGGER.candidateApplied(operation.text, installationDir);
-                return conflicts;
-            } catch (IOException ex) {
-                try {
-                    if (backup != null) {
-                        backup.restore();
-                    }
-                } catch (IOException e) {
-                    throw new ProvisioningException("Unable to restore the server from a backup.", e);
-                }
-                throw new ProvisioningException("Unable to apply the candidate changes.", ex);
-            } finally {
-                if (backup != null) {
-                    backup.close();
+                for (FileConflict conflict : conflicts) {
+                    ProsperoLogger.ROOT_LOGGER.info(conflict.prettyPrint());
                 }
             }
+
+            updateMetadata(operation);
+            ProsperoLogger.ROOT_LOGGER.candidateApplied(operation.text, installationDir);
+
+            // remove the backup if the apply operation was successful
+            backup.close();
+            return conflicts;
+        } catch (IOException ex) {
+            try {
+                if (backup != null) {
+                    backup.restore();
+                    // remove close the backup if the restore was successful. If there were any errors, we want to keep the backup untouched.
+                    backup.close();
+                }
+            } catch (IOException e) {
+                ProsperoLogger.ROOT_LOGGER.error("Unable to restore the server from a backup, preserving the backup.", e);
+            }
+            throw new ProvisioningException("Unable to apply the candidate changes.", ex);
         }
     }
 
@@ -402,14 +404,12 @@ public class ApplyCandidateAction {
 
     }
 
-    private void updateMetadata(Type operation, ApplyStageBackup backup) throws IOException, MetadataException {
+    private void updateMetadata(Type operation) throws IOException, MetadataException {
         // add all files in .installation folder to the backup set
-        backup.record(installationDir.resolve(METADATA_DIR));
         copyCurrentVersions();
         Path installationGalleonPath = PathsUtils.getProvisionedStateDir(installationDir);
         Path updateGalleonPath = PathsUtils.getProvisionedStateDir(updateDir);
         // add all files in .galleon folder to the backup set
-        backup.record(installationGalleonPath);
         IoUtils.recursiveDelete(installationGalleonPath);
         IoUtils.copy(updateGalleonPath, installationGalleonPath, true);
         // after the galleon data is copied, persist a copy of provisioning.xml and record it
@@ -440,7 +440,7 @@ public class ApplyCandidateAction {
 
         Path installationMetadataDir = installationDir.resolve(METADATA_DIR);
         Path installationManifest = installationMetadataDir.resolve(ProsperoMetadataUtils.MANIFEST_FILE_NAME);
-        IoUtils.copy(updateManifest, installationManifest);
+        copyFiles(updateManifest, installationManifest);
 
         try (GitStorage git = new GitStorage(installationDir)) {
             switch (operation) {
@@ -452,7 +452,7 @@ public class ApplyCandidateAction {
 
                     final Path updateChannels = updateMetadataDir.resolve(ProsperoMetadataUtils.INSTALLER_CHANNELS_FILE_NAME);
                     final Path installationChannels = installationMetadataDir.resolve(ProsperoMetadataUtils.INSTALLER_CHANNELS_FILE_NAME);
-                    IoUtils.copy(updateChannels, installationChannels);
+                    copyFiles(updateChannels, installationChannels);
 
                     break;
                 case FEATURE_ADD:
@@ -460,6 +460,14 @@ public class ApplyCandidateAction {
                     break;
             }
         }
+    }
+
+    private static void copyFiles(Path source, Path target) throws IOException {
+        if (Files.exists(target)) {
+            // need to remove the existing file, because we use a hardlink to provide a backup
+            FileUtils.deleteQuietly(target.toFile());
+        }
+        IoUtils.copy(source, target);
     }
 
     private void updateInstallationCache() throws IOException {
@@ -471,7 +479,7 @@ public class ApplyCandidateAction {
             IoUtils.recursiveDelete(installationCacheDir);
         }
         if (Files.exists(updateCacheDir)) {
-            IoUtils.copy(updateCacheDir, installationCacheDir);
+            copyFiles(updateCacheDir, installationCacheDir);
         }
     }
 
@@ -615,14 +623,14 @@ public class ApplyCandidateAction {
         return Collections.unmodifiableList(conflicts);
     }
 
-    private List<FileConflict> doApplyUpdate(FsDiff fsDiff, ApplyStageBackup backup) throws IOException, ProvisioningException {
+    private List<FileConflict> doApplyUpdate(FsDiff fsDiff) throws IOException, ProvisioningException {
         List<FileConflict> conflicts = new ArrayList<>();
         // Handles user added/removed/modified files
         conflicts.addAll(handleRemovedFiles(fsDiff));
         conflicts.addAll(handleAddedFiles(fsDiff));
         conflicts.addAll(handleModifiedFiles(fsDiff));
 
-        resolveFileConflicts(conflicts, backup);
+        resolveFileConflicts(conflicts);
 
         // Handles files added/removed/modified in the update.
         Path skipUpdateGalleon = PathsUtils.getProvisionedStateDir(updateDir);
@@ -647,8 +655,7 @@ public class ApplyCandidateAction {
                         if (ProsperoLogger.ROOT_LOGGER.isDebugEnabled()) {
                             ProsperoLogger.ROOT_LOGGER.debug("Copying updated file " + relative + " to the installation");
                         }
-                        backup.record(installationFile);
-                        IoUtils.copy(file, installationFile);
+                        copyFiles(file, installationFile);
                     }
                 }
                 return FileVisitResult.CONTINUE;
@@ -695,7 +702,6 @@ public class ApplyCandidateAction {
                     if (ProsperoLogger.ROOT_LOGGER.isDebugEnabled()) {
                         ProsperoLogger.ROOT_LOGGER.debug("Deleting the file " + relative + " that doesn't exist in the update");
                     }
-                    backup.record(file);
                     IoUtils.recursiveDelete(file);
                 }
                 return FileVisitResult.CONTINUE;
@@ -708,9 +714,8 @@ public class ApplyCandidateAction {
             }
 
             @Override
-            public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs)
-                    throws IOException {
-                if (dir.equals(skipInstallationGalleon) || dir.equals(skipInstallationInstallation)) {
+            public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) {
+                if (dir.equals(skipInstallationGalleon) || dir.equals(skipInstallationInstallation) || dir.equals(installationDir.resolve(ApplyStageBackup.BACKUP_FOLDER))) {
                     return FileVisitResult.SKIP_SUBTREE;
                 }
                 if (!dir.equals(installationDir)) {
@@ -728,8 +733,7 @@ public class ApplyCandidateAction {
             }
 
             @Override
-            public FileVisitResult postVisitDirectory(Path dir, IOException e)
-                    throws IOException {
+            public FileVisitResult postVisitDirectory(Path dir, IOException e) {
                 if (!dir.equals(installationDir)) {
                     Path relative = installationDir.relativize(dir);
                     Path target = updateDir.resolve(relative);
@@ -738,7 +742,6 @@ public class ApplyCandidateAction {
                         if (ProsperoLogger.ROOT_LOGGER.isDebugEnabled()) {
                             ProsperoLogger.ROOT_LOGGER.debug("Deleting the directory " + relative + " that doesn't exist in the update");
                         }
-                        backup.record(dir);
                         IoUtils.recursiveDelete(dir);
                         return FileVisitResult.SKIP_SUBTREE;
                     }
@@ -749,7 +752,7 @@ public class ApplyCandidateAction {
         return Collections.unmodifiableList(conflicts);
     }
 
-    private void resolveFileConflicts(List<FileConflict> conflicts, ApplyStageBackup backup) throws IOException, ProvisioningException {
+    private void resolveFileConflicts(List<FileConflict> conflicts) throws IOException, ProvisioningException {
         // apply conflict resolution
         for (FileConflict conflict : conflicts) {
             final Path target = updateDir.resolve(conflict.getRelativePath());
@@ -764,22 +767,22 @@ public class ApplyCandidateAction {
                 if (ProsperoLogger.ROOT_LOGGER.isTraceEnabled()) {
                     ProsperoLogger.ROOT_LOGGER.trace("Resolving file conflict: backing up user changes and applying update changes: " + conflict);
                 }
-                glold(current, target, backup);
+                glold(current, target);
             } else if (conflict.getUpdateChange() == FileConflict.Change.ADDED && conflict.getResolution() == FileConflict.Resolution.USER) {
                 if (ProsperoLogger.ROOT_LOGGER.isTraceEnabled()) {
                     ProsperoLogger.ROOT_LOGGER.trace("Resolving file conflict: preserving user changes and backing up update changes: " + conflict);
                 }
-                glnew(target, current, backup);
+                glnew(target, current);
             } else if (conflict.getUpdateChange() == FileConflict.Change.MODIFIED && conflict.getResolution() == FileConflict.Resolution.UPDATE) {
                 if (ProsperoLogger.ROOT_LOGGER.isTraceEnabled()) {
                     ProsperoLogger.ROOT_LOGGER.trace("Resolving file conflict: backing up user changes and applying update changes: " + conflict);
                 }
-                glold(current, target, backup);
+                glold(current, target);
             } else if (conflict.getUpdateChange() == FileConflict.Change.MODIFIED && conflict.getResolution() == FileConflict.Resolution.USER) {
                 if (ProsperoLogger.ROOT_LOGGER.isTraceEnabled()) {
                     ProsperoLogger.ROOT_LOGGER.trace("Resolving file conflict: preserving user changes and backing up update changes: " + conflict);
                 }
-                glnew(target, current, backup);
+                glnew(target, current);
             } else {
                 ProsperoLogger.ROOT_LOGGER.debug("Unknown conflict type: " + conflict);
             }
@@ -813,27 +816,20 @@ public class ApplyCandidateAction {
 
 
 
-    private static void glnew(final Path updateFile, Path installationFile, ApplyStageBackup backup) throws ProvisioningException {
+    private static void glnew(final Path updateFile, Path installationFile) throws ProvisioningException {
         final Path glnewFile = installationFile.getParent().resolve(installationFile.getFileName() + Constants.DOT_GLNEW);
         try {
-            if (backup != null) {
-                backup.record(glnewFile);
-                IoUtils.copy(updateFile, glnewFile);
-            }
+            copyFiles(updateFile, glnewFile);
         } catch (IOException e) {
             throw new ProvisioningException("Failed to persist " + glnewFile, e);
         }
     }
 
-    private static void glold(Path installationFile, final Path target, ApplyStageBackup backup) throws ProvisioningException {
+    private static void glold(Path installationFile, final Path target) throws ProvisioningException {
         final Path gloldFile = installationFile.getParent().resolve(installationFile.getFileName() + Constants.DOT_GLOLD);
         try {
-            if (backup != null) {
-                backup.record(gloldFile);
-                IoUtils.copy(installationFile, gloldFile);
-                backup.record(installationFile);
-                IoUtils.copy(target, installationFile);
-            }
+            copyFiles(installationFile, gloldFile);
+            copyFiles(target, installationFile);
         } catch (IOException e) {
             throw new ProvisioningException("Failed to persist " + gloldFile, e);
         }

--- a/prospero-common/src/main/java/org/wildfly/prospero/actions/ApplyStageBackup.java
+++ b/prospero-common/src/main/java/org/wildfly/prospero/actions/ApplyStageBackup.java
@@ -1,0 +1,223 @@
+package org.wildfly.prospero.actions;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.IOUtils;
+import org.wildfly.prospero.ProsperoLogger;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * A temporary record of all files modified, removed or added during applying a candidate server.
+ */
+class ApplyStageBackup implements AutoCloseable {
+
+    private final Path backupRoot;
+    private final Path serverRoot;
+    private final Set<Path> addedFiles = new HashSet<>();
+    // list of folders where the content is fully backed up
+    private final Set<Path> backupRootDirs = new HashSet<>();
+
+    /**
+     * create a record for server at {@code serverRoot}. The recorded files will be stored in {@tempRoot}
+     *
+     * @param serverRoot - root folder of the server that will be updated
+     * @param tempRoot - directory to record changed files in
+     */
+    public ApplyStageBackup(Path serverRoot, Path tempRoot) {
+        if (ProsperoLogger.ROOT_LOGGER.isDebugEnabled()) {
+            ProsperoLogger.ROOT_LOGGER.debug("Creating backup record in " + tempRoot);
+        }
+
+        this.serverRoot = serverRoot;
+        this.backupRoot = tempRoot;
+    }
+
+    /**
+     * clean up the cache
+     */
+    @Override
+    public void close() {
+        addedFiles.clear();
+        backupRootDirs.clear();
+        FileUtils.deleteQuietly(backupRoot.toFile());
+    }
+
+    /**
+     * add the {@code file} to the backup cache. If {@code file} is a directory, all of its children (recursive) are
+     * added to the backup as well.
+     *
+     * If the {@code file} does not exist in the {@code serverRoot} at the time this method
+     * is called it is assumed that on revert it should be removed.
+     *
+     * @param file - the file or directory to be backed up
+     * @throws IOException - if unable to backup the file
+     */
+    public void record(Path file) throws IOException {
+        if (Files.exists(file)) {
+            recordChanged(file);
+        } else {
+            recordAdded(file);
+        }
+    }
+
+    /**
+     * restore files and directories in {@code targetServer} to the recorded values.
+     *
+     * @throws IOException - if unable to perform operations of the filesystem
+     */
+    public void restore() throws IOException {
+        if (ProsperoLogger.ROOT_LOGGER.isDebugEnabled()) {
+            ProsperoLogger.ROOT_LOGGER.debug("Restoring server from the backup.");
+        }
+
+        // copy backed-up files back into the server
+        Files.walkFileTree(backupRoot, restoreModifiedFiles());
+
+        // remove all files added to recorded folders that were not handled by addedFiles
+        for (Path root : backupRootDirs) {
+            Files.walkFileTree(root, deleteNewFiles());
+        }
+
+        // remove explicitly added files
+        removeRemainingAddedFiles();
+    }
+
+    private void recordChanged(Path file) throws IOException {
+        if (ProsperoLogger.ROOT_LOGGER.isTraceEnabled()) {
+            ProsperoLogger.ROOT_LOGGER.trace("Recording existing file " + file + " for backup.");
+        }
+
+        final Path relativePath = serverRoot.relativize(file);
+
+        final Path parentDir = relativePath.getParent();
+        if (parentDir != null && !Files.exists(backupRoot.resolve(parentDir))) {
+            Files.createDirectories(backupRoot.resolve(parentDir));
+        }
+
+        if (Files.isDirectory(file)) {
+            if (ProsperoLogger.ROOT_LOGGER.isTraceEnabled()) {
+                ProsperoLogger.ROOT_LOGGER.trace("Setting folder " + file + " as backup root.");
+            }
+
+            backupRootDirs.add(file);
+            FileUtils.copyDirectory(file.toFile(), backupRoot.resolve(relativePath).toFile());
+        } else {
+            Files.copy(file, backupRoot.resolve(relativePath), StandardCopyOption.REPLACE_EXISTING);
+        }
+    }
+
+    private void recordAdded(Path addedFile) {
+        if (ProsperoLogger.ROOT_LOGGER.isTraceEnabled()) {
+            ProsperoLogger.ROOT_LOGGER.trace("Recording new file " + addedFile + " for backup.");
+        }
+
+        if (addedFile.equals(serverRoot)) {
+            // we're done don't recurse anymore
+            return;
+        }
+
+        if (Files.exists(addedFile.getParent())) {
+            addedFiles.add(addedFile);
+        } else {
+            // we need to add parent folders to make sure that folders that were created are removed
+            recordAdded(addedFile.getParent());
+            addedFiles.add(addedFile);
+        }
+    }
+
+    private SimpleFileVisitor<Path> deleteNewFiles() {
+        return new SimpleFileVisitor<>() {
+            @Override
+            public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+                final Path relativePath = serverRoot.relativize(file);
+                if (!Files.exists(backupRoot.resolve(relativePath))) {
+                    if (ProsperoLogger.ROOT_LOGGER.isTraceEnabled()) {
+                        ProsperoLogger.ROOT_LOGGER.trace("Removing added file " + relativePath);
+                    }
+
+                    Files.delete(file);
+                }
+                return FileVisitResult.CONTINUE;
+            }
+
+            @Override
+            public FileVisitResult postVisitDirectory(Path dir, IOException exc) throws IOException {
+                final Path relativePath = serverRoot.relativize(dir);
+                if (!Files.exists(backupRoot.resolve(relativePath))) {
+                    if (ProsperoLogger.ROOT_LOGGER.isTraceEnabled()) {
+                        ProsperoLogger.ROOT_LOGGER.trace("Removing added directory " + relativePath);
+                    }
+
+                    Files.delete(dir);
+                }
+                return FileVisitResult.CONTINUE;
+            }
+        };
+    }
+
+    private void removeRemainingAddedFiles() throws IOException {
+        for (Path addedFile : addedFiles) {
+            if (Files.isDirectory(addedFile)) {
+                if (ProsperoLogger.ROOT_LOGGER.isTraceEnabled()) {
+                    ProsperoLogger.ROOT_LOGGER.trace("Removing added directory " + addedFile);
+                }
+
+                FileUtils.deleteDirectory(addedFile.toFile());
+            } else {
+                if (ProsperoLogger.ROOT_LOGGER.isTraceEnabled()) {
+                    ProsperoLogger.ROOT_LOGGER.trace("Removing added file " + addedFile);
+                }
+
+                Files.deleteIfExists(addedFile);
+            }
+        }
+    }
+
+    private SimpleFileVisitor<Path> restoreModifiedFiles() {
+        return new SimpleFileVisitor<>() {
+            @Override
+            public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+                final Path relativePath = backupRoot.relativize(file);
+
+                final Path parentDir = relativePath.getParent();
+                if (parentDir != null && !Files.exists(serverRoot.resolve(parentDir))) {
+                    if (ProsperoLogger.ROOT_LOGGER.isTraceEnabled()) {
+                        ProsperoLogger.ROOT_LOGGER.trace("Recreating removed directory " + parentDir);
+                    }
+
+                    Files.createDirectories(serverRoot.resolve(parentDir));
+                }
+
+                final Path targetFile = serverRoot.resolve(relativePath);
+                if (fileChanged(file, targetFile)) {
+                    if (ProsperoLogger.ROOT_LOGGER.isTraceEnabled()) {
+                        ProsperoLogger.ROOT_LOGGER.trace("Restoring changed file " + relativePath);
+                    }
+
+                    Files.copy(file, targetFile, StandardCopyOption.REPLACE_EXISTING);
+                }
+                return FileVisitResult.CONTINUE;
+            }
+        };
+    }
+
+    private static boolean fileChanged(Path file, Path targetFile) throws IOException {
+        if (!Files.exists(targetFile)) {
+            return true;
+        }
+
+        try (FileInputStream fis1 = new FileInputStream(targetFile.toFile());
+             FileInputStream fis2 = new FileInputStream(file.toFile())){
+            return !IOUtils.contentEquals(fis1, fis2);
+        }
+    }
+}

--- a/prospero-common/src/main/java/org/wildfly/prospero/api/exceptions/ApplyCandidateException.java
+++ b/prospero-common/src/main/java/org/wildfly/prospero/api/exceptions/ApplyCandidateException.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2024 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.prospero.api.exceptions;
+
+import java.nio.file.Path;
+
+public class ApplyCandidateException extends OperationException {
+
+    private final boolean rollbackSuccessful;
+    private final Path backupPath;
+
+    public ApplyCandidateException(String msg, boolean rollbackSuccessful, Path backupPath, Throwable e) {
+        super(msg, e);
+        this.rollbackSuccessful = rollbackSuccessful;
+        this.backupPath = backupPath;
+    }
+
+    public boolean isRollbackSuccessful() {
+        return rollbackSuccessful;
+    }
+
+    public Path getBackupPath() {
+        return backupPath;
+    }
+}

--- a/prospero-common/src/test/java/org/wildfly/prospero/actions/ApplyCandidateActionTest.java
+++ b/prospero-common/src/test/java/org/wildfly/prospero/actions/ApplyCandidateActionTest.java
@@ -573,6 +573,44 @@ public class ApplyCandidateActionTest {
         );
     }
 
+    @Test
+    public void ignoreAddedNonReadableFolders() throws Exception {
+        final DirState expectedState = dirBuilder
+                .addFile("prod1/p1.txt", "p1 1.0.1")
+                .addFile("prod1/p2.txt", "p2 1.0.1")
+                .addFile("test/test.txt", "test")
+                .build();
+
+        // build test packages
+        creator.newFeaturePack(FeaturePackLocation.fromString(FPL_100).getFPID())
+                .addSystemPaths("prod1")
+                .newPackage("p1", true)
+                .writeContent("prod1/p1.txt", "p1 1.0.0") // modified by the user
+                .writeContent("prod1/p2.txt", "p2 1.0.0") // removed by user and restored in update
+                .getFeaturePack();
+        creator.newFeaturePack(FeaturePackLocation.fromString(FPL_101).getFPID())
+                .addSystemPaths("prod1")
+                .newPackage("p1", true)
+                .writeContent("prod1/p1.txt", "p1 1.0.1")
+                .writeContent("prod1/p2.txt", "p2 1.0.1")
+                .getFeaturePack();
+        creator.install();
+
+        // install base and update. perform apply-update
+        install(installationPath, FPL_100);
+        Files.createDirectories(installationPath.resolve("test"));
+        Files.writeString(installationPath.resolve("test").resolve("test.txt"), "test");
+        installationPath.resolve("test").toFile().setReadable(false);
+
+        prepareUpdate(updatePath, installationPath, FPL_101);
+        new ApplyCandidateAction(installationPath, updatePath)
+                .applyUpdate(ApplyCandidateAction.Type.UPDATE);
+
+        // verify
+        installationPath.resolve("test").toFile().setReadable(true);
+        expectedState.assertState(installationPath);
+    }
+
     private void createSimpleFeaturePacks() throws ProvisioningException {
         creator.newFeaturePack(FeaturePackLocation.fromString(FPL_100).getFPID())
                 .newPackage("p1", true)

--- a/prospero-common/src/test/java/org/wildfly/prospero/actions/ApplyStageBackupTest.java
+++ b/prospero-common/src/test/java/org/wildfly/prospero/actions/ApplyStageBackupTest.java
@@ -1,0 +1,248 @@
+package org.wildfly.prospero.actions;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.FileTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
+
+public class ApplyStageBackupTest {
+
+    @Rule
+    public TemporaryFolder temp = new TemporaryFolder();
+
+    private ApplyStageBackup backup;
+    private Path server;
+    private Path backupPath;
+
+    @Before
+    public void setUp() throws Exception {
+        server = temp.newFolder().toPath();
+        backupPath = temp.newFolder("backup").toPath();
+        backup = new ApplyStageBackup(server, backupPath);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        backup.close();
+    }
+
+    @Test
+    public void restoreWithEmptyList() throws Exception {
+        backup.restore();
+
+        assertThat(server)
+                .isEmptyDirectory();
+    }
+
+    @Test
+    public void closeRemovesBackupFolder() throws Exception {
+        final Path testFile = createFile("test.txt");
+
+        backup.record(testFile);
+
+        backup.close();
+
+        assertThat(backupPath)
+                .doesNotExist();
+    }
+
+    @Test
+    public void restoreRemovedFile() throws Exception {
+        final Path testFile = createFile("test.txt");
+
+        backup.record(testFile);
+        Files.delete(testFile);
+        backup.restore();
+
+        assertThat(testFile)
+                .hasContent("test text");
+    }
+
+    @Test
+    public void restoreChangedFile() throws Exception {
+        final Path testFile = createFile("test.txt");
+
+        backup.record(testFile);
+        Files.writeString(testFile, "changed text");
+        backup.restore();
+
+        assertThat(testFile)
+                .hasContent("test text");
+    }
+
+    @Test
+    public void dontTouchUnchangedFiles() throws Exception {
+        final Path testFile = createFile("test.txt");
+        final FileTime lastModifiedTime = Files.getLastModifiedTime(testFile);
+
+        backup.record(testFile);
+        Thread.sleep(200);
+        backup.restore();
+
+        final FileTime restoredModifiedTime = Files.getLastModifiedTime(testFile);
+        assertEquals(lastModifiedTime, restoredModifiedTime);
+    }
+
+    @Test
+    public void restoreFileInDirectory() throws Exception {
+        final Path testFile = createFile("test/test.txt");
+
+        backup.record(testFile);
+        Files.delete(testFile);
+        backup.restore();
+
+        assertThat(testFile)
+                .hasContent("test text");
+    }
+
+    @Test
+    public void restoreFileInDeletedDirectory() throws Exception {
+        final Path testFile = createFile("test/test.txt");
+
+        backup.record(testFile);
+        Files.delete(testFile);
+        Files.delete(testFile.getParent());
+        backup.restore();
+
+        assertThat(testFile)
+                .hasContent("test text");
+    }
+
+    @Test
+    public void recordAllFilesInDirectory() throws Exception {
+        final Path testFile = createFile("test/test.txt");
+
+        backup.record(testFile.getParent());
+        Files.delete(testFile);
+        Files.delete(testFile.getParent());
+        backup.restore();
+
+        assertThat(testFile)
+                .hasContent("test text");
+    }
+
+    @Test
+    public void recordChangedFileTwice() throws Exception {
+        final Path testFile = createFile("test.txt");
+
+        backup.record(testFile);
+        backup.record(testFile);
+        Files.writeString(testFile, "changed text");
+        backup.restore();
+
+        assertThat(testFile)
+                .hasContent("test text");
+    }
+
+    @Test
+    public void removeAddedFile() throws Exception {
+        final Path testFile = server.resolve("test.txt");
+
+        backup.record(testFile);
+        Files.writeString(testFile, "changed text");
+        backup.restore();
+
+        assertThat(testFile)
+                .doesNotExist();
+    }
+
+    @Test
+    public void removeAddedFileInDirectory() throws Exception {
+        final Path existingFile = createFile("test/existing.txt");
+        final Path testFile = server.resolve("test/test.txt");
+
+        backup.record(testFile);
+        Files.createDirectories(testFile.getParent());
+        Files.writeString(testFile, "changed text");
+        backup.restore();
+
+        assertThat(testFile)
+                .doesNotExist();
+        assertThat(testFile.getParent())
+                .exists();
+        assertThat(existingFile)
+                .exists();
+    }
+
+    @Test
+    public void preserveExistingFilesInDirectoryWithAddedFile() throws Exception {
+        final Path testFile = server.resolve("test/test.txt");
+
+        backup.record(testFile);
+        Files.createDirectories(testFile.getParent());
+        Files.writeString(testFile, "changed text");
+        backup.restore();
+
+        assertThat(testFile)
+                .doesNotExist();
+        assertThat(testFile.getParent())
+                .doesNotExist();
+    }
+
+    @Test
+    public void removeAddedFileInRecordedDirectory() throws Exception {
+        final Path testFile = server.resolve("test/test.txt");
+        Files.createDirectories(testFile.getParent());
+
+        backup.record(testFile.getParent());
+        Files.writeString(testFile, "changed text");
+        backup.restore();
+
+        assertThat(testFile)
+                .doesNotExist();
+        assertThat(testFile.getParent())
+                .exists();
+    }
+
+    @Test
+    public void removeAddedFolderInRecordedDirectory() throws Exception {
+        final Path testFile = server.resolve("test/foo/test.txt");
+        Files.createDirectories(server.resolve("test"));
+
+        backup.record(server.resolve("test"));
+        Files.createDirectories(server.resolve("test/foo"));
+        Files.writeString(testFile, "changed text");
+        backup.restore();
+
+        assertThat(testFile)
+                .doesNotExist();
+        assertThat(testFile.getParent())
+                .doesNotExist();
+        assertThat(testFile.getParent().getParent())
+                .exists();
+    }
+
+    @Test
+    public void dontRemoveUnchangedFiles() throws Exception {
+        final Path testFile = server.resolve("test/test.txt");
+        final Path existing = createFile("test/existing.txt");
+
+        backup.record(testFile);
+        Files.writeString(testFile, "changed text");
+        backup.restore();
+
+        assertThat(existing)
+                .hasContent("test text");
+        assertThat(testFile)
+                .doesNotExist();
+    }
+
+    private Path createFile(String path) throws IOException {
+        final Path testFile = server.resolve(path);
+        if (!Files.exists(testFile.getParent())) {
+            Files.createDirectories(testFile.getParent());
+        }
+        Files.writeString(testFile, "test text");
+        return testFile;
+    }
+
+}


### PR DESCRIPTION
Before applying changes to a server, backup the state of the server in a `<SERVER_HOME>.update.old` folder. The backup is done using hardlinks if the file system allows it to save disk space. 

If the update fails due to IOException, we try and restore the server state. If the update is interrupted, either by the user or a program crash, the original state will be available for the user to perform manual restore.