### PR TITLE
Improvements for the CLI test utility class

### DIFF
--- a/integration-tests/src/test/java/org/wildfly/prospero/test/TestInstallation.java
+++ b/integration-tests/src/test/java/org/wildfly/prospero/test/TestInstallation.java
@@ -169,8 +169,8 @@ public class TestInstallation {
      * @throws ProvisioningException
      * @throws OperationException
      */
-    public List<FileConflict> update() throws Exception {
-        return update(new AcceptingConsole());
+    public List<FileConflict> update(String... args) throws Exception {
+        return update(new AcceptingConsole(), args);
     }
 
     /**
@@ -181,11 +181,14 @@ public class TestInstallation {
      * @throws ProvisioningException
      * @throws OperationException
      */
-    public List<FileConflict> update(Console console) throws Exception {
+    public List<FileConflict> update(Console console, String... args) throws Exception {
         final ArrayList<String> argList = new ArrayList<>();
-        Collections.addAll(argList, CliConstants.Commands.UPDATE, CliConstants.Commands.PERFORM,
+        Collections.addAll(argList,
+                CliConstants.Commands.UPDATE, CliConstants.Commands.PERFORM,
                 CliConstants.YES,
                 CliConstants.DIR, serverRoot.toAbsolutePath().toString());
+
+        Collections.addAll(argList, args);
 
         ExecutionUtils.prosperoExecution(argList.toArray(new String[]{}))
                 .withTimeLimit(10, TimeUnit.MINUTES)
@@ -232,6 +235,36 @@ public class TestInstallation {
             list.add(new Repository("test-" + i, repositories.get(i).toExternalForm()));
         }
         installationHistoryAction.rollback(originalState, MavenOptions.OFFLINE_NO_CACHE, list);
+    }
+
+    public void prepareUpdate(Path candidate, String... args) throws Exception {
+        final ArrayList<String> argList = new ArrayList<>();
+        Collections.addAll(argList,
+                CliConstants.Commands.UPDATE, CliConstants.Commands.PREPARE,
+                CliConstants.YES,
+                CliConstants.DIR, serverRoot.toAbsolutePath().toString(),
+                CliConstants.CANDIDATE_DIR, candidate.toAbsolutePath().toString());
+
+        Collections.addAll(argList, args);
+
+        ExecutionUtils.prosperoExecution(argList.toArray(new String[]{}))
+                .withTimeLimit(10, TimeUnit.MINUTES)
+                .execute()
+                .assertReturnCode(ReturnCodes.SUCCESS);
+    }
+
+    public void apply(Path candidatePath) throws Exception {
+        final ArrayList<String> argList = new ArrayList<>();
+        Collections.addAll(argList,
+                CliConstants.Commands.UPDATE, CliConstants.Commands.APPLY,
+                CliConstants.YES,
+                CliConstants.DIR, serverRoot.toAbsolutePath().toString(),
+                CliConstants.CANDIDATE_DIR, candidatePath.toAbsolutePath().toString());
+
+        ExecutionUtils.prosperoExecution(argList.toArray(new String[]{}))
+                .withTimeLimit(10, TimeUnit.MINUTES)
+                .execute()
+                .assertReturnCode(ReturnCodes.SUCCESS);
     }
 
     /**

--- a/integration-tests/src/test/java/org/wildfly/prospero/test/TestLocalRepository.java
+++ b/integration-tests/src/test/java/org/wildfly/prospero/test/TestLocalRepository.java
@@ -45,6 +45,7 @@ import org.wildfly.prospero.wfchannel.MavenSessionManager;
  * Utility class to generate a local Maven repository and deploy artifacts to it
  */
 public class TestLocalRepository {
+    public static final String GALLEON_PLUGINS_VERSION = BuildProperties.getProperty("version.org.wildfly.galleon-plugins");
 
     private final Path root;
     private final RepositorySystem system;
@@ -107,11 +108,14 @@ public class TestLocalRepository {
      * Resolves an artifact in upstream repositories, and if successful, deploys it locally.
      *
      * @param artifact
+     * @return the resolved artifact
      * @throws ArtifactResolutionException
      * @throws DeploymentException
      */
-    public void resolveAndDeploy(Artifact artifact) throws ArtifactResolutionException, DeploymentException {
-        deploy(resolveUpstream(artifact));
+    public Artifact resolveAndDeploy(Artifact artifact) throws ArtifactResolutionException, DeploymentException {
+        final Artifact resolved = resolveUpstream(artifact);
+        deploy(resolved);
+        return resolved;
     }
 
     /**
@@ -130,6 +134,17 @@ public class TestLocalRepository {
     public void deployMockUpdate(String groupId, String artifactId, String version, String newVersionSuffix) throws DeploymentException, ArtifactResolutionException {
         Artifact artifact = resolveUpstream(new DefaultArtifact(groupId, artifactId, null, "jar", version));
         deploy(artifact.setVersion(version + newVersionSuffix));
+    }
+
+    /**
+     * Deploys default Galleon jars needed by the provisioning
+     *
+     * @throws ArtifactResolutionException
+     * @throws DeploymentException
+     */
+    public void deployGalleonPlugins() throws ArtifactResolutionException, DeploymentException {
+        resolveAndDeploy(new DefaultArtifact("org.wildfly.galleon-plugins", "wildfly-galleon-plugins", "jar", GALLEON_PLUGINS_VERSION));
+        resolveAndDeploy(new DefaultArtifact("org.wildfly.galleon-plugins", "wildfly-config-gen", "jar", GALLEON_PLUGINS_VERSION));
     }
 
     /**


### PR DESCRIPTION
This PR switches TestInstallation to test using CLI rather than the API providing for a more complete integration tests set up.

- **Switch TestInstallation to use CLI**
- **TestLocalRepository improvements**
- **Add a way to pass additional arguments to TestInstallation**
- **Support prompts in the CLI tests**
