### PR TITLE
Align jboss repository ID with other WildFly projects

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -603,7 +603,7 @@
                 <enabled>true</enabled>
                 <updatePolicy>never</updatePolicy>
             </snapshots>
-            <id>jboss-public-repository</id>
+            <id>jboss-public-repository-group</id>
             <name>JBoss Public Repository</name>
             <url>https://repository.jboss.org/nexus/content/groups/public/</url>
             <layout>default</layout>
@@ -619,7 +619,7 @@
                 <enabled>true</enabled>
                 <updatePolicy>never</updatePolicy>
             </snapshots>
-            <id>jboss-public-repository</id>
+            <id>jboss-public-repository-group</id>
             <name>JBoss Public Repository</name>
             <url>https://repository.jboss.org/nexus/content/groups/public/</url>
             <layout>default</layout>


### PR DESCRIPTION
Majority of other WildFly projects use ID of `jboss-public-repository-group` rather than `jboss-public-repository`. This can lead to Maven caching issues when building multiple projects.

Fixes #713
