### PR TITLE
[JBEAP 29337] Print user-friendly error message when provisioning.xml cannot be parsed

### DIFF
--- a/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/UpdateCommand.java
+++ b/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/UpdateCommand.java
@@ -50,6 +50,7 @@ import org.wildfly.prospero.api.InstallationProfilesManager;
 import org.wildfly.prospero.api.MavenOptions;
 import org.wildfly.prospero.api.RepositoryUtils;
 import org.wildfly.prospero.api.TemporaryRepositoriesHandler;
+import org.wildfly.prospero.api.exceptions.MetadataException;
 import org.wildfly.prospero.api.exceptions.OperationException;
 import org.wildfly.prospero.cli.ActionFactory;
 import org.wildfly.prospero.cli.ArgumentParsingException;
@@ -66,7 +67,6 @@ import org.wildfly.prospero.model.InstallationProfile;
 import org.wildfly.prospero.updates.UpdateSet;
 import picocli.CommandLine;
 
-import javax.xml.stream.XMLStreamException;
 import org.jboss.galleon.api.config.GalleonProvisioningConfig;
 
 @CommandLine.Command(
@@ -436,8 +436,8 @@ public class UpdateCommand extends AbstractParentCommand {
             return diff.hasAddedEntries() || diff.hasModifiedEntries() || diff.hasRemovedEntries();
         }
 
-        private FeaturePackLocation getFpl(InstallationProfile knownFeaturePack, String version) throws XMLStreamException, ProvisioningException {
-            GalleonProvisioningConfig config = GalleonUtils.loadProvisioningConfig(knownFeaturePack.getGalleonConfiguration());
+        private FeaturePackLocation getFpl(InstallationProfile knownFeaturePack, String version) throws MetadataException, ProvisioningException {
+            GalleonProvisioningConfig config = GalleonUtils.readProvisioningConfig(knownFeaturePack.getGalleonConfiguration());
             if (config.getFeaturePackDeps().isEmpty()) {
                 throw new ProvisioningException("At least one feature pack location must be specified in the provisioning configuration");
             }

--- a/prospero-common/src/main/java/org/wildfly/prospero/api/ProvisioningDefinition.java
+++ b/prospero-common/src/main/java/org/wildfly/prospero/api/ProvisioningDefinition.java
@@ -29,8 +29,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
-import javax.xml.stream.XMLStreamException;
-
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.eclipse.aether.repository.RemoteRepository;
@@ -174,23 +172,19 @@ public class ProvisioningDefinition {
             return builder.build();
 
         } else if (definition != null) {
-            try {
-                final GalleonProvisioningConfig config = GalleonUtils.loadProvisioningConfig(definition);
-                final GalleonProvisioningConfig.Builder builder = GalleonProvisioningConfig.builder(config);
-                if (StringUtils.isNotEmpty(stabilityLevel)) {
-                    builder.addOption(Constants.STABILITY_LEVEL, stabilityLevel);
-                }
-                if (StringUtils.isNotEmpty(configStabilityLevel)) {
-                    builder.addOption(Constants.CONFIG_STABILITY_LEVEL, configStabilityLevel);
-                }
-                if (StringUtils.isNotEmpty(packageStabilityLevel)) {
-                    builder.addOption(Constants.PACKAGE_STABILITY_LEVEL, packageStabilityLevel);
-                }
-
-                return builder.build();
-            } catch (XMLStreamException e) {
-                throw ProsperoLogger.ROOT_LOGGER.unableToParseConfigurationUri(definition, e);
+            final GalleonProvisioningConfig config = GalleonUtils.readProvisioningConfig(definition);
+            final GalleonProvisioningConfig.Builder builder = GalleonProvisioningConfig.builder(config);
+            if (StringUtils.isNotEmpty(stabilityLevel)) {
+                builder.addOption(Constants.STABILITY_LEVEL, stabilityLevel);
             }
+            if (StringUtils.isNotEmpty(configStabilityLevel)) {
+                builder.addOption(Constants.CONFIG_STABILITY_LEVEL, configStabilityLevel);
+            }
+            if (StringUtils.isNotEmpty(packageStabilityLevel)) {
+                builder.addOption(Constants.PACKAGE_STABILITY_LEVEL, packageStabilityLevel);
+            }
+
+            return builder.build();
         } else {
             throw ProsperoLogger.ROOT_LOGGER.fplNorGalleonConfigWereSet();
         }

--- a/prospero-common/src/test/java/org/wildfly/prospero/api/InstallationProfilesManagerTest.java
+++ b/prospero-common/src/test/java/org/wildfly/prospero/api/InstallationProfilesManagerTest.java
@@ -18,12 +18,8 @@
 package org.wildfly.prospero.api;
 
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.util.Map;
 
-import javax.xml.stream.XMLStreamException;
-
-import org.jboss.galleon.ProvisioningException;
 import org.junit.Test;
 import org.wildfly.channel.MavenCoordinate;
 import org.wildfly.channel.Repository;
@@ -36,7 +32,7 @@ import org.jboss.galleon.api.config.GalleonProvisioningConfig;
 public class InstallationProfilesManagerTest {
 
     @Test
-    public void testFpFromGalleonConfig() throws ProvisioningException, XMLStreamException, URISyntaxException {
+    public void testFpFromGalleonConfig() throws Exception {
         InstallationProfile installationProfile = InstallationProfilesManager.getByName("known-fpl");
 
         assertThat(installationProfile).isNotNull();
@@ -47,7 +43,7 @@ public class InstallationProfilesManagerTest {
             assertThat(channel.getRepositories()).containsOnly(new Repository("central", "https://repo1.maven.org/maven2/"));
         });
 
-        GalleonProvisioningConfig galleonConfig = GalleonUtils.loadProvisioningConfig(installationProfile.getGalleonConfiguration());
+        GalleonProvisioningConfig galleonConfig = GalleonUtils.readProvisioningConfig(installationProfile.getGalleonConfiguration());
         assertThat(galleonConfig.getOptions()).containsOnly(Map.entry("jboss-bulk-resolve-artifacts", "true"));
         assertThat(galleonConfig.getFeaturePackDeps().iterator().next()).satisfies(fp -> {
             assertThat(fp.getLocation().toString()).isEqualTo("org.wildfly.core:wildfly-core-galleon-pack:zip");

--- a/prospero-common/src/test/java/org/wildfly/prospero/api/ProvisioningDefinitionTest.java
+++ b/prospero-common/src/test/java/org/wildfly/prospero/api/ProvisioningDefinitionTest.java
@@ -19,7 +19,6 @@ package org.wildfly.prospero.api;
 
 import org.assertj.core.groups.Tuple;
 import org.jboss.galleon.Constants;
-import org.jboss.galleon.ProvisioningException;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -30,6 +29,7 @@ import org.wildfly.channel.Repository;
 import org.wildfly.channel.maven.VersionResolverFactory;
 import org.wildfly.prospero.ProsperoLogger;
 import org.wildfly.prospero.api.exceptions.ChannelDefinitionException;
+import org.wildfly.prospero.api.exceptions.MetadataException;
 import org.wildfly.prospero.api.exceptions.NoChannelException;
 import org.wildfly.prospero.galleon.GalleonUtils;
 import org.wildfly.prospero.test.MetadataTestUtils;
@@ -40,8 +40,6 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.List;
-
-import javax.xml.stream.XMLStreamException;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -337,9 +335,9 @@ public class ProvisioningDefinitionTest {
                         entry(Constants.CONFIG_STABILITY_LEVEL, Constants.STABILITY_COMMUNITY));
     }
 
-    private void verifyFeaturePackLocation(ProvisioningDefinition definition) throws ProvisioningException, XMLStreamException {
+    private void verifyFeaturePackLocation(ProvisioningDefinition definition) throws MetadataException {
         assertNull(definition.getFpl());
-        GalleonProvisioningConfig galleonConfig = GalleonUtils.loadProvisioningConfig(definition.getDefinition());
+        GalleonProvisioningConfig galleonConfig = GalleonUtils.readProvisioningConfig(definition.getDefinition());
         assertEquals(1, galleonConfig.getFeaturePackDeps().size());
         assertEquals("org.wildfly.core:wildfly-core-galleon-pack:zip",
                 galleonConfig.getFeaturePackDeps().iterator().next().getLocation().toString());


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/JBEAP-29656

Upstream: https://github.com/wildfly-extras/prospero/pull/861