### PR TITLE
The container tests use fixed version of fedora (F40) as base image

### DIFF
--- a/integration-tests/src/test/java/org/wildfly/prospero/extended/MultiUserServerDirectoryTest.java
+++ b/integration-tests/src/test/java/org/wildfly/prospero/extended/MultiUserServerDirectoryTest.java
@@ -65,7 +65,7 @@ public class MultiUserServerDirectoryTest extends WfCoreTestBase {
         container = new GenericContainer(new ImageFromDockerfile()
                 .withDockerfileFromBuilder(builder ->
                         builder
-                                .from("quay.io/fedora/fedora")
+                                .from("quay.io/fedora/fedora:40")
                                 .run("dnf install -y java-17-openjdk-devel")
                                 .run("mkdir -p /home/serveradmin && adduser serveradmin && adduser siteadmin")
                 ))


### PR DESCRIPTION
Fixing the fedora image version to F40 to be able to continue using JDK17 package