### PR TITLE
Update-subscribe command ignores repositories option

### DIFF
--- a/integration-tests/src/test/java/org/wildfly/prospero/it/cli/FeaturesAddTest.java
+++ b/integration-tests/src/test/java/org/wildfly/prospero/it/cli/FeaturesAddTest.java
@@ -115,6 +115,7 @@ public class FeaturesAddTest {
                         CliConstants.LAYERS, "datasources-web-server,postgresql-datasource",
                         CliConstants.ACCEPT_AGREEMENTS,
                         CliConstants.YES,
+                        CliConstants.REPOSITORIES, String.join(",", TestProperties.TEST_REPO_URLS),
                         CliConstants.DIR, targetDir.getAbsolutePath())
                 .withTimeLimit(10, TimeUnit.MINUTES)
                 .execute()
@@ -138,6 +139,7 @@ public class FeaturesAddTest {
                         CliConstants.REVISION, savedState.getName(),
                         CliConstants.YES,
                         CliConstants.VERBOSE,
+                        CliConstants.REPOSITORIES, String.join(",", TestProperties.TEST_REPO_URLS),
                         CliConstants.DIR, targetDir.getAbsolutePath())
                 .withTimeLimit(10, TimeUnit.MINUTES)
                 .execute()
@@ -230,6 +232,7 @@ public class FeaturesAddTest {
                 CliConstants.Commands.INSTALL,
                 CliConstants.ACCEPT_AGREEMENTS,
                 CliConstants.PROFILE, profileName,
+                CliConstants.REPOSITORIES, String.join(",", TestProperties.TEST_REPO_URLS),
                 CliConstants.DIR, targetDir.getAbsolutePath()));
 
         if (profileName.equals("wildfly")) {

--- a/integration-tests/src/test/java/org/wildfly/prospero/it/cli/GenerateTest.java
+++ b/integration-tests/src/test/java/org/wildfly/prospero/it/cli/GenerateTest.java
@@ -30,6 +30,7 @@ import org.wildfly.channel.version.VersionMatcher;
 import org.wildfly.prospero.cli.ReturnCodes;
 import org.wildfly.prospero.cli.commands.CliConstants;
 import org.wildfly.prospero.it.ExecutionUtils;
+import org.wildfly.prospero.it.utils.TestProperties;
 import org.wildfly.prospero.metadata.ProsperoMetadataUtils;
 import org.wildfly.prospero.model.ManifestYamlSupport;
 import org.wildfly.prospero.model.ProsperoConfig;
@@ -89,6 +90,7 @@ public class GenerateTest {
                         CliConstants.PRODUCT, PRODUCT,
                         CliConstants.VERSION, VERSION,
                         CliConstants.Y,
+                        CliConstants.REPOSITORIES, String.join(",", TestProperties.TEST_REPO_URLS),
                         CliConstants.DIR, serverDir.toString())
                 .withTimeLimit(10, TimeUnit.MINUTES)
                 .execute()

--- a/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/UpdateCommand.java
+++ b/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/UpdateCommand.java
@@ -48,6 +48,7 @@ import org.wildfly.prospero.api.InstallationMetadata;
 import org.wildfly.prospero.api.InstallationProfilesManager;
 import org.wildfly.prospero.api.MavenOptions;
 import org.wildfly.prospero.api.RepositoryUtils;
+import org.wildfly.prospero.api.TemporaryRepositoriesHandler;
 import org.wildfly.prospero.api.exceptions.OperationException;
 import org.wildfly.prospero.cli.ActionFactory;
 import org.wildfly.prospero.cli.ArgumentParsingException;
@@ -365,9 +366,15 @@ public class UpdateCommand extends AbstractParentCommand {
             FeaturePackLocation loc = getFpl(installationProfile, version);
             log.debugf("Will generate FeaturePackLocation %s.", loc.toString());
 
-            SubscribeNewServerAction subscribeNewServerAction = actionFactory.subscribeNewServerAction(parseMavenOptions(), console);
-            SubscribeNewServerAction.GenerateResult generateResult = subscribeNewServerAction.generateServerMetadata(channels, loc);
-            generateMeta(installDir, generateResult);
+            try (TemporaryFilesManager temporaryFiles = TemporaryFilesManager.getInstance()) {
+                final List<Repository> repositories = RepositoryUtils.unzipArchives(
+                        RepositoryDefinition.from(temporaryRepositories), temporaryFiles);
+                final List<Channel> tempChannels = TemporaryRepositoriesHandler.overrideRepositories(channels, repositories);
+
+                SubscribeNewServerAction subscribeNewServerAction = actionFactory.subscribeNewServerAction(parseMavenOptions(), console);
+                SubscribeNewServerAction.GenerateResult generateResult = subscribeNewServerAction.generateServerMetadata(tempChannels, loc);
+                generateMeta(installDir, generateResult);
+            }
 
             return ReturnCodes.SUCCESS;
         }


### PR DESCRIPTION
`prospero update subscribe` command exposes `--repositories` option used to provide temporary repositories (e.g. local zips) for single operations.

However in this case `--repositories` is ignored and the tool always uses repositories configured in the channels.

Expected:
 * user should be able to use `--repositories` to specify a local repository used to subscribe a server
