### PR TITLE
Ignore non-readable folders in the installation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
         <version.org.codehaus.plexus-interpolation>1.27</version.org.codehaus.plexus-interpolation>
         <version.org.codehaus.plexus-utils>3.5.0</version.org.codehaus.plexus-utils>
         <version.org.jboss.staxmapper>1.5.0.Final</version.org.jboss.staxmapper>
-        <version.org.jboss.galleon>6.0.1.Final</version.org.jboss.galleon>
+        <version.org.jboss.galleon>6.0.2.Final</version.org.jboss.galleon>
         <version.org.eclipse.jgit>6.9.0.202403050737-r</version.org.eclipse.jgit>
         <version.com.fasterxml.jackson>2.15.4</version.com.fasterxml.jackson>
         <version.org.jboss.logmanager>2.1.19.Final</version.org.jboss.logmanager>

--- a/prospero-common/src/test/java/org/wildfly/prospero/actions/ApplyCandidateActionTest.java
+++ b/prospero-common/src/test/java/org/wildfly/prospero/actions/ApplyCandidateActionTest.java
@@ -573,6 +573,44 @@ public class ApplyCandidateActionTest {
         );
     }
 
+    @Test
+    public void ignoreAddedNonReadableFolders() throws Exception {
+        final DirState expectedState = dirBuilder
+                .addFile("prod1/p1.txt", "p1 1.0.1")
+                .addFile("prod1/p2.txt", "p2 1.0.1")
+                .addFile("test/test.txt", "test")
+                .build();
+
+        // build test packages
+        creator.newFeaturePack(FeaturePackLocation.fromString(FPL_100).getFPID())
+                .addSystemPaths("prod1")
+                .newPackage("p1", true)
+                .writeContent("prod1/p1.txt", "p1 1.0.0") // modified by the user
+                .writeContent("prod1/p2.txt", "p2 1.0.0") // removed by user and restored in update
+                .getFeaturePack();
+        creator.newFeaturePack(FeaturePackLocation.fromString(FPL_101).getFPID())
+                .addSystemPaths("prod1")
+                .newPackage("p1", true)
+                .writeContent("prod1/p1.txt", "p1 1.0.1")
+                .writeContent("prod1/p2.txt", "p2 1.0.1")
+                .getFeaturePack();
+        creator.install();
+
+        // install base and update. perform apply-update
+        install(installationPath, FPL_100);
+        Files.createDirectories(installationPath.resolve("test"));
+        Files.writeString(installationPath.resolve("test").resolve("test.txt"), "test");
+        installationPath.resolve("test").toFile().setReadable(false);
+
+        prepareUpdate(updatePath, installationPath, FPL_101);
+        new ApplyCandidateAction(installationPath, updatePath)
+                .applyUpdate(ApplyCandidateAction.Type.UPDATE);
+
+        // verify
+        installationPath.resolve("test").toFile().setReadable(true);
+        expectedState.assertState(installationPath);
+    }
+
     private void createSimpleFeaturePacks() throws ProvisioningException {
         creator.newFeaturePack(FeaturePackLocation.fromString(FPL_100).getFPID())
                 .newPackage("p1", true)


### PR DESCRIPTION
The user can create additional files inside a directory created by installing Galleon feature pack, and those files are ignored during update.

 

However if such file is made read-only, an error is thrown when calculating FsDiff 

 
```
org.jboss.galleon.ProvisioningException: Failed to process child entries for /Users/spyrkob/workspaces/set/prospero/prospero/wildfly
    at org.jboss.galleon.diff.FsEntryFactory.forPath(FsEntryFactory.java:147)
    at org.jboss.galleon.ProvisioningManager.getFsDiff(ProvisioningManager.java:741)
    at org.jboss.galleon.caller.ProvisioningContextImpl.getFsDiff(ProvisioningContextImpl.java:227)
    at org.jboss.galleon.api.ProvisioningImpl.getFsDiff(ProvisioningImpl.java:335)
    at org.wildfly.prospero.actions.ApplyCandidateAction.findChanges(ApplyCandidateAction.java:384)
    at org.wildfly.prospero.actions.ApplyCandidateAction.getConflicts(ApplyCandidateAction.java:280)
    at org.wildfly.prospero.cli.commands.UpdateCommand$ApplyCommand.call(UpdateCommand.java:257)
    at org.wildfly.prospero.cli.commands.UpdateCommand$ApplyCommand.call(UpdateCommand.java:214)
    at picocli.CommandLine.executeUserObject(CommandLine.java:2045)
    at picocli.CommandLine.access$1500(CommandLine.java:148)
    at picocli.CommandLine$RunLast.executeUserObjectOfLastSubcommandWithSameParent(CommandLine.java:2465)
    at picocli.CommandLine$RunLast.handle(CommandLine.java:2457)
    at picocli.CommandLine$RunLast.handle(CommandLine.java:2419)
    at picocli.CommandLine$AbstractParseResultHandler.execute(CommandLine.java:2277)
    at picocli.CommandLine$RunLast.execute(CommandLine.java:2421)
    at picocli.CommandLine.execute(CommandLine.java:2174)
    at org.wildfly.prospero.cli.CliMain.execute(CliMain.java:132)
    at org.wildfly.prospero.cli.CliMain.main(CliMain.java:60)
Caused by: java.nio.file.AccessDeniedException: /Users/spyrkob/workspaces/set/prospero/prospero/wildfly/non-read
    at java.base/sun.nio.fs.UnixException.translateToIOException(UnixException.java:90)
    at java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:111)
    at java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:116)
    at java.base/sun.nio.fs.UnixFileSystemProvider.newDirectoryStream(UnixFileSystemProvider.java:412)
    at java.base/java.nio.file.Files.newDirectoryStream(Files.java:472)
    at org.jboss.galleon.diff.FsEntryFactory.initChildren(FsEntryFactory.java:155)
    at org.jboss.galleon.diff.FsEntryFactory.initChildren(FsEntryFactory.java:168)
    at org.jboss.galleon.diff.FsEntryFactory.forPath(FsEntryFactory.java:145)
 ```