### PR TITLE
Hide commit msg on Windows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,7 +30,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Set up JDK ${{ matrix.jdk }}
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.jdk }}
           distribution: 'adopt'
@@ -54,7 +54,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Set up JDK
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
           java-version: 17
           distribution: 'adopt'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,7 +19,7 @@ jobs:
           github-token: ${{secrets.GITHUB_TOKEN}}
           metadata-file-path: '.github/project.yml'
       - uses: actions/checkout@v2
-      - uses: actions/setup-java@v1
+      - uses: actions/setup-java@v4
         with:
           java-version: 17
       - name: maven release ${{steps.metadata.outputs.current-version}}

--- a/dist/common/src/main/resources/packages/org.jboss.prospero/content/bin/prospero.bat
+++ b/dist/common/src/main/resources/packages/org.jboss.prospero/content/bin/prospero.bat
@@ -202,7 +202,7 @@ rem Use a copy of jboss-modules to avoid locking issues when jboss-modules is up
     set "TMP_JBOSS_MODULES=%PROSPERO_HOME%\jboss-modules~%RANDOM%.tmp"
     rem loop while we find a non-existing filename
     if exist "%TMP_JBOSS_MODULES%" goto :COPY_JBOSS_MODULES
-    copy "%RUNJAR%" "%TMP_JBOSS_MODULES%"
+    copy "%RUNJAR%" "%TMP_JBOSS_MODULES%" 1>NULL
 
 rem If the -Djava.security.manager is found, enable the -secmgr and include a bogus security manager for JBoss Modules to replace
 echo(!JAVA_OPTS! | findstr /r /c:"-Djava.security.manager" > nul && (


### PR DESCRIPTION
When prospero is started on Windows, the modules jar is copied to a
temporary file so that we don't run into locking issues during update
