### PR TITLE
Prevent making changes when conflicts in an update are rejected

### DIFF
--- a/prospero-common/src/main/java/org/wildfly/prospero/actions/ApplyCandidateAction.java
+++ b/prospero-common/src/main/java/org/wildfly/prospero/actions/ApplyCandidateAction.java
@@ -473,8 +473,6 @@ public class ApplyCandidateAction {
                         if (ProsperoLogger.ROOT_LOGGER.isDebugEnabled()) {
                             ProsperoLogger.ROOT_LOGGER.debug(formatMessage(FORCED, removed.getRelativePath(), HAS_CHANGED_IN_THE_UPDATED_VERSION));
                         }
-                        Files.createDirectories(installationDir.resolve(removed.getRelativePath()).getParent());
-                        IoUtils.copy(target, installationDir.resolve(removed.getRelativePath()));
                     }
                 } else {
                     if (ProsperoLogger.ROOT_LOGGER.isDebugEnabled()) {
@@ -532,13 +530,11 @@ public class ApplyCandidateAction {
                         ProsperoLogger.ROOT_LOGGER.debug(formatMessage(FORCED, added.getRelativePath(), CONFLICTS_WITH_THE_UPDATED_VERSION));
                     }
                     conflictList.add(FileConflict.userAdded(added.getRelativePath()).updateAdded().overwritten());
-                    glold(installationDir.resolve(added.getRelativePath()), target);
                 } else {
                     if (ProsperoLogger.ROOT_LOGGER.isDebugEnabled()) {
                         ProsperoLogger.ROOT_LOGGER.debug(formatMessage(CONFLICT, added.getRelativePath(), CONFLICTS_WITH_THE_UPDATED_VERSION));
                     }
                     conflictList.add(FileConflict.userAdded(added.getRelativePath()).updateAdded().userPreserved());
-                    glnew(target, installationDir.resolve(added.getRelativePath()));
                 }
             }
         }
@@ -561,7 +557,6 @@ public class ApplyCandidateAction {
                     } catch (IOException e) {
                         throw new ProvisioningException(BaseErrors.hashCalculation(file), e);
                     }
-                    Path installationFile = installationDir.resolve(modified[1].getRelativePath());
                     // Case where the modified file is equal to the hash of the update. Do nothing
                     if (Arrays.equals(installation.getHash(), updateHash)) {
                         if (ProsperoLogger.ROOT_LOGGER.isDebugEnabled()) {
@@ -574,13 +569,11 @@ public class ApplyCandidateAction {
                                     ProsperoLogger.ROOT_LOGGER.debug(formatMessage(FORCED, installation.getRelativePath(), HAS_CHANGED_IN_THE_UPDATED_VERSION));
                                 }
                                 conflictList.add(FileConflict.userModified(installation.getRelativePath()).updateModified().overwritten());
-                                glold(installation.getPath(), file);
                             } else {
                                 if (ProsperoLogger.ROOT_LOGGER.isDebugEnabled()) {
                                     ProsperoLogger.ROOT_LOGGER.debug(formatMessage(CONFLICT, installation.getRelativePath(), HAS_CHANGED_IN_THE_UPDATED_VERSION));
                                 }
                                 conflictList.add(FileConflict.userModified(installation.getRelativePath()).updateModified().userPreserved());
-                                glnew(file, installationFile);
                             }
                         }
                     }
@@ -611,6 +604,8 @@ public class ApplyCandidateAction {
         conflicts.addAll(handleRemovedFiles(fsDiff));
         conflicts.addAll(handleAddedFiles(fsDiff));
         conflicts.addAll(handleModifiedFiles(fsDiff));
+
+        resolveFileConflicts(conflicts);
 
         // Handles files added/removed/modified in the update.
         Path skipUpdateGalleon = PathsUtils.getProvisionedStateDir(updateDir);
@@ -732,6 +727,43 @@ public class ApplyCandidateAction {
             }
         });
         return Collections.unmodifiableList(conflicts);
+    }
+
+    private void resolveFileConflicts(List<FileConflict> conflicts) throws IOException, ProvisioningException {
+        // apply conflict resolution
+        for (FileConflict conflict : conflicts) {
+            final Path target = updateDir.resolve(conflict.getRelativePath());
+            final Path current = installationDir.resolve(conflict.getRelativePath());
+            if (conflict.getUserChange() == FileConflict.Change.REMOVED && conflict.getResolution() == FileConflict.Resolution.UPDATE) {
+                if (ProsperoLogger.ROOT_LOGGER.isTraceEnabled()) {
+                    ProsperoLogger.ROOT_LOGGER.trace("Resolving file conflict: restoring files removed by the user: " + conflict);
+                }
+                Files.createDirectories(current.getParent());
+                IoUtils.copy(target, current);
+            } else if (conflict.getUpdateChange() == FileConflict.Change.ADDED && conflict.getResolution() == FileConflict.Resolution.UPDATE) {
+                if (ProsperoLogger.ROOT_LOGGER.isTraceEnabled()) {
+                    ProsperoLogger.ROOT_LOGGER.trace("Resolving file conflict: backing up user changes and applying update changes: " + conflict);
+                }
+                glold(current, target);
+            } else if (conflict.getUpdateChange() == FileConflict.Change.ADDED && conflict.getResolution() == FileConflict.Resolution.USER) {
+                if (ProsperoLogger.ROOT_LOGGER.isTraceEnabled()) {
+                    ProsperoLogger.ROOT_LOGGER.trace("Resolving file conflict: preserving user changes and backing up update changes: " + conflict);
+                }
+                glnew(target, current);
+            } else if (conflict.getUpdateChange() == FileConflict.Change.MODIFIED && conflict.getResolution() == FileConflict.Resolution.UPDATE) {
+                if (ProsperoLogger.ROOT_LOGGER.isTraceEnabled()) {
+                    ProsperoLogger.ROOT_LOGGER.trace("Resolving file conflict: backing up user changes and applying update changes: " + conflict);
+                }
+                glold(current, target);
+            } else if (conflict.getUpdateChange() == FileConflict.Change.MODIFIED && conflict.getResolution() == FileConflict.Resolution.USER) {
+                if (ProsperoLogger.ROOT_LOGGER.isTraceEnabled()) {
+                    ProsperoLogger.ROOT_LOGGER.trace("Resolving file conflict: preserving user changes and backing up update changes: " + conflict);
+                }
+                glnew(target, current);
+            } else {
+                ProsperoLogger.ROOT_LOGGER.debug("Unknown conflict type: " + conflict);
+            }
+        }
     }
 
     private static boolean isEmpty(Path dir) {


### PR DESCRIPTION
The conflicts are resolved too early resulting in the changes being written even if the update has been rejected.

To reproduce:
1. Install wildfly
2. Prepare candidate update
3. Force a conflict (e.g. modify module.xml in one of updated modules)
4. Run `update apply` and reject update after the conflicts are displayed

The module.xml will be updated (and module.xml.glold will be created)
