### PR TITLE
Downgrade plexus-utils from 3.5.0 to 3.0.24

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
         <version.org.apache.maven>3.9.9</version.org.apache.maven>
         <version.org.codehaus.gmaven.groovy-maven-plugin>2.1.1</version.org.codehaus.gmaven.groovy-maven-plugin>
         <version.org.codehaus.plexus-interpolation>1.27</version.org.codehaus.plexus-interpolation>
-        <version.org.codehaus.plexus-utils>3.5.0</version.org.codehaus.plexus-utils>
+        <version.org.codehaus.plexus-utils>3.0.24</version.org.codehaus.plexus-utils>
         <version.org.jboss.staxmapper>1.5.0.Final</version.org.jboss.staxmapper>
         <version.org.jboss.galleon>6.0.4.Final</version.org.jboss.galleon>
         <version.org.eclipse.jgit>6.9.0.202403050737-r</version.org.eclipse.jgit>


### PR DESCRIPTION
This is to align with wildfly-jar-maven-plugin.