### PR TITLE
Return correct code from a bat script execution

### DIFF
--- a/dist/common/src/main/resources/packages/org.jboss.prospero/content/bin/prospero.bat
+++ b/dist/common/src/main/resources/packages/org.jboss.prospero/content/bin/prospero.bat
@@ -255,6 +255,6 @@ if %errorlevel% equ 10 (
 if "x%NOPAUSE%" == "x" pause
 
 :END_NO_PAUSE
-set EXIT_LEVEL="%errorlevel%"
+set "EXIT_LEVEL=%errorlevel%"
 if exist "%TMP_JBOSS_MODULES%" del /Q "%TMP_JBOSS_MODULES%"
 exit /b %EXIT_LEVEL%


### PR DESCRIPTION
The `prospero.bat` returns 0 even if the operation was not successful. The `prospero.sh` works as expected.

```
prospero.bat install --dir wfly --profile=wildfly
...
Operation completed ...
echo %ERRORLEVEL%
0

prospero.bat history --dir wfly
[685d7562] ...

prospero.bat revert perform --dir wfly --revision=685d7562
(there is only one revision in the history, so the operation should fail)
PRSP000268: The revision 685d7562 is the state of the current installation. Reverting to the same state is not a valid operation.
echo %ERRORLEVEL%
0

prospero.bat install --dir wfly --profile=wildfly
(installation folder is not empty)
echo %ERRORLEVEL%
0
```
