### PR TITLE
[#750] Fix logging configuration to avoid duplicated logs when using --debug option

### DIFF
--- a/dist/common/src/main/resources/packages/org.jboss.prospero/content/bin/prospero-logging.properties
+++ b/dist/common/src/main/resources/packages/org.jboss.prospero/content/bin/prospero-logging.properties
@@ -2,13 +2,10 @@
 loggers=org.wildfly.prospero,com.networknt.schema,org.eclipse.aether.internal.impl
 
 logger.org.wildfly.prospero.level=INFO
-logger.org.wildfly.prospero.handlers=FILE
 # networknt schema is very verbose at DEBUG level
 logger.com.networknt.schema.level=INFO
-logger.com.networknt.schema.handlers=FILE
 # set to DEBUG for additional information on artifact resolution
 logger.org.eclipse.aether.internal.impl.level=INFO
-logger.org.eclipse.aether.internal.impl.handlers=FILE
 
 # Root logger level
 logger.level=INFO

--- a/prospero-cli/src/main/java/org/wildfly/prospero/cli/CliMain.java
+++ b/prospero-cli/src/main/java/org/wildfly/prospero/cli/CliMain.java
@@ -115,8 +115,10 @@ public class CliMain {
             if (c instanceof PropertyConfigurator) {
                 LogContextConfiguration lcc = ((PropertyConfigurator) c).getLogContextConfiguration();
                 lcc.getLoggerConfiguration("org.wildfly.prospero").setLevel(Level.DEBUG.getName());
-                lcc.getLoggerConfiguration("org.wildfly.prospero").addHandlerName("CONSOLE");
                 lcc.getHandlerConfiguration("CONSOLE").setLevel(Level.DEBUG.getName());
+                if (!lcc.getLoggerConfiguration("").getHandlerNames().contains("CONSOLE")) {
+                    lcc.getLoggerConfiguration("").addHandlerName("CONSOLE");
+                }
                 lcc.commit();
             } else {
                 logger.warn("Cannot change logging level, using default.");


### PR DESCRIPTION
Fixes: #750
