### PR TITLE
[JBEAP-27509] extending history information

### DIFF
--- a/integration-tests/src/test/java/org/wildfly/prospero/it/cli/CacheManifestTest.java
+++ b/integration-tests/src/test/java/org/wildfly/prospero/it/cli/CacheManifestTest.java
@@ -384,6 +384,7 @@ public class CacheManifestTest extends WfCoreTestBase {
                 .collect(Collectors.toList());
         return new ChannelManifest(
                 sourceManifest.getSchemaVersion(),
+                sourceManifest.getName(),
                 sourceManifest.getId(),
                 sourceManifest.getLogicalVersion(),
                 sourceManifest.getDescription(),

--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
         <version.org.wildfly.galleon-plugins>7.2.0.Final</version.org.wildfly.galleon-plugins>
         <version.org.wildfly.installation-manager>2.0.0.Beta1</version.org.wildfly.installation-manager>
         <version.org.wildfly.maven.plugins.licenses-plugin>2.4.1.Final</version.org.wildfly.maven.plugins.licenses-plugin>
-        <version.org.wildfly.prospero.prospero-metadata>1.3.0.Beta1</version.org.wildfly.prospero.prospero-metadata>
+        <version.org.wildfly.prospero.prospero-metadata>1.3.0.Beta2</version.org.wildfly.prospero.prospero-metadata>
         <version.org.mockito>5.14.1</version.org.mockito>
         <version.org.slf4j>2.0.7</version.org.slf4j>
         <version.org.yaml.snakeyaml>2.2</version.org.yaml.snakeyaml>

--- a/prospero-cli/src/test/java/org/wildfly/prospero/cli/commands/HistoryCommandTest.java
+++ b/prospero-cli/src/test/java/org/wildfly/prospero/cli/commands/HistoryCommandTest.java
@@ -90,7 +90,8 @@ public class HistoryCommandTest extends AbstractConsoleTest {
     @Test
     public void displayListOfStates() throws Exception {
         when(historyAction.getRevisions()).thenReturn(Arrays.asList(
-                new SavedState("abcd", Instant.ofEpochSecond(System.currentTimeMillis()), SavedState.Type.INSTALL, null)));
+                new SavedState("abcd", Instant.ofEpochSecond(System.currentTimeMillis()), SavedState.Type.INSTALL,
+                        null, Collections.emptyList())));
 
         int exitCode = commandLine.execute(CliConstants.Commands.HISTORY, CliConstants.DIR, installationDir.toString());
         assertEquals(ReturnCodes.SUCCESS, exitCode);

--- a/prospero-common/src/main/java/org/wildfly/prospero/api/SavedState.java
+++ b/prospero-common/src/main/java/org/wildfly/prospero/api/SavedState.java
@@ -18,10 +18,18 @@
 package org.wildfly.prospero.api;
 
 import java.time.Instant;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
 
 public class SavedState {
+
+    private Set<Version> manifestVersions = Collections.emptySet();
 
     public enum Type { UPDATE, INSTALL, ROLLBACK, CONFIG_CHANGE,
         /**
@@ -50,11 +58,21 @@ public class SavedState {
     private Type type;
     private String msg = "";
 
+    @Deprecated
     public SavedState(String hash, Instant timestamp, Type type, String msg) {
         this.hash = hash;
         this.timestamp = timestamp;
         this.type = type;
         this.msg = msg;
+    }
+
+    public SavedState(String hash, Instant timestamp, Type type, String msg, List<Version> manifestVersions) {
+        this.hash = hash;
+        this.timestamp = timestamp;
+        this.type = type;
+        this.msg = msg;
+        // sort the manifests alphabetically so that the order of manifests in display will be consistent
+        this.manifestVersions = new TreeSet<>(manifestVersions);
     }
 
     public SavedState(String hash) {
@@ -79,8 +97,19 @@ public class SavedState {
         return msg;
     }
 
+    public Collection<Version> getManifestVersions() {
+        return manifestVersions;
+    }
+
     public String shortDescription() {
-        return String.format("[%s] %s - %s %s", hash, timestamp.toString(), type.toString().toLowerCase(Locale.ROOT), this.msg);
+        final String msg;
+        if (manifestVersions.isEmpty()) {
+            msg = this.msg;
+        } else {
+            final String versions = manifestVersions.stream().map(Version::getDisplayVersion).collect(Collectors.joining("+"));
+            msg = "[" + versions + "]";
+        }
+        return String.format("[%s] %s - %s %s", hash, timestamp.toString(), type.toString().toLowerCase(Locale.ROOT), msg);
     }
 
     @Override
@@ -88,11 +117,111 @@ public class SavedState {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         SavedState that = (SavedState) o;
-        return Objects.equals(hash, that.hash) && Objects.equals(timestamp, that.timestamp) && type == that.type;
+        return Objects.equals(manifestVersions, that.manifestVersions) && Objects.equals(hash, that.hash) && Objects.equals(timestamp, that.timestamp) && type == that.type && Objects.equals(msg, that.msg);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(hash, timestamp, type);
+        return Objects.hash(manifestVersions, hash, timestamp, type, msg);
+    }
+
+    @Override
+    public String toString() {
+        return "SavedState{" +
+                "manifestVersions=" + manifestVersions +
+                ", hash='" + hash + '\'' +
+                ", timestamp=" + timestamp +
+                ", type=" + type +
+                ", msg='" + msg + '\'' +
+                '}';
+    }
+
+    public static class Version implements Comparable<Version> {
+        public final String physicalVersion;
+        public final String logicalVersion;
+        private final String identifier;
+
+        /**
+         * Constructs version description of a manifest.
+         *
+         * @param identifier - see {@link Version#getIdentifier()}
+         * @param physicalVersion - see {@link Version#getPhysicalVersion()}
+         * @param logicalVersion - see {@link Version#getLogicalVersion()}
+         */
+        public Version(String identifier, String physicalVersion, String logicalVersion) {
+            Objects.requireNonNull(identifier);
+            Objects.requireNonNull(physicalVersion);
+
+            this.identifier = identifier;
+            this.physicalVersion = physicalVersion;
+            this.logicalVersion = logicalVersion;
+        }
+
+        /**
+         * The version of Maven coordinate if the manifest is a Maven artifact or a hash of a file in case if URL manifest.
+         * @return
+         */
+        public String getPhysicalVersion() {
+            return physicalVersion;
+        }
+
+        /**
+         * The version of manifest declared by the manifest header. For example since schema version 1.1.0, manifests
+         * can define {@code logicalVersion} field. Note this is an optional value.
+         * @return
+         */
+        public String getLogicalVersion() {
+            return logicalVersion;
+        }
+
+        /**
+         * Identifier of the manifest. In case of Maven manifest it is the GA part of the Maven coordinates. In case
+         * of URL manifest, it is the URL of the manifest.
+         * @return
+         */
+        public String getIdentifier() {
+            return identifier;
+        }
+
+        public String getDisplayVersion() {
+            if (logicalVersion != null) {
+                return logicalVersion;
+            } else {
+                return identifier + ":" + physicalVersion;
+            }
+        }
+        @Override
+        public String toString() {
+            return "Version{" +
+                    "physicalVersion='" + physicalVersion + '\'' +
+                    ", logicalVersion='" + logicalVersion + '\'' +
+                    ", identifier='" + identifier + '\'' +
+                    '}';
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            Version version = (Version) o;
+            return Objects.equals(physicalVersion, version.physicalVersion) && Objects.equals(logicalVersion, version.logicalVersion) && Objects.equals(identifier, version.identifier);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(physicalVersion, logicalVersion, identifier);
+        }
+
+        @Override
+        public int compareTo(Version o) {
+            int res = this.identifier.compareTo(o.getIdentifier());
+            if (res == 0) {
+                res = this.physicalVersion.compareTo(o.getPhysicalVersion());
+            }
+            if (res == 0 && this.logicalVersion != null && o.getLogicalVersion() != null) {
+                res = this.logicalVersion.compareTo(o.getLogicalVersion());
+            }
+            return res;
+        }
     }
 }

--- a/prospero-common/src/main/java/org/wildfly/prospero/installation/git/SavedStateParser.java
+++ b/prospero-common/src/main/java/org/wildfly/prospero/installation/git/SavedStateParser.java
@@ -1,0 +1,74 @@
+package org.wildfly.prospero.installation.git;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.wildfly.prospero.api.SavedState;
+import org.wildfly.prospero.metadata.ManifestVersionRecord;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * generates commit messages used in the git history storage
+ */
+class SavedStateParser {
+
+    private static final ObjectMapper JSON_MAPPER = new ObjectMapper(new JsonFactory());
+
+    String write(SavedState.Type recordType, ManifestVersionRecord currentVersions) throws IOException {
+        if (currentVersions == null) {
+            return null;
+        }
+
+        final String header = currentVersions.getSummary();
+
+        return recordType.name() + " " + header + "\n\n" + toJson(currentVersions);
+    }
+
+    SavedState read(String hash, Instant now, String text) throws IOException {
+        final SavedState.Type type;
+        final String msg;
+        final List<SavedState.Version> versions = new ArrayList<>();
+
+        if (!text.contains(" ")) {
+            // the message is only type
+            type = SavedState.Type.fromText(text);
+            text = "";
+        } else {
+            final int endOfType = text.indexOf(' ');
+            type = SavedState.Type.fromText(text.substring(0, endOfType));
+            text = text.substring(endOfType + 1);
+        }
+
+        if (!text.contains("\n\n")) {
+            // the message contains type and short description
+            msg = text;
+        } else {
+            // the message contains type, short description and versions
+            final int endOfShortDesc = text.indexOf("\n\n");
+            msg = text.substring(0, endOfShortDesc).trim();
+
+            text = text.substring(endOfShortDesc).trim();
+            if (!text.isEmpty()) {
+                final ManifestVersionRecord record = JSON_MAPPER.readValue(text, ManifestVersionRecord.class);
+                record.getMavenManifests().forEach(m -> versions.add(new SavedState.Version(
+                        m.getGroupId() + ":" + m.getArtifactId(),
+                        m.getVersion(), m.getDescription())));
+                record.getUrlManifests().forEach(m -> versions.add(new SavedState.Version(
+                        m.getUrl(), m.getHash(), m.getDescription()
+                )));
+                record.getOpenManifests().forEach(m ->  versions.add(new SavedState.Version(
+                        "unknown", "unknown", m.getSummary()
+                )));
+            }
+        }
+
+        return new SavedState(hash, now, type, msg.isEmpty() ? null : msg, versions);
+    }
+
+    private String toJson(ManifestVersionRecord currentVersions) throws IOException {
+        return JSON_MAPPER.writeValueAsString(currentVersions);
+    }
+}

--- a/prospero-common/src/main/java/org/wildfly/prospero/installation/git/SavedStateParser.java
+++ b/prospero-common/src/main/java/org/wildfly/prospero/installation/git/SavedStateParser.java
@@ -1,21 +1,43 @@
 package org.wildfly.prospero.installation.git;
 
 import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.networknt.schema.JsonSchema;
+import com.networknt.schema.JsonSchemaFactory;
+import com.networknt.schema.SpecVersion;
+import com.networknt.schema.ValidationMessage;
+import org.wildfly.channel.ChannelMapper;
+import org.wildfly.channel.version.VersionMatcher;
+import org.wildfly.prospero.ProsperoLogger;
 import org.wildfly.prospero.api.SavedState;
 import org.wildfly.prospero.metadata.ManifestVersionRecord;
 
 import java.io.IOException;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 
 /**
  * generates commit messages used in the git history storage
  */
 class SavedStateParser {
-
+    public static final String SCHEMA_VERSION_1_0_0 = "1.0.0";
+    private static final String SCHEMA_1_0_0_FILE = "org/wildfly/prospero/savedstate/v1.0.0/schema.json";
+    private static final Map<String, JsonSchema> SCHEMAS = new HashMap();
     private static final ObjectMapper JSON_MAPPER = new ObjectMapper(new JsonFactory());
+    private static final JsonSchemaFactory SCHEMA_FACTORY = JsonSchemaFactory.builder(JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V201909)).jsonMapper(JSON_MAPPER).build();
+
+    static {
+        SCHEMAS.put(SCHEMA_VERSION_1_0_0, SCHEMA_FACTORY.getSchema(ChannelMapper.class.getClassLoader().getResourceAsStream(SCHEMA_1_0_0_FILE)));
+    }
 
     String write(SavedState.Type recordType, ManifestVersionRecord currentVersions) throws IOException {
         if (currentVersions == null) {
@@ -29,8 +51,9 @@ class SavedStateParser {
 
     SavedState read(String hash, Instant now, String text) throws IOException {
         final SavedState.Type type;
+        final String originalText = text;
         final String msg;
-        final List<SavedState.Version> versions = new ArrayList<>();
+        List<SavedState.Version> versions = Collections.emptyList();
 
         if (!text.contains(" ")) {
             // the message is only type
@@ -40,6 +63,10 @@ class SavedStateParser {
             final int endOfType = text.indexOf(' ');
             type = SavedState.Type.fromText(text.substring(0, endOfType));
             text = text.substring(endOfType + 1);
+        }
+
+        if (type == SavedState.Type.UNKNOWN) {
+            return new SavedState(hash, now, type, shortMessage(originalText), versions);
         }
 
         if (!text.contains("\n\n")) {
@@ -52,23 +79,96 @@ class SavedStateParser {
 
             text = text.substring(endOfShortDesc).trim();
             if (!text.isEmpty()) {
-                final ManifestVersionRecord record = JSON_MAPPER.readValue(text, ManifestVersionRecord.class);
-                record.getMavenManifests().forEach(m -> versions.add(new SavedState.Version(
-                        m.getGroupId() + ":" + m.getArtifactId(),
-                        m.getVersion(), m.getDescription())));
-                record.getUrlManifests().forEach(m -> versions.add(new SavedState.Version(
-                        m.getUrl(), m.getHash(), m.getDescription()
-                )));
-                record.getOpenManifests().forEach(m ->  versions.add(new SavedState.Version(
-                        "unknown", "unknown", m.getSummary()
-                )));
+                try {
+                    versions = readVersions(text);
+                } catch (JsonParseException e) {
+                    ProsperoLogger.ROOT_LOGGER.error("Unable to parse a history record [" + text + "]", e);
+                }
             }
         }
 
-        return new SavedState(hash, now, type, msg.isEmpty() ? null : msg, versions);
+        return new SavedState(hash, now, type, msg, versions);
+    }
+
+    private static String shortMessage(String originalText) {
+        originalText = originalText.trim();
+
+        if (originalText.isEmpty()) {
+            return null;
+        } else if (originalText.contains("\n")) {
+            return originalText.split("\n") [0].trim();
+        } else {
+            return originalText;
+        }
+    }
+
+    private static List<SavedState.Version> readVersions(String text) throws JsonProcessingException {
+        JsonNode node = JSON_MAPPER.readTree(text);
+        JsonSchema schema = getSchema(node);
+
+        if (schema == null) {
+            return Collections.emptyList();
+        }
+
+        Set<ValidationMessage> validationMessages = schema.validate(node);
+        if (!validationMessages.isEmpty()) {
+            for (ValidationMessage validationMessage : validationMessages) {
+                ProsperoLogger.ROOT_LOGGER.error("Invalid Saved State in history " + validationMessage);
+            }
+            return Collections.emptyList();
+        }
+
+        final ManifestVersionRecord record = JSON_MAPPER.readValue(text, ManifestVersionRecord.class);
+        final List<SavedState.Version> versions = new ArrayList<>();
+        record.getMavenManifests().forEach(m -> versions.add(new SavedState.Version(
+                m.getGroupId() + ":" + m.getArtifactId(),
+                m.getVersion(), m.getDescription())));
+        record.getUrlManifests().forEach(m -> versions.add(new SavedState.Version(
+                m.getUrl(), m.getHash(), m.getDescription()
+        )));
+        record.getOpenManifests().forEach(m ->  versions.add(new SavedState.Version(
+                "unknown", "unknown", m.getSummary()
+        )));
+        return versions;
     }
 
     private String toJson(ManifestVersionRecord currentVersions) throws IOException {
         return JSON_MAPPER.writeValueAsString(currentVersions);
+    }
+
+    private static JsonSchema getSchema(JsonNode node) {
+        JsonNode schemaVersion = node.path("schemaVersion");
+        String version = schemaVersion.asText();
+        if (version == null || version.isEmpty()) {
+            ProsperoLogger.ROOT_LOGGER.error("Invalid Saved State record in history - schema version is not specified");
+            return null;
+        }
+
+        JsonSchema schema = SCHEMAS.get(version);
+        if (schema != null) {
+            return schema;
+        } else {
+            final String[] parts = version.split("\\.");
+            StringBuilder versionPattern = new StringBuilder();
+            for (int i = 0; i < parts.length; i++) {
+                if (i == 0) {
+                    versionPattern.append(parts[i]);
+                } else if (i == parts.length -1 ) {
+                    versionPattern.append(".*");
+                } else {
+                    versionPattern.append("\\.").append(parts[i]);
+                }
+            }
+
+            final Optional<String> latestCompatibleSchemaVersion = SCHEMAS.keySet().stream()
+                    .filter(v -> v.matches(versionPattern.toString()))
+                    .max(VersionMatcher.COMPARATOR);
+
+            return latestCompatibleSchemaVersion.map(SCHEMAS::get)
+                    .orElseGet(()->{
+                        ProsperoLogger.ROOT_LOGGER.error("Invalid Saved State record in history - unknown schema version " + schemaVersion);
+                        return null;
+                    });
+        }
     }
 }

--- a/prospero-common/src/main/java/org/wildfly/prospero/spi/ProsperoInstallationManager.java
+++ b/prospero-common/src/main/java/org/wildfly/prospero/spi/ProsperoInstallationManager.java
@@ -81,7 +81,8 @@ public class ProsperoInstallationManager implements InstallationManager {
 
         for (SavedState savedState : revisions) {
             results.add(new HistoryResult(savedState.getName(), savedState.getTimestamp(), savedState.getType().toString(),
-                    savedState.getMsg(), Collections.emptyList()));
+                    savedState.getMsg(),
+                    map(savedState.getManifestVersions(), ProsperoInstallationManager::mapManifestVersion)));
         }
         return results;
     }
@@ -346,7 +347,7 @@ public class ProsperoInstallationManager implements InstallationManager {
         }
     }
 
-    private static <T, R> List<R> map(List<T> subject, Function<T,R> mapper) {
+    private static <T, R> List<R> map(Collection<T> subject, Function<T,R> mapper) {
         if (subject == null) {
             return Collections.emptyList();
         }
@@ -383,6 +384,10 @@ public class ProsperoInstallationManager implements InstallationManager {
             default:
                 return new ChannelChange(oldChannel, newChannel, ChannelChange.Status.MODIFIED);
         }
+    }
+
+    private static ManifestVersion mapManifestVersion(SavedState.Version version) {
+        return new ManifestVersion(version.getIdentifier(), version.getLogicalVersion(), version.getPhysicalVersion(), ManifestVersion.Type.MAVEN);
     }
 
     ActionFactory getActionFactory() {

--- a/prospero-common/src/main/resources/org/wildfly/prospero/savedstate/v1.0.0/schema.json
+++ b/prospero-common/src/main/resources/org/wildfly/prospero/savedstate/v1.0.0/schema.json
@@ -1,0 +1,76 @@
+{
+  "$id": "https://wildfly.org/prospero/savedstate/v1.0.0/schema.json",
+  "$schema": "https://json-schema.org/draft/2019-09/schema#",
+  "type": "object",
+  "required": ["schemaVersion"],
+  "properties": {
+    "schemaVersion": {
+      "description": "The version of the schema defining a saved state.",
+      "type": "string",
+      "pattern": "^[0-9]+.[0-9]+.[0-9]+$"
+    },
+    "maven": {
+      "type": "array",
+      "items": {
+        "type" : "object",
+        "properties": {
+          "groupId": {
+            "description": "GroupID Maven coordinate of the manifest",
+            "type": "string"
+          },
+          "artifactId": {
+            "description": "ArtifactID Maven coordinate of the manifest",
+            "type": "string"
+          },
+          "version": {
+            "description": "Version Maven coordinate of the manifest",
+            "type": "string"
+          },
+          "description": {
+            "description": "A human readable description of the manifest version",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "url": {
+      "type": "array",
+      "items": {
+        "type" : "object",
+        "properties": {
+          "url": {
+            "description": "A URL the manifest was resolved from",
+            "type": "string"
+          },
+          "hash": {
+            "description": "A SHA-1 hash of the manifest content",
+            "type": "string"
+          },
+          "description": {
+            "description": "A human readable description of the manifest version",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "open": {
+      "type": "array",
+      "items": {
+        "type" : "object",
+        "properties": {
+          "repos": {
+            "type": "array",
+            "description": "Repositories used to assemble the manifest",
+            "items": {
+              "type": "string"
+            }
+          },
+          "strategy": {
+            "description": "Resolution strategy for the channel",
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/prospero-common/src/test/java/org/wildfly/prospero/api/SavedStateTest.java
+++ b/prospero-common/src/test/java/org/wildfly/prospero/api/SavedStateTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2024 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.prospero.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public class SavedStateTest {
+
+    @Test
+    public void versionDisplayDefaultsToLogicalVersion() {
+        final SavedState.Version version = new SavedState.Version("abcd", "1.0.0", "Logical version");
+
+        assertEquals("Logical version", version.getDisplayVersion());
+    }
+
+    @Test
+    public void versionDisplayFallsBackToPhysicalVersionIfLogicalVersionDoesNotExist() {
+        final SavedState.Version version = new SavedState.Version("abcd", "1.0.0", null);
+
+        assertEquals("abcd:1.0.0", version.getDisplayVersion());
+    }
+
+    @Test
+    public void testVersionOrdering() {
+        SavedState.Version v1 = new SavedState.Version("aaa", "2", "1");
+        SavedState.Version v2 = new SavedState.Version("bbb", "2", "1");
+        assertThat(v1).isLessThan(v2);
+
+        v2 = new SavedState.Version("aaa", "3", "1");
+        assertThat(v1).isLessThan(v2);
+
+        v2 = new SavedState.Version("aaa", "1", "1");
+        assertThat(v1).isGreaterThan(v2);
+
+        v2 = new SavedState.Version("aaa", "2", "2");
+        assertThat(v1).isLessThan(v2);
+    }
+}

--- a/prospero-common/src/test/java/org/wildfly/prospero/installation/git/SavedStateParserTest.java
+++ b/prospero-common/src/test/java/org/wildfly/prospero/installation/git/SavedStateParserTest.java
@@ -1,0 +1,67 @@
+package org.wildfly.prospero.installation.git;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.wildfly.prospero.api.SavedState;
+import org.wildfly.prospero.metadata.ManifestVersionRecord;
+
+import java.time.Instant;
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SavedStateParserTest {
+
+    protected static final Instant A_TIMESTAMP = Instant.now();
+    protected static final String A_HASH = "abcd";
+    private SavedStateParser savedStateParser;
+
+    @Before
+    public void setUp() throws Exception {
+        this.savedStateParser = new SavedStateParser();
+    }
+
+    @Test
+    public void readSavedStateOperationOnly() throws Exception {
+        final SavedState state = savedStateParser.read(A_HASH, A_TIMESTAMP, SavedState.Type.INSTALL.toString());
+
+        assertThat(state)
+                .isEqualTo(new SavedState(A_HASH, A_TIMESTAMP, SavedState.Type.INSTALL, null, Collections.emptyList()));
+    }
+
+    @Test
+    public void readSavedStateOperationAndShortDescription() throws Exception {
+        final String msg = SavedState.Type.INSTALL + " [foo:bar]";
+
+        final SavedState state = savedStateParser.read(A_HASH, A_TIMESTAMP, msg);
+
+        assertThat(state)
+                .isEqualTo(new SavedState(A_HASH, A_TIMESTAMP, SavedState.Type.INSTALL, "[foo:bar]", Collections.emptyList()));
+    }
+
+    @Test
+    public void readSavedStateFullRecord() throws Exception {
+        final ManifestVersionRecord record = new ManifestVersionRecord("1.0.0",
+                List.of(new ManifestVersionRecord.MavenManifest("org.foo", "bar", "1.0.0", "Update 1")),
+                Collections.emptyList(), Collections.emptyList());
+        final String msg = savedStateParser.write(SavedState.Type.INSTALL, record);
+
+        final SavedState state = savedStateParser.read(A_HASH, A_TIMESTAMP, msg);
+
+        assertThat(state)
+                .isEqualTo(new SavedState(A_HASH, A_TIMESTAMP, SavedState.Type.INSTALL, "[org.foo:bar::1.0.0]",
+                        List.of(new SavedState.Version("org.foo:bar", "1.0.0", "Update 1"))));
+    }
+
+    @Test
+    public void readSavedStateShortStatusWithTrailingNewLines() throws Exception {
+        final String msg = SavedState.Type.INSTALL + " [foo:bar]\n\n";
+
+        final SavedState state = savedStateParser.read(A_HASH, A_TIMESTAMP, msg);
+
+        assertThat(state)
+                .isEqualTo(new SavedState(A_HASH, A_TIMESTAMP, SavedState.Type.INSTALL, "[foo:bar]", Collections.emptyList()));
+    }
+
+}

--- a/prospero-common/src/test/java/org/wildfly/prospero/installation/git/SavedStateParserTest.java
+++ b/prospero-common/src/test/java/org/wildfly/prospero/installation/git/SavedStateParserTest.java
@@ -27,7 +27,7 @@ public class SavedStateParserTest {
         final SavedState state = savedStateParser.read(A_HASH, A_TIMESTAMP, SavedState.Type.INSTALL.toString());
 
         assertThat(state)
-                .isEqualTo(new SavedState(A_HASH, A_TIMESTAMP, SavedState.Type.INSTALL, null, Collections.emptyList()));
+                .isEqualTo(new SavedState(A_HASH, A_TIMESTAMP, SavedState.Type.INSTALL, "", Collections.emptyList()));
     }
 
     @Test
@@ -47,11 +47,61 @@ public class SavedStateParserTest {
                 Collections.emptyList(), Collections.emptyList());
         final String msg = savedStateParser.write(SavedState.Type.INSTALL, record);
 
+        System.out.println(msg);
+
         final SavedState state = savedStateParser.read(A_HASH, A_TIMESTAMP, msg);
 
         assertThat(state)
                 .isEqualTo(new SavedState(A_HASH, A_TIMESTAMP, SavedState.Type.INSTALL, "[org.foo:bar::1.0.0]",
                         List.of(new SavedState.Version("org.foo:bar", "1.0.0", "Update 1"))));
+    }
+
+    @Test
+    public void readSavedStateWithAdditionalFieldRecord() throws Exception {
+        final String msg = "INSTALL [org.foo:bar::1.0.0]\n\n" + "{\"schemaVersion\":\"1.0.0\",\"maven\":" +
+                "[{\"groupId\":\"org.foo\",\"artifactId\":\"bar\",\"version\":\"1.0.0\",\"description\":\"Update 1\", \"idontexit\":\"foobar\"}]}";
+
+        final SavedState state = savedStateParser.read(A_HASH, A_TIMESTAMP, msg);
+
+        assertThat(state)
+                .isEqualTo(new SavedState(A_HASH, A_TIMESTAMP, SavedState.Type.INSTALL, "[org.foo:bar::1.0.0]",
+                        List.of(new SavedState.Version("org.foo:bar", "1.0.0", "Update 1"))));
+    }
+
+    @Test
+    public void readUnknownMicroSchemaVersion() throws Exception {
+        final String msg = "INSTALL [org.foo:bar::1.0.0]\n\n" + "{\"schemaVersion\":\"1.0.999\",\"maven\":" +
+                "[{\"groupId\":\"org.foo\",\"artifactId\":\"bar\",\"version\":\"1.0.0\",\"description\":\"Update 1\", \"idontexit\":\"foobar\"}]}";
+
+        final SavedState state = savedStateParser.read(A_HASH, A_TIMESTAMP, msg);
+
+        assertThat(state)
+                .isEqualTo(new SavedState(A_HASH, A_TIMESTAMP, SavedState.Type.INSTALL, "[org.foo:bar::1.0.0]",
+                        List.of(new SavedState.Version("org.foo:bar", "1.0.0", "Update 1"))));
+    }
+
+    @Test
+    public void readUnknownMajorSchemaVersion() throws Exception {
+        final String msg = "INSTALL [org.foo:bar::1.0.0]\n\n" + "{\"schemaVersion\":\"999999.0.0\",\"maven\":" +
+                "[{\"groupId\":\"org.foo\",\"artifactId\":\"bar\",\"version\":\"1.0.0\",\"description\":\"Update 1\", \"idontexit\":\"foobar\"}]}";
+
+        final SavedState state = savedStateParser.read(A_HASH, A_TIMESTAMP, msg);
+
+        assertThat(state)
+                .isEqualTo(new SavedState(A_HASH, A_TIMESTAMP, SavedState.Type.INSTALL, "[org.foo:bar::1.0.0]",
+                        Collections.emptyList()));
+    }
+
+    @Test
+    public void readNoSchemaVersion() throws Exception {
+        final String msg = "INSTALL [org.foo:bar::1.0.0]\n\n" + "{\"maven\":" +
+                "[{\"groupId\":\"org.foo\",\"artifactId\":\"bar\",\"version\":\"1.0.0\",\"description\":\"Update 1\", \"idontexit\":\"foobar\"}]}";
+
+        final SavedState state = savedStateParser.read(A_HASH, A_TIMESTAMP, msg);
+
+        assertThat(state)
+                .isEqualTo(new SavedState(A_HASH, A_TIMESTAMP, SavedState.Type.INSTALL, "[org.foo:bar::1.0.0]",
+                        Collections.emptyList()));
     }
 
     @Test
@@ -62,6 +112,36 @@ public class SavedStateParserTest {
 
         assertThat(state)
                 .isEqualTo(new SavedState(A_HASH, A_TIMESTAMP, SavedState.Type.INSTALL, "[foo:bar]", Collections.emptyList()));
+    }
+
+    @Test
+    public void garbageSingleLineIn_ProducesUnknownStateWithShortMessage() throws Exception {
+        final String msg = "A random text that makes no sense";
+
+        final SavedState state = savedStateParser.read(A_HASH, A_TIMESTAMP, msg);
+
+        assertThat(state)
+                .isEqualTo(new SavedState(A_HASH, A_TIMESTAMP, SavedState.Type.UNKNOWN, msg, Collections.emptyList()));
+    }
+
+    @Test
+    public void garbageMultiLineIn_ProducesUnknownStateWithShortMessage() throws Exception {
+        final String msg = "A random text that \n\n makes no sense";
+
+        final SavedState state = savedStateParser.read(A_HASH, A_TIMESTAMP, msg);
+
+        assertThat(state)
+                .isEqualTo(new SavedState(A_HASH, A_TIMESTAMP, SavedState.Type.UNKNOWN, "A random text that", Collections.emptyList()));
+    }
+
+    @Test
+    public void garbageVersions_ProducesCorrectStateTypeWithShortMessage() throws Exception {
+        final String msg = "UPDATE A random text that \n\n makes no sense";
+
+        final SavedState state = savedStateParser.read(A_HASH, A_TIMESTAMP, msg);
+
+        assertThat(state)
+                .isEqualTo(new SavedState(A_HASH, A_TIMESTAMP, SavedState.Type.UPDATE, "A random text that", Collections.emptyList()));
     }
 
 }


### PR DESCRIPTION
Add current manifest versions to the git commit so that they can be displayed in history operations

== Overview
The channel manifest 1.1.0 adds a notion of `logicalVersion` to separate the version of manifest from the Maven coordinate. This change will consume the new field falling back to the Maven coordinate (physical version) if the logicalVersion is not present.
Additionally, the PR changes how the manifest version information is stored. Previously the version string visible in history information was constructed during update and stored. This make it hard for API clients that would like to display the versions of individual manifests.

== Expected results
1.  History operation on servers installed with old versions of Prospero works as previously
2. A newly provisioned server's history contains individual manifest's version information rather than the constructed version message
3. Installation-manger-api returns manifest version information for each history state including logical and physical version. If the commit was made before this changes, API should return commit information instead.