### PR TITLE
Add option to reject update and revert operations if there are any file conflicts

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
         <version.org.jboss.xnio>3.8.16.Final</version.org.jboss.xnio>
         <version.org.wildfly.common>1.7.0.Final</version.org.wildfly.common>
         <version.org.wildfly.galleon-plugins>7.2.0.Final</version.org.wildfly.galleon-plugins>
-        <version.org.wildfly.installation-manager>1.0.3.Final</version.org.wildfly.installation-manager>
+        <version.org.wildfly.installation-manager>2.0.0.Beta1</version.org.wildfly.installation-manager>
         <version.org.wildfly.maven.plugins.licenses-plugin>2.4.1.Final</version.org.wildfly.maven.plugins.licenses-plugin>
         <version.org.wildfly.prospero.prospero-metadata>1.2.1.Final</version.org.wildfly.prospero.prospero-metadata>
         <version.org.mockito>5.14.1</version.org.mockito>

--- a/prospero-cli/src/main/java/org/wildfly/prospero/cli/CliMessages.java
+++ b/prospero-cli/src/main/java/org/wildfly/prospero/cli/CliMessages.java
@@ -716,4 +716,10 @@ public interface CliMessages {
     default String candidateApplyRollbackFailure(Path backup) {
         return format(bundle.getString("prospero.candidate.apply.error.rollback_error.desc"), backup);
     }
+
+    default OperationException cancelledByConfilcts() {
+        return new OperationException(format(
+                bundle.getString("prospero.updates.apply.candidate.cancel_conflicts"),
+                CliConstants.NO_CONFLICTS_ONLY));
+    }
 }

--- a/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/CliConstants.java
+++ b/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/CliConstants.java
@@ -101,4 +101,5 @@ public final class CliConstants {
     public static final String VV = "-vv";
     public static final String Y = "-y";
     public static final String YES = "--yes";
+    public static final String NO_CONFLICTS_ONLY = "--no-conflicts-only";
 }

--- a/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/CliConstants.java
+++ b/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/CliConstants.java
@@ -102,4 +102,6 @@ public final class CliConstants {
     public static final String Y = "-y";
     public static final String YES = "--yes";
     public static final String NO_CONFLICTS_ONLY = "--no-conflicts-only";
+    public static final String DRY_RUN = "--dry-run";
+
 }

--- a/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/RevertCommand.java
+++ b/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/RevertCommand.java
@@ -52,11 +52,15 @@ import static org.wildfly.prospero.cli.ReturnCodes.SUCCESS;
 )
 public class RevertCommand extends AbstractParentCommand {
 
-    private static int applyCandidate(CliConsole console, ApplyCandidateAction applyCandidateAction, boolean yes) throws OperationException, ProvisioningException {
+    private static int applyCandidate(CliConsole console, ApplyCandidateAction applyCandidateAction, boolean yes, boolean noConflictsOnly) throws OperationException, ProvisioningException {
         List<ArtifactChange> artifactUpdates = applyCandidateAction.findUpdates().getArtifactUpdates();
         console.printArtifactChanges(artifactUpdates);
         final List<FileConflict> conflicts = applyCandidateAction.getConflicts();
         FileConflictPrinter.print(conflicts, console);
+
+        if (noConflictsOnly && !conflicts.isEmpty()) {
+            throw CliMessages.MESSAGES.cancelledByConfilcts();
+        }
 
         if (!yes && !artifactUpdates.isEmpty() && !console.confirm(CliMessages.MESSAGES.continueWithRevert(),
                 CliMessages.MESSAGES.applyingChanges(), CliMessages.MESSAGES.revertCancelled())) {
@@ -92,6 +96,9 @@ public class RevertCommand extends AbstractParentCommand {
         @CommandLine.Option(names = {CliConstants.Y, CliConstants.YES})
         boolean yes;
 
+        @CommandLine.Option(names = {CliConstants.NO_CONFLICTS_ONLY})
+        boolean noConflictsOnly;
+
         public PerformCommand(CliConsole console, ActionFactory actionFactory) {
             super(console, actionFactory);
         }
@@ -121,7 +128,7 @@ public class RevertCommand extends AbstractParentCommand {
 
                 validateRevertCandidate(installationDirectory, tempDirectory, applyCandidateAction);
 
-                applyCandidate(console, applyCandidateAction, yes);
+                applyCandidate(console, applyCandidateAction, yes, noConflictsOnly);
             } catch (IOException e) {
                 throw ProsperoLogger.ROOT_LOGGER.unableToCreateTemporaryDirectory(e);
             }
@@ -147,6 +154,9 @@ public class RevertCommand extends AbstractParentCommand {
         @CommandLine.Option(names = {CliConstants.Y, CliConstants.YES})
         boolean yes;
 
+        @CommandLine.Option(names = {CliConstants.NO_CONFLICTS_ONLY})
+        boolean noConflictsOnly;
+
         public ApplyCommand(CliConsole console, ActionFactory actionFactory) {
             super(console, actionFactory);
         }
@@ -162,7 +172,7 @@ public class RevertCommand extends AbstractParentCommand {
             console.println(CliMessages.MESSAGES.revertStart(installationDirectory, applyCandidateAction.getCandidateRevision().getName()));
             console.println("");
 
-            applyCandidate(console, applyCandidateAction, yes);
+            applyCandidate(console, applyCandidateAction, yes, noConflictsOnly);
             if(remove) {
                 applyCandidateAction.removeCandidate(candidateDirectory.toFile());
             }

--- a/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/UpdateCommand.java
+++ b/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/UpdateCommand.java
@@ -237,6 +237,9 @@ public class UpdateCommand extends AbstractParentCommand {
         @CommandLine.Option(names = {CliConstants.NO_CONFLICTS_ONLY})
         boolean noConflictsOnly;
 
+        @CommandLine.Option(names = {CliConstants.DRY_RUN})
+        boolean dryRun;
+
         public ApplyCommand(CliConsole console, ActionFactory actionFactory) {
             super(console, actionFactory);
         }
@@ -267,6 +270,10 @@ public class UpdateCommand extends AbstractParentCommand {
             console.updatesFound(applyCandidateAction.findUpdates().getArtifactUpdates());
             final List<FileConflict> conflicts = applyCandidateAction.getConflicts();
             FileConflictPrinter.print(conflicts, console);
+
+            if (dryRun) {
+                return ReturnCodes.SUCCESS;
+            }
 
             if (noConflictsOnly && !conflicts.isEmpty()) {
                 throw CliMessages.MESSAGES.cancelledByConfilcts();

--- a/prospero-cli/src/main/java/org/wildfly/prospero/cli/spi/CliProviderImpl.java
+++ b/prospero-cli/src/main/java/org/wildfly/prospero/cli/spi/CliProviderImpl.java
@@ -49,20 +49,22 @@ public class CliProviderImpl implements CliProvider {
     }
 
     @Override
-    public String getApplyUpdateCommand(Path installationPath, Path candidatePath) {
+    public String getApplyUpdateCommand(Path installationPath, Path candidatePath, boolean noConflictsOnly) {
         return CliConstants.Commands.UPDATE + " " + CliConstants.Commands.APPLY + " "
                 + CliConstants.DIR + " " + escape(installationPath.toAbsolutePath()) + " "
                 + CliConstants.CANDIDATE_DIR + " " + escape(candidatePath.toAbsolutePath()) + " "
                 + CliConstants.YES + " "
+                + (noConflictsOnly ? CliConstants.NO_CONFLICTS_ONLY + " " : "")
                 + CliConstants.REMOVE;
     }
 
     @Override
-    public String getApplyRevertCommand(Path installationPath, Path candidatePath) {
+    public String getApplyRevertCommand(Path installationPath, Path candidatePath, boolean noConflictsOnly) {
         return CliConstants.Commands.REVERT + " " + CliConstants.Commands.APPLY + " "
                 + CliConstants.DIR + " " + escape(installationPath.toAbsolutePath()) + " "
                 + CliConstants.CANDIDATE_DIR + " " + escape(candidatePath.toAbsolutePath()) + " "
                 + CliConstants.YES + " "
+                + (noConflictsOnly ? CliConstants.NO_CONFLICTS_ONLY + " " : "")
                 + CliConstants.REMOVE;
     }
 

--- a/prospero-cli/src/main/resources/UsageMessages.properties
+++ b/prospero-cli/src/main/resources/UsageMessages.properties
@@ -155,7 +155,6 @@ dir = Location of the existing application server. If not specified, current wor
 ${prospero.dist.name}.install.dir = Target directory where the application server will be provisioned.
 ${prospero.dist.name}.clone.recreate.dir = Target directory where the application server will be provisioned.
 
-dry-run = Print components that can be upgraded, but do not perform the upgrades.
 fpl.0 = Maven coordinates of a Galleon feature pack. The specified feature pack is installed \
   with default layers and packages.
 fpl.1 = When you use this option, you should also specify the @|bold --channels|@ or a combination of @|bold --manifest|@ \
@@ -199,6 +198,7 @@ ${prospero.dist.name}.update.subscribe.product = Specify the product name. This 
 ${prospero.dist.name}.update.subscribe.version = Specify the version of the product.
 no-conflicts-only = Rejects the operation if any file conflicts are detected. If not used, the user will be asked to \
   confirm automatic conflict resolution, unless @|bold --yes|@ option is used.
+dry-run = Prints the changes that would be performed by executing the command, but does not perform any changes on the filesystem.
 
 #
 # Exit Codes

--- a/prospero-cli/src/main/resources/UsageMessages.properties
+++ b/prospero-cli/src/main/resources/UsageMessages.properties
@@ -197,6 +197,8 @@ package-stability-level.1 = Valid options are ${COMPLETION-CANDIDATES}.
 ${prospero.dist.name}.update.prepare.candidate-dir = Target directory where the candidate server will be provisioned. The existing server is not updated.
 ${prospero.dist.name}.update.subscribe.product = Specify the product name. This must be a known feature pack supported by ${prospero.dist.name}.
 ${prospero.dist.name}.update.subscribe.version = Specify the version of the product.
+no-conflicts-only = Rejects the operation if any file conflicts are detected. If not used, the user will be asked to \
+  confirm automatic conflict resolution, unless @|bold --yes|@ option is used.
 
 #
 # Exit Codes
@@ -281,6 +283,8 @@ prospero.updates.apply.validation.candidate.wrong_type=Unable to apply candidate
 prospero.updates.apply.validation.candidate.not_candidate=Unable to apply candidate.%n  Installation at [%s] doesn't have a candidate marker file.
 prospero.updates.apply.candidate.remove=Remove the candidate directory after applying update.
 
+prospero.updates.apply.candidate.cancel_conflicts = Potential conflicts exist in the installation. Resolve the conflicts in the listed files, or \
+  use [%s=false] to preserve user changes where possible.
 
 prospero.updates.build.candidate.header=Building update candidate for %s%n
 prospero.updates.build.candidate.complete=Update candidate generated in %s

--- a/prospero-cli/src/test/java/org/wildfly/prospero/cli/commands/ApplyUpdateCommandTest.java
+++ b/prospero-cli/src/test/java/org/wildfly/prospero/cli/commands/ApplyUpdateCommandTest.java
@@ -223,6 +223,21 @@ public class ApplyUpdateCommandTest extends AbstractConsoleTest {
         verify(applyCandidateAction).applyUpdate(ApplyCandidateAction.Type.UPDATE);
     }
 
+    @Test
+    public void dryRun_DoesntCallApplyAction() throws Exception {
+        final Path updatePath = mockInstallation("update");
+        final Path targetPath = mockInstallation("target");
+        when(applyCandidateAction.getConflicts()).thenReturn(Collections.emptyList());
+
+        int exitCode = commandLine.execute(CliConstants.Commands.UPDATE, CliConstants.Commands.APPLY,
+                CliConstants.CANDIDATE_DIR, updatePath.toString(),
+                CliConstants.DIR, targetPath.toString(),
+                CliConstants.DRY_RUN);
+
+        assertEquals(ReturnCodes.SUCCESS, exitCode);
+        verify(applyCandidateAction, Mockito.never()).applyUpdate(any());
+    }
+
     private Path mockInstallation(String target) throws IOException, MetadataException, XMLStreamException {
         final Path targetPath = temp.newFolder(target).toPath();
         MetadataTestUtils.createInstallationMetadata(targetPath).close();

--- a/prospero-cli/src/test/java/org/wildfly/prospero/cli/commands/ApplyUpdateCommandTest.java
+++ b/prospero-cli/src/test/java/org/wildfly/prospero/cli/commands/ApplyUpdateCommandTest.java
@@ -24,6 +24,7 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.wildfly.prospero.actions.ApplyCandidateAction;
 import org.wildfly.prospero.api.FileConflict;
@@ -43,6 +44,7 @@ import java.nio.file.Path;
 import java.util.Collections;
 import java.util.List;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -186,6 +188,39 @@ public class ApplyUpdateCommandTest extends AbstractConsoleTest {
 
         Assert.assertEquals(getErrorOutput(), ReturnCodes.SUCCESS, exitCode);
         assertEquals(1, askedConfirmation);
+    }
+
+    @Test
+    public void noConflictArgumentFailsCommand_WhenConflictsAreFound() throws Exception {
+        final Path updatePath = mockInstallation("update");
+        final Path targetPath = mockInstallation("target");
+        when(applyCandidateAction.getConflicts()).thenReturn(List.of(mock(FileConflict.class)));
+
+        int exitCode = commandLine.execute(CliConstants.Commands.UPDATE, CliConstants.Commands.APPLY,
+                CliConstants.CANDIDATE_DIR, updatePath.toString(),
+                CliConstants.DIR, targetPath.toString(),
+                CliConstants.NO_CONFLICTS_ONLY);
+
+        assertEquals(ReturnCodes.PROCESSING_ERROR, exitCode);
+        assertThat(getErrorOutput())
+                .contains(CliMessages.MESSAGES.cancelledByConfilcts().getMessage());
+
+        verify(applyCandidateAction, Mockito.never()).applyUpdate(any());
+    }
+
+    @Test
+    public void noConflictArgumentHasNoEffect_WhenNoConflictsAreFound() throws Exception {
+        final Path updatePath = mockInstallation("update");
+        final Path targetPath = mockInstallation("target");
+        when(applyCandidateAction.getConflicts()).thenReturn(Collections.emptyList());
+
+        int exitCode = commandLine.execute(CliConstants.Commands.UPDATE, CliConstants.Commands.APPLY,
+                CliConstants.CANDIDATE_DIR, updatePath.toString(),
+                CliConstants.DIR, targetPath.toString(),
+                CliConstants.NO_CONFLICTS_ONLY);
+
+        assertEquals(ReturnCodes.SUCCESS, exitCode);
+        verify(applyCandidateAction).applyUpdate(ApplyCandidateAction.Type.UPDATE);
     }
 
     private Path mockInstallation(String target) throws IOException, MetadataException, XMLStreamException {

--- a/prospero-cli/src/test/java/org/wildfly/prospero/cli/commands/RevertApplyCommandTest.java
+++ b/prospero-cli/src/test/java/org/wildfly/prospero/cli/commands/RevertApplyCommandTest.java
@@ -154,4 +154,17 @@ public class RevertApplyCommandTest extends AbstractConsoleTest {
         assertEquals(ReturnCodes.SUCCESS, exitCode);
         verify(applyCandidateAction).applyUpdate(ApplyCandidateAction.Type.REVERT);
     }
+
+    @Test
+    public void dryRun_DoesntCallApplyAction() throws Exception {
+        when(applyCandidateAction.getConflicts()).thenReturn(Collections.emptyList());
+
+        int exitCode = commandLine.execute(CliConstants.Commands.REVERT, CliConstants.Commands.APPLY,
+                CliConstants.CANDIDATE_DIR, updateDir.toString(),
+                CliConstants.DIR, installationDir.toString(),
+                CliConstants.DRY_RUN);
+
+        assertEquals(ReturnCodes.SUCCESS, exitCode);
+        verify(applyCandidateAction, Mockito.never()).applyUpdate(any());
+    }
 }

--- a/prospero-common/src/main/java/org/wildfly/prospero/ProsperoLogger.java
+++ b/prospero-common/src/main/java/org/wildfly/prospero/ProsperoLogger.java
@@ -26,6 +26,7 @@ import org.jboss.logging.annotations.LogMessage;
 import org.jboss.logging.annotations.Message;
 import org.jboss.logging.annotations.MessageLogger;
 import org.wildfly.channel.InvalidChannelMetadataException;
+import org.wildfly.prospero.actions.ApplyCandidateAction;
 import org.wildfly.prospero.actions.FeaturesAddAction;
 import org.wildfly.prospero.api.exceptions.ArtifactPromoteException;
 import org.wildfly.prospero.api.exceptions.ChannelDefinitionException;
@@ -392,4 +393,14 @@ public interface ProsperoLogger extends BasicLogger {
 
     @Message(id = 272, value = "Failed to apply the candidate changes due to: %s")
     String failedToApplyCandidate(String reason);
+
+    @Message(id = 273, value = "The server [%s] has been modified after the candidate has been created [%s].")
+    InvalidUpdateCandidateException staleCandidate(Path originalServer, Path candiadate);
+
+    @Message(id = 274, value = "The folder [%s] doesn't contain a server candidate.")
+    InvalidUpdateCandidateException notCandidate(Path candidateServer);
+
+    @Message(id = 275, value = "The candidate at [%s] was not prepared for %s operation.")
+    InvalidUpdateCandidateException wrongCandidateOperation(Path candidateServer, ApplyCandidateAction.Type operationType);
+
 }

--- a/prospero-common/src/main/java/org/wildfly/prospero/actions/FeaturesAddAction.java
+++ b/prospero-common/src/main/java/org/wildfly/prospero/actions/FeaturesAddAction.java
@@ -753,9 +753,9 @@ public class FeaturesAddAction {
         }
 
         @Override
-        public ApplyCandidateAction newApplyCandidateActionInstance(Path candidateDir)
+        public ApplyCandidateAction newApplyCandidateActionInstance(Path candidatePath)
                 throws ProvisioningException, OperationException {
-            return new ApplyCandidateAction(installDir, candidateDir);
+            return new ApplyCandidateAction(installDir, candidatePath);
         }
     }
 }

--- a/prospero-common/src/main/java/org/wildfly/prospero/spi/ProsperoInstallationManager.java
+++ b/prospero-common/src/main/java/org/wildfly/prospero/spi/ProsperoInstallationManager.java
@@ -5,8 +5,10 @@ import org.jboss.logging.Logger;
 import org.wildfly.channel.ChannelManifestCoordinate;
 import org.wildfly.channel.MavenCoordinate;
 import org.wildfly.installationmanager.ArtifactChange;
+import org.wildfly.installationmanager.CandidateType;
 import org.wildfly.installationmanager.Channel;
 import org.wildfly.installationmanager.ChannelChange;
+import org.wildfly.installationmanager.FileConflict;
 import org.wildfly.installationmanager.HistoryResult;
 import org.wildfly.installationmanager.InstallationChanges;
 import org.wildfly.installationmanager.ManifestVersion;
@@ -16,11 +18,13 @@ import org.wildfly.installationmanager.Repository;
 import org.wildfly.installationmanager.spi.InstallationManager;
 import org.wildfly.installationmanager.spi.OsShell;
 import org.wildfly.prospero.ProsperoLogger;
+import org.wildfly.prospero.actions.ApplyCandidateAction;
 import org.wildfly.prospero.actions.InstallationExportAction;
 import org.wildfly.prospero.actions.InstallationHistoryAction;
 import org.wildfly.prospero.actions.MetadataAction;
 import org.wildfly.prospero.actions.UpdateAction;
 import org.wildfly.prospero.api.MavenOptions.Builder;
+import org.wildfly.prospero.api.exceptions.InvalidUpdateCandidateException;
 import org.wildfly.prospero.galleon.GalleonCallbackAdapter;
 import org.wildfly.prospero.metadata.ManifestVersionRecord;
 import org.wildfly.prospero.spi.internal.CliProvider;
@@ -115,6 +119,61 @@ public class ProsperoInstallationManager implements InstallationManager {
     public boolean prepareUpdate(Path targetDir, List<Repository> repositories) throws Exception {
         try (UpdateAction prepareUpdateAction = actionFactory.getUpdateAction(map(repositories, ProsperoInstallationManager::mapRepository))) {
             return prepareUpdateAction.buildUpdate(targetDir);
+        }
+    }
+
+    @Override
+    public Collection<FileConflict> verifyCandidate(Path candidatePath, CandidateType candidateType) throws Exception {
+        final ApplyCandidateAction applyCandidateAction = actionFactory.getApplyCandidateAction(candidatePath);
+        final ApplyCandidateAction.Type operation;
+        switch (candidateType) {
+            case UPDATE:
+                operation = ApplyCandidateAction.Type.UPDATE;
+                break;
+            case REVERT:
+                operation = ApplyCandidateAction.Type.REVERT;
+                break;
+            default:
+                throw new IllegalArgumentException("Unsupported candidate type: " + candidateType);
+        }
+
+        final ApplyCandidateAction.ValidationResult validationResult = applyCandidateAction.verifyCandidate(operation);
+        switch (validationResult) {
+            case OK:
+                // we're good, continue
+                break;
+            case STALE:
+                throw ProsperoLogger.ROOT_LOGGER.staleCandidate(installationDir, candidatePath);
+            case NO_CHANGES:
+                throw ProsperoLogger.ROOT_LOGGER.noChangesAvailable(installationDir, candidatePath);
+            case NOT_CANDIDATE:
+                throw ProsperoLogger.ROOT_LOGGER.notCandidate(candidatePath);
+            case WRONG_TYPE:
+                throw ProsperoLogger.ROOT_LOGGER.wrongCandidateOperation(candidatePath, operation);
+            default:
+                // unexpected validation type - include the error in the description
+                throw new InvalidUpdateCandidateException(String.format("The candidate server %s is invalid - %s.", candidatePath, validationResult));
+        }
+
+        return map(applyCandidateAction.getConflicts(), ProsperoInstallationManager::mapFileConflict);
+    }
+
+    private static FileConflict mapFileConflict(org.wildfly.prospero.api.FileConflict fileConflict) {
+        return new FileConflict(Path.of(fileConflict.getRelativePath()), map(fileConflict.getUserChange()), map(fileConflict.getUpdateChange()), fileConflict.getResolution() == org.wildfly.prospero.api.FileConflict.Resolution.UPDATE);
+    }
+
+    private static FileConflict.Status map(org.wildfly.prospero.api.FileConflict.Change change) {
+        switch (change) {
+            case MODIFIED:
+                return FileConflict.Status.MODIFIED;
+            case ADDED:
+                return FileConflict.Status.ADDED;
+            case REMOVED:
+                return FileConflict.Status.REMOVED;
+            case NONE:
+                return FileConflict.Status.NONE;
+            default:
+                throw new IllegalArgumentException("Unknown file conflict change: " + change);
         }
     }
 
@@ -354,6 +413,10 @@ public class ProsperoInstallationManager implements InstallationManager {
 
         protected InstallationExportAction getInstallationExportAction() {
             return new InstallationExportAction(server);
+        }
+
+        protected ApplyCandidateAction getApplyCandidateAction(Path candidateDir) throws ProvisioningException, OperationException {
+            return new ApplyCandidateAction(server, candidateDir);
         }
 
         org.wildfly.prospero.api.MavenOptions getMavenOptions() {

--- a/prospero-common/src/main/java/org/wildfly/prospero/spi/ProsperoInstallationManager.java
+++ b/prospero-common/src/main/java/org/wildfly/prospero/spi/ProsperoInstallationManager.java
@@ -76,7 +76,8 @@ public class ProsperoInstallationManager implements InstallationManager {
         final List<HistoryResult> results = new ArrayList<>();
 
         for (SavedState savedState : revisions) {
-            results.add(new HistoryResult(savedState.getName(), savedState.getTimestamp(), savedState.getType().toString(), savedState.getMsg()));
+            results.add(new HistoryResult(savedState.getName(), savedState.getTimestamp(), savedState.getType().toString(),
+                    savedState.getMsg(), Collections.emptyList()));
         }
         return results;
     }
@@ -197,24 +198,34 @@ public class ProsperoInstallationManager implements InstallationManager {
 
     @Override
     public String generateApplyUpdateCommand(Path scriptHome, Path candidatePath, OsShell shell) throws OperationNotAvailableException {
-        final Optional<CliProvider> cliProviderLoader = ServiceLoader.load(CliProvider.class).findFirst();
-        if (cliProviderLoader.isEmpty()) {
-            throw new OperationNotAvailableException("Installation manager does not support CLI operations.");
-        }
-
-        final CliProvider cliProvider = cliProviderLoader.get();
-        return escape(scriptHome.resolve(cliProvider.getScriptName(shell))) + " " + cliProvider.getApplyUpdateCommand(installationDir, candidatePath);
+        return generateApplyUpdateCommand(scriptHome, candidatePath, shell, false);
     }
 
     @Override
     public String generateApplyRevertCommand(Path scriptHome, Path candidatePath, OsShell shell) throws OperationNotAvailableException {
+        return generateApplyUpdateCommand(scriptHome, candidatePath, shell, false);
+    }
+
+    @Override
+    public String generateApplyUpdateCommand(Path scriptHome, Path candidatePath, OsShell shell, boolean noConflictsOnly) throws OperationNotAvailableException {
         final Optional<CliProvider> cliProviderLoader = ServiceLoader.load(CliProvider.class).findFirst();
         if (cliProviderLoader.isEmpty()) {
             throw new OperationNotAvailableException("Installation manager does not support CLI operations.");
         }
 
         final CliProvider cliProvider = cliProviderLoader.get();
-        return escape(scriptHome.resolve(cliProvider.getScriptName(shell))) + " " + cliProvider.getApplyRevertCommand(installationDir, candidatePath);
+        return escape(scriptHome.resolve(cliProvider.getScriptName(shell))) + " " + cliProvider.getApplyUpdateCommand(installationDir, candidatePath, false);
+    }
+
+    @Override
+    public String generateApplyRevertCommand(Path scriptHome, Path candidatePath, OsShell shell, boolean noConflictsOnly) throws OperationNotAvailableException {
+        final Optional<CliProvider> cliProviderLoader = ServiceLoader.load(CliProvider.class).findFirst();
+        if (cliProviderLoader.isEmpty()) {
+            throw new OperationNotAvailableException("Installation manager does not support CLI operations.");
+        }
+
+        final CliProvider cliProvider = cliProviderLoader.get();
+        return escape(scriptHome.resolve(cliProvider.getScriptName(shell))) + " " + cliProvider.getApplyRevertCommand(installationDir, candidatePath, noConflictsOnly);
     }
 
     @Override

--- a/prospero-common/src/main/java/org/wildfly/prospero/spi/internal/CliProvider.java
+++ b/prospero-common/src/main/java/org/wildfly/prospero/spi/internal/CliProvider.java
@@ -37,16 +37,18 @@ public interface CliProvider {
      *
      * @param installationPath
      * @param candidatePath
+     * @param noConflictsOnly - whether to append the no-conflicts-only flag
      * @return
      */
-    String getApplyUpdateCommand(Path installationPath, Path candidatePath);
+    String getApplyUpdateCommand(Path installationPath, Path candidatePath, boolean noConflictsOnly);
 
     /**
      * generates command used to apply a revert candidate in {@code candidatePath} into {@code installationPath}
      *
      * @param installationPath
      * @param candidatePath
+     * @param noConflictsOnly - whether to append the no-conflicts-only flag
      * @return
      */
-    String getApplyRevertCommand(Path installationPath, Path candidatePath);
+    String getApplyRevertCommand(Path installationPath, Path candidatePath, boolean noConflictsOnly);
 }


### PR DESCRIPTION
Add `--no-conflicts-only` argument to update and revert operations.

When `--no-conflicts-only` argument is present, the `apply` and `perform` operations should fail if any file conflicts are detected. An error code (1) should be returned and no changes to the installation should be applied.

Requires https://github.com/wildfly-extras/wildfly-installation-manager-api/pull/20
