### PR TITLE
[JBEAP-27438] Improve error message when repositories argument points at non-existing folder

### DIFF
--- a/prospero-cli/src/main/java/org/wildfly/prospero/cli/CliMessages.java
+++ b/prospero-cli/src/main/java/org/wildfly/prospero/cli/CliMessages.java
@@ -19,6 +19,7 @@ package org.wildfly.prospero.cli;
 
 import org.apache.commons.lang3.StringUtils;
 import org.jboss.galleon.Constants;
+import org.jboss.logging.annotations.Cause;
 import org.wildfly.prospero.actions.ApplyCandidateAction;
 import org.wildfly.prospero.cli.commands.CliConstants;
 import org.wildfly.prospero.metadata.ProsperoMetadataUtils;
@@ -414,8 +415,12 @@ public interface CliMessages {
         return new ArgumentParsingException(format(bundle.getString("prospero.general.validation.repo_format"), repoKey));
     }
 
-    default ArgumentParsingException invalidFilePath(String invalidPath) {
-        return new ArgumentParsingException(format(bundle.getString("prospero.general.validation.file_path.not_exists"), invalidPath));
+    default ArgumentParsingException invalidFilePath(String invalidPath, @Cause Exception cause) {
+        return new ArgumentParsingException(format(bundle.getString("prospero.general.validation.file_path.invalid"), invalidPath), cause);
+    }
+
+    default ArgumentParsingException nonExistingFilePath(Path nonExistingPath) {
+        return new ArgumentParsingException(format(bundle.getString("prospero.general.validation.file_path.not_exists"), nonExistingPath));
     }
 
     default IllegalArgumentException updateCandidateStateNotMatched(Path targetDir, Path updateDir) {

--- a/prospero-cli/src/main/java/org/wildfly/prospero/cli/RepositoryDefinition.java
+++ b/prospero-cli/src/main/java/org/wildfly/prospero/cli/RepositoryDefinition.java
@@ -93,7 +93,7 @@ public class RepositoryDefinition {
         if (Files.exists(repoPath)) {
             return repoPath.toUri();
         } else {
-            throw CliMessages.MESSAGES.invalidFilePath(repoInfo);
+            throw CliMessages.MESSAGES.nonExistingFilePath(repoPath);
         }
     }
 
@@ -109,7 +109,7 @@ public class RepositoryDefinition {
             try {
                 return Path.of(repoInfo);
             } catch (InvalidPathException e) {
-                throw CliMessages.MESSAGES.invalidFilePath(repoInfo);
+                throw CliMessages.MESSAGES.invalidFilePath(repoInfo, e);
             }
         }
     }

--- a/prospero-cli/src/main/resources/UsageMessages.properties
+++ b/prospero-cli/src/main/resources/UsageMessages.properties
@@ -314,7 +314,9 @@ prospero.general.error.resolve.streams.header=Required artifact streams are not 
 prospero.general.validation.conflicting_options=Only one of %s and %s can be set.
 prospero.general.validation.local_repo.not_directory=Repository path `%s` is a file not a directory.
 prospero.general.validation.repo_format=Repository definition [%s] is invalid. The definition format should be [id::url] or [url].
-prospero.general.validation.file_path.not_exists= The given file path [%s] is invalid.
+prospero.general.validation.file_path.not_exists=The provided path [%s] doesn't exist or is not accessible. The local repository has to an existing, readable folder.
+prospero.general.validation.file_path.invalid=The given file path [%s] is invalid.
+
 prospero.general.error.missing_file=Required file at `%s` cannot be opened.
 prospero.general.error.galleon.parse=Failed to parse provisioning configuration: %s
 prospero.general.error.feature_pack.not_found=The feature pack `%s` is not available in the subscribed channels.

--- a/prospero-cli/src/test/java/org/wildfly/prospero/cli/RepositoryDefinitionTest.java
+++ b/prospero-cli/src/test/java/org/wildfly/prospero/cli/RepositoryDefinitionTest.java
@@ -18,6 +18,7 @@
 package org.wildfly.prospero.cli;
 
 import org.apache.commons.lang3.StringUtils;
+import org.assertj.core.api.Assertions;
 import org.junit.Before;
 import org.junit.Test;
 import org.wildfly.channel.Repository;
@@ -164,5 +165,21 @@ public class RepositoryDefinitionTest {
         assertNotNull(actualList);
         assertEquals(1, actualList.size());
         assertTrue(actualList.contains(repository));
+    }
+
+    @Test
+    public void testNonExistingFile() throws Exception {
+        Assertions.assertThatThrownBy(() -> from(List.of("idontexist")))
+                .hasMessageContaining(String.format(
+                        "The provided path [%s] doesn't exist or is not accessible. The local repository has to an existing, readable folder.",
+                        Path.of("idontexist").toAbsolutePath()));
+    }
+
+    @Test
+    public void testNonExistingFileUri() throws Exception {
+        Assertions.assertThatThrownBy(() -> from(List.of("file:idontexist")))
+                .hasMessageContaining(String.format(
+                        "The provided path [%s] doesn't exist or is not accessible. The local repository has to an existing, readable folder.",
+                        Path.of("idontexist").toAbsolutePath()));
     }
 }


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/JBEAP-27438
Upstream: #721
