### PR TITLE
[#754] Allow to update the server to a specific version

### DIFF
--- a/integration-tests/src/test/java/org/wildfly/prospero/it/cli/CacheManifestTest.java
+++ b/integration-tests/src/test/java/org/wildfly/prospero/it/cli/CacheManifestTest.java
@@ -303,7 +303,7 @@ public class CacheManifestTest extends WfCoreTestBase {
     }
 
     private void performUpdate() throws OperationException, ProvisioningException {
-        try (UpdateAction updateAction = new UpdateAction(outputPath, mavenOptions, new CliConsole(), Collections.emptyList())) {
+        try (UpdateAction updateAction = new UpdateAction(outputPath, Collections.emptyList(), mavenOptions, new CliConsole())) {
             updateAction.performUpdate();
             FileUtils.deleteQuietly(mavenSessionManager.getProvisioningRepo().toFile());
         }

--- a/integration-tests/src/test/java/org/wildfly/prospero/it/cli/UpdateToVersionTest.java
+++ b/integration-tests/src/test/java/org/wildfly/prospero/it/cli/UpdateToVersionTest.java
@@ -10,11 +10,11 @@ import java.util.regex.Pattern;
 import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.artifact.DefaultArtifact;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.wildfly.channel.Channel;
 import org.wildfly.channel.ChannelManifest;
 import org.wildfly.channel.Stream;
+import org.wildfly.prospero.cli.commands.CliConstants;
 import org.wildfly.prospero.test.BuildProperties;
 import org.wildfly.prospero.test.TestInstallation;
 import org.wildfly.prospero.test.TestLocalRepository;
@@ -48,29 +48,27 @@ public class UpdateToVersionTest extends CliTestBase {
 
     @Test
     public void installSpecificVersionOfManifest() throws Exception {
-        testInstallation.install("org.test:pack-one:1.0.0", List.of(testChannel), "--version=test-channel::1.0.0");
+        testInstallation.install("org.test:pack-one:1.0.0", List.of(testChannel), CliConstants.VERSION, "test-channel::1.0.0");
 
         testInstallation.verifyModuleJar("commons-io", "commons-io", COMMONS_IO_VERSION);
         testInstallation.verifyInstallationMetadataPresent();
     }
 
     @Test
-    @Ignore
     public void updateServerToNonLatestVersion() throws Exception {
-//        testInstallation.install("org.test:pack-one:1.0.0", List.of(testChannel), "--version=test-channel:1.0.0");
-//
-//        testInstallation.update("--version=test-channel:1.0.1");
+        testInstallation.install("org.test:pack-one:1.0.0", List.of(testChannel), CliConstants.VERSION, "test-channel::1.0.0");
+
+        testInstallation.update(CliConstants.VERSION, "test-channel::1.0.1");
 
         testInstallation.verifyModuleJar("commons-io", "commons-io", bump(COMMONS_IO_VERSION));
         testInstallation.verifyInstallationMetadataPresent();
     }
 
     @Test
-    @Ignore
     public void downgradeServerToNonLatestVersion() throws Exception {
-//        testInstallation.install("org.test:pack-one:1.0.0", List.of(testChannel), "--version=test-channel:1.0.1");
-//
-//        testInstallation.update("--version=test-channel:1.0.0");
+        testInstallation.install("org.test:pack-one:1.0.0", List.of(testChannel), "--version=test-channel::1.0.1");
+
+        testInstallation.update("--version=test-channel::1.0.0");
 
         testInstallation.verifyModuleJar("commons-io", "commons-io", COMMONS_IO_VERSION);
         testInstallation.verifyInstallationMetadataPresent();
@@ -94,23 +92,23 @@ public class UpdateToVersionTest extends CliTestBase {
                         new Stream("org.test", "pack-one", "1.0.0")
                 )));
 
-//        testLocalRepository.deploy(
-//                new DefaultArtifact("org.test", "test-channel", "manifest", "yaml","1.0.1"),
-//                new ChannelManifest("test-manifest", null, null, List.of(
-//                        new Stream("org.wildfly.galleon-plugins", "wildfly-config-gen", GALLEON_PLUGINS_VERSION),
-//                        new Stream("org.wildfly.galleon-plugins", "wildfly-galleon-plugins", GALLEON_PLUGINS_VERSION),
-//                        new Stream("commons-io", "commons-io", bump(COMMONS_IO_VERSION)),
-//                        new Stream("org.test", "pack-one", "1.0.0")
-//                )));
+        testLocalRepository.deploy(
+                new DefaultArtifact("org.test", "test-channel", "manifest", "yaml","1.0.1"),
+                new ChannelManifest("test-manifest", null, null, List.of(
+                        new Stream("org.wildfly.galleon-plugins", "wildfly-config-gen", GALLEON_PLUGINS_VERSION),
+                        new Stream("org.wildfly.galleon-plugins", "wildfly-galleon-plugins", GALLEON_PLUGINS_VERSION),
+                        new Stream("commons-io", "commons-io", bump(COMMONS_IO_VERSION)),
+                        new Stream("org.test", "pack-one", "1.0.0")
+                )));
 
-//        testLocalRepository.deploy(
-//                new DefaultArtifact("org.test", "test-channel", "manifest", "yaml","1.0.2"),
-//                new ChannelManifest("test-manifest", null, null, List.of(
-//                        new Stream("org.wildfly.galleon-plugins", "wildfly-config-gen", GALLEON_PLUGINS_VERSION),
-//                        new Stream("org.wildfly.galleon-plugins", "wildfly-galleon-plugins", GALLEON_PLUGINS_VERSION),
-//                        new Stream("commons-io", "commons-io", bump(bump(COMMONS_IO_VERSION))),
-//                        new Stream("org.test", "pack-one", "1.0.0")
-//                )));
+        testLocalRepository.deploy(
+                new DefaultArtifact("org.test", "test-channel", "manifest", "yaml","1.0.2"),
+                new ChannelManifest("test-manifest", null, null, List.of(
+                        new Stream("org.wildfly.galleon-plugins", "wildfly-config-gen", GALLEON_PLUGINS_VERSION),
+                        new Stream("org.wildfly.galleon-plugins", "wildfly-galleon-plugins", GALLEON_PLUGINS_VERSION),
+                        new Stream("commons-io", "commons-io", bump(bump(COMMONS_IO_VERSION))),
+                        new Stream("org.test", "pack-one", "1.0.0")
+                )));
     }
 
     private String bump(String version) {

--- a/integration-tests/src/test/java/org/wildfly/prospero/it/cli/UpdateToVersionTest.java
+++ b/integration-tests/src/test/java/org/wildfly/prospero/it/cli/UpdateToVersionTest.java
@@ -1,0 +1,128 @@
+package org.wildfly.prospero.it.cli;
+
+import static org.wildfly.prospero.test.TestLocalRepository.GALLEON_PLUGINS_VERSION;
+
+import java.net.URL;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.eclipse.aether.artifact.Artifact;
+import org.eclipse.aether.artifact.DefaultArtifact;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.wildfly.channel.Channel;
+import org.wildfly.channel.ChannelManifest;
+import org.wildfly.channel.Stream;
+import org.wildfly.prospero.test.BuildProperties;
+import org.wildfly.prospero.test.TestInstallation;
+import org.wildfly.prospero.test.TestLocalRepository;
+
+public class UpdateToVersionTest extends CliTestBase {
+    protected static final String COMMONS_IO_VERSION = BuildProperties.getProperty("version.commons-io");
+
+    private TestLocalRepository testLocalRepository;
+    private TestInstallation testInstallation;
+    private Channel testChannel;
+
+    @Before
+    public void setUp() throws Exception {
+        testLocalRepository = new TestLocalRepository(temp.newFolder("local-repo").toPath(),
+                List.of(new URL("https://repo1.maven.org/maven2")));
+
+        prepareRequiredArtifacts(testLocalRepository);
+
+        testInstallation = new TestInstallation(temp.newFolder("server").toPath());
+
+        testLocalRepository.deploy(TestInstallation.fpBuilder("org.test:pack-one:1.0.0")
+                .addModule("commons-io", "commons-io", COMMONS_IO_VERSION)
+                .build());
+
+        testChannel = new Channel.Builder()
+                .setName("test-channel")
+                .addRepository("local-repo", testLocalRepository.getUri().toString())
+                .setManifestCoordinate("org.test", "test-channel")
+                .build();
+    }
+
+    @Test
+    public void installSpecificVersionOfManifest() throws Exception {
+        testInstallation.install("org.test:pack-one:1.0.0", List.of(testChannel), "--version=test-channel::1.0.0");
+
+        testInstallation.verifyModuleJar("commons-io", "commons-io", COMMONS_IO_VERSION);
+        testInstallation.verifyInstallationMetadataPresent();
+    }
+
+    @Test
+    @Ignore
+    public void updateServerToNonLatestVersion() throws Exception {
+//        testInstallation.install("org.test:pack-one:1.0.0", List.of(testChannel), "--version=test-channel:1.0.0");
+//
+//        testInstallation.update("--version=test-channel:1.0.1");
+
+        testInstallation.verifyModuleJar("commons-io", "commons-io", bump(COMMONS_IO_VERSION));
+        testInstallation.verifyInstallationMetadataPresent();
+    }
+
+    @Test
+    @Ignore
+    public void downgradeServerToNonLatestVersion() throws Exception {
+//        testInstallation.install("org.test:pack-one:1.0.0", List.of(testChannel), "--version=test-channel:1.0.1");
+//
+//        testInstallation.update("--version=test-channel:1.0.0");
+
+        testInstallation.verifyModuleJar("commons-io", "commons-io", COMMONS_IO_VERSION);
+        testInstallation.verifyInstallationMetadataPresent();
+    }
+
+    private void prepareRequiredArtifacts(TestLocalRepository localRepository) throws Exception {
+        localRepository.deployGalleonPlugins();
+
+        Artifact resolved = localRepository.resolveAndDeploy(new DefaultArtifact("commons-io", "commons-io", "jar", COMMONS_IO_VERSION));
+        resolved = resolved.setVersion(bump(resolved.getVersion()));
+        localRepository.deploy(resolved);
+        localRepository.deploy(resolved.setVersion(bump(resolved.getVersion())));
+
+        // deploy test manifests updating the commons-io in each
+        localRepository.deploy(
+                new DefaultArtifact("org.test", "test-channel", "manifest", "yaml","1.0.0"),
+                new ChannelManifest("test-manifest", null, null, List.of(
+                        new Stream("org.wildfly.galleon-plugins", "wildfly-config-gen", GALLEON_PLUGINS_VERSION),
+                        new Stream("org.wildfly.galleon-plugins", "wildfly-galleon-plugins", GALLEON_PLUGINS_VERSION),
+                        new Stream("commons-io", "commons-io", COMMONS_IO_VERSION),
+                        new Stream("org.test", "pack-one", "1.0.0")
+                )));
+
+//        testLocalRepository.deploy(
+//                new DefaultArtifact("org.test", "test-channel", "manifest", "yaml","1.0.1"),
+//                new ChannelManifest("test-manifest", null, null, List.of(
+//                        new Stream("org.wildfly.galleon-plugins", "wildfly-config-gen", GALLEON_PLUGINS_VERSION),
+//                        new Stream("org.wildfly.galleon-plugins", "wildfly-galleon-plugins", GALLEON_PLUGINS_VERSION),
+//                        new Stream("commons-io", "commons-io", bump(COMMONS_IO_VERSION)),
+//                        new Stream("org.test", "pack-one", "1.0.0")
+//                )));
+
+//        testLocalRepository.deploy(
+//                new DefaultArtifact("org.test", "test-channel", "manifest", "yaml","1.0.2"),
+//                new ChannelManifest("test-manifest", null, null, List.of(
+//                        new Stream("org.wildfly.galleon-plugins", "wildfly-config-gen", GALLEON_PLUGINS_VERSION),
+//                        new Stream("org.wildfly.galleon-plugins", "wildfly-galleon-plugins", GALLEON_PLUGINS_VERSION),
+//                        new Stream("commons-io", "commons-io", bump(bump(COMMONS_IO_VERSION))),
+//                        new Stream("org.test", "pack-one", "1.0.0")
+//                )));
+    }
+
+    private String bump(String version) {
+        final Pattern pattern = Pattern.compile(".*\\.CP-(\\d{2})");
+        final Matcher matcher = pattern.matcher(version);
+        if (matcher.matches()) {
+            final String suffixVersion = matcher.group(1);
+            final int ver = Integer.parseInt(suffixVersion) + 1;
+            final String replaced = version.replace(".CP-" + suffixVersion, String.format(".CP-%02d", ver));
+            return replaced;
+        } else {
+            return version + ".CP-01";
+        }
+    }
+}

--- a/integration-tests/src/test/java/org/wildfly/prospero/it/cli/UpdateToVersionTest.java
+++ b/integration-tests/src/test/java/org/wildfly/prospero/it/cli/UpdateToVersionTest.java
@@ -3,6 +3,7 @@ package org.wildfly.prospero.it.cli;
 import static org.wildfly.prospero.test.TestLocalRepository.GALLEON_PLUGINS_VERSION;
 
 import java.net.URL;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -73,6 +74,22 @@ public class UpdateToVersionTest extends CliTestBase {
         testInstallation.verifyModuleJar("commons-io", "commons-io", COMMONS_IO_VERSION);
         testInstallation.verifyInstallationMetadataPresent();
     }
+
+    @Test
+    public void updateWithPrepareApplyServerToNonLatestVersion() throws Exception {
+        testInstallation.install("org.test:pack-one:1.0.0", List.of(testChannel), CliConstants.VERSION, "test-channel::1.0.0");
+
+        final Path candidatePath = temp.newFolder("candidate").toPath();
+        testInstallation.prepareUpdate(candidatePath, CliConstants.VERSION, "test-channel::1.0.1");
+        testInstallation.apply(candidatePath);
+
+        testInstallation.verifyModuleJar("commons-io", "commons-io", bump(COMMONS_IO_VERSION));
+        testInstallation.verifyInstallationMetadataPresent();
+        testInstallation.verifyInstallationMetadataPresent();
+    }
+
+    // TODO: ask about downgrading
+    // TODO: non-interactive downgrade
 
     private void prepareRequiredArtifacts(TestLocalRepository localRepository) throws Exception {
         localRepository.deployGalleonPlugins();

--- a/integration-tests/src/test/java/org/wildfly/prospero/it/cli/UpdateToVersionTest.java
+++ b/integration-tests/src/test/java/org/wildfly/prospero/it/cli/UpdateToVersionTest.java
@@ -170,7 +170,13 @@ public class UpdateToVersionTest extends CliTestBase {
                 .contains("1.0.0", "1.0.1", "1.0.2");
     }
 
-    // TODO: update list --version shows changes in the selected version
+    @Test
+    public void listUpdatesToSpecificVersion() throws Exception {
+        testInstallation.install("org.test:pack-one:1.0.0", List.of(testChannel), "--version=test-channel::1.0.0", "-vv");
+
+        assertThat(testInstallation.listUpdates(CliConstants.VERSION, "test-channel::1.0.1"))
+                .containsPattern("commons-io:commons-io\\s+2.18.0\\s+==>\\s+2.18.0.CP-01");
+    }
 
     private void prepareRequiredArtifacts(TestLocalRepository localRepository) throws Exception {
         localRepository.deployGalleonPlugins();

--- a/integration-tests/src/test/java/org/wildfly/prospero/it/commonapi/InstallationHistoryActionTest.java
+++ b/integration-tests/src/test/java/org/wildfly/prospero/it/commonapi/InstallationHistoryActionTest.java
@@ -489,7 +489,7 @@ public class InstallationHistoryActionTest extends WfCoreTestBase {
     }
 
     private UpdateAction updateAction() throws ProvisioningException, OperationException {
-        return new UpdateAction(outputPath, mavenOptions, new AcceptingConsole(), Collections.emptyList());
+        return new UpdateAction(outputPath, Collections.emptyList(), mavenOptions, new AcceptingConsole());
     }
 
     private Optional<Artifact> readArtifactFromManifest(String groupId, String artifactId) throws IOException, MetadataException {

--- a/integration-tests/src/test/java/org/wildfly/prospero/it/commonapi/SimpleProvisionTest.java
+++ b/integration-tests/src/test/java/org/wildfly/prospero/it/commonapi/SimpleProvisionTest.java
@@ -194,7 +194,7 @@ public class SimpleProvisionTest extends WfCoreTestBase {
                 provisioningDefinition.resolveChannels(CHANNELS_RESOLVER_FACTORY));
 
         MetadataTestUtils.prepareChannel(outputPath.resolve(MetadataTestUtils.INSTALLER_CHANNELS_FILE_PATH), CHANNEL_COMPONENT_UPDATES, CHANNEL_BASE_CORE_19);
-        final Set<String> updates = new UpdateAction(outputPath, mavenOptions, new AcceptingConsole(), Collections.emptyList())
+        final Set<String> updates = new UpdateAction(outputPath, Collections.emptyList(), mavenOptions, new AcceptingConsole())
                 .findUpdates().getArtifactUpdates().stream()
                 .map(ArtifactChange::getArtifactName)
                 .collect(Collectors.toSet());
@@ -258,7 +258,7 @@ public class SimpleProvisionTest extends WfCoreTestBase {
     }
 
     private UpdateAction getUpdateAction() throws ProvisioningException, OperationException {
-        return new UpdateAction(outputPath, mavenOptions, new AcceptingConsole(), Collections.emptyList());
+        return new UpdateAction(outputPath, Collections.emptyList(), mavenOptions, new AcceptingConsole());
     }
 
     private Optional<Artifact> readArtifactFromManifest(String groupId, String artifactId) throws IOException, MetadataException {

--- a/integration-tests/src/test/java/org/wildfly/prospero/test/TestInstallation.java
+++ b/integration-tests/src/test/java/org/wildfly/prospero/test/TestInstallation.java
@@ -302,6 +302,25 @@ public class TestInstallation {
         final ExecutionUtils.ExecutionResult result = ExecutionUtils.prosperoExecution(argList.toArray(new String[]{}))
                 .withTimeLimit(10, TimeUnit.MINUTES)
                 .execute();
+
+        result.assertReturnCode(ReturnCodes.SUCCESS);
+        return result.getCommandOutput();
+    }
+
+
+    public String listChannelManifestUpdates(boolean allVersions) throws Exception {
+        final ArrayList<String> argList = new ArrayList<>();
+        Collections.addAll(argList,
+                CliConstants.Commands.UPDATE, CliConstants.Commands.LIST_CHANNELS,
+                CliConstants.DIR, serverRoot.toAbsolutePath().toString());
+
+        if (allVersions) {
+            argList.add(CliConstants.ALL);
+        }
+
+        final ExecutionUtils.ExecutionResult result = ExecutionUtils.prosperoExecution(argList.toArray(new String[]{}))
+                .withTimeLimit(10, TimeUnit.MINUTES)
+                .execute();
         result.assertReturnCode(ReturnCodes.SUCCESS);
 
         return result.getCommandOutput();

--- a/prospero-cli/src/main/java/org/wildfly/prospero/cli/ActionFactory.java
+++ b/prospero-cli/src/main/java/org/wildfly/prospero/cli/ActionFactory.java
@@ -44,8 +44,7 @@ public class ActionFactory {
         return new ProvisioningAction(targetPath, mavenOptions, console);
     }
 
-    // Option for BETA update support
-    // TODO: evaluate in GA - replace by repository:add / custom channels?
+    @Deprecated(forRemoval = true)
     public UpdateAction update(Path targetPath, MavenOptions mavenOptions, Console console, List<Repository> additionalRepositories)
             throws OperationException,
             ProvisioningException {

--- a/prospero-cli/src/main/java/org/wildfly/prospero/cli/ActionFactory.java
+++ b/prospero-cli/src/main/java/org/wildfly/prospero/cli/ActionFactory.java
@@ -21,6 +21,7 @@ import java.nio.file.Path;
 import java.util.List;
 
 import org.jboss.galleon.ProvisioningException;
+import org.wildfly.channel.Channel;
 import org.wildfly.channel.Repository;
 import org.wildfly.prospero.actions.ApplyCandidateAction;
 import org.wildfly.prospero.actions.FeaturesAddAction;
@@ -49,6 +50,11 @@ public class ActionFactory {
             throws OperationException,
             ProvisioningException {
         return new UpdateAction(targetPath, mavenOptions, console, additionalRepositories);
+    }
+
+    public UpdateAction update(Path targetPath, List<Channel> overrideChannels, MavenOptions mavenOptions, Console console)
+            throws OperationException, ProvisioningException {
+        return new UpdateAction(targetPath, overrideChannels, mavenOptions, console);
     }
 
     public ApplyCandidateAction applyUpdate(Path installationPath, Path updatePath)

--- a/prospero-cli/src/main/java/org/wildfly/prospero/cli/CliMessages.java
+++ b/prospero-cli/src/main/java/org/wildfly/prospero/cli/CliMessages.java
@@ -723,4 +723,26 @@ public interface CliMessages {
                 bundle.getString("prospero.updates.apply.candidate.cancel_conflicts"),
                 CliConstants.NO_CONFLICTS_ONLY));
     }
+
+    default ArgumentParsingException invalidVersionOverrideString(String versionString) {
+        return new ArgumentParsingException(format(
+                bundle.getString("prospero.general.error.version_overwrite.invalid_format"),
+                versionString));
+    }
+
+    default ArgumentParsingException channelNotFoundException(String channelName) {
+        return new ArgumentParsingException(format(
+                bundle.getString("prospero.general.error.version_overwrite.channel_not_found"),
+                channelName));
+    }
+
+    default ArgumentParsingException versionOverrideHasToApplyToAllChannels() {
+        return new ArgumentParsingException(format(
+                bundle.getString("prospero.general.error.version_overwrite.not_complete")));
+    }
+
+    default ArgumentParsingException duplicatedVersionOverride(String channelName) {
+        return new ArgumentParsingException(format(
+                bundle.getString("prospero.general.error.version_overwrite.duplicated"), channelName));
+    }
 }

--- a/prospero-cli/src/main/java/org/wildfly/prospero/cli/CliMessages.java
+++ b/prospero-cli/src/main/java/org/wildfly/prospero/cli/CliMessages.java
@@ -745,4 +745,8 @@ public interface CliMessages {
         return new ArgumentParsingException(format(
                 bundle.getString("prospero.general.error.version_overwrite.duplicated"), channelName));
     }
+
+    default String channelDowngradeWarningHeader() {
+        return bundle.getString("prospero.downgrade.warning.header");
+    }
 }

--- a/prospero-cli/src/main/java/org/wildfly/prospero/cli/CliMessages.java
+++ b/prospero-cli/src/main/java/org/wildfly/prospero/cli/CliMessages.java
@@ -753,4 +753,33 @@ public interface CliMessages {
     default String unexpectedVersionsHeader(String command) {
         return bundle.getString("prospero.downgrade.unexpected_versions").formatted(command);
     }
+
+    default String noChannelVersionUpdates() {
+        return bundle.getString("prospero.update.channel-list.no_updates");
+    }
+
+    default String channelVersionListUnsupportedChannelType() {
+        return bundle.getString("prospero.update.channel-list.unsupported_channel");
+    }
+
+    default String channelVersionUpdateListHeader() {
+        return bundle.getString("prospero.update.channel-list.updates_found.header");
+    }
+
+    default String channelVersionUpdateListChannelName() {
+        return bundle.getString("prospero.update.channel-list.updates.channel_name");
+    }
+
+    default String channelVersionUpdateListCurrentVersion() {
+        return bundle.getString("prospero.update.channel-list.updates.current_version");
+    }
+
+    default String channelVersionUpdateListAvailableVersions() {
+        return bundle.getString("prospero.update.channel-list.updates.available_versions");
+    }
+
+    default String channelVersionUpdateListUpdateCommandSuggestion(String cmd) {
+        return bundle.getString("prospero.update.channel-list.updates.update_command_suggestion")
+                .formatted(cmd);
+    }
 }

--- a/prospero-cli/src/main/java/org/wildfly/prospero/cli/CliMessages.java
+++ b/prospero-cli/src/main/java/org/wildfly/prospero/cli/CliMessages.java
@@ -749,4 +749,8 @@ public interface CliMessages {
     default String channelDowngradeWarningHeader() {
         return bundle.getString("prospero.downgrade.warning.header");
     }
+
+    default String unexpectedVersionsHeader(String command) {
+        return bundle.getString("prospero.downgrade.unexpected_versions").formatted(command);
+    }
 }

--- a/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/CliConstants.java
+++ b/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/CliConstants.java
@@ -60,6 +60,7 @@ public final class CliConstants {
     }
 
     public static final String ACCEPT_AGREEMENTS = "--accept-license-agreements";
+    public static final String ALL = "--all";
     public static final String ARG_PATH = "--path";
     public static final String CANDIDATE_DIR = "--candidate-dir";
     public static final String CHANNEL = "--channel";

--- a/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/CliConstants.java
+++ b/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/CliConstants.java
@@ -47,6 +47,7 @@ public final class CliConstants {
         public static final String HISTORY = "history";
         public static final String INSTALL = "install";
         public static final String LIST = "list";
+        public static final String LIST_CHANNELS = "list-channels";
         public static final String PERFORM = "perform";
         public static final String PREPARE = "prepare";
         public static final String PRINT_LICENSES = "print-licenses";

--- a/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/InstallCommand.java
+++ b/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/InstallCommand.java
@@ -107,6 +107,12 @@ public class InstallCommand extends AbstractInstallCommand {
     )
     StabilityLevels stabilityLevels = new StabilityLevels();
 
+    @CommandLine.Option(
+            names = CliConstants.VERSION,
+            split = ","
+    )
+    List<String> versions = new ArrayList<>();
+
     static class FeaturePackOrDefinition {
         @CommandLine.Option(
                 names = CliConstants.PROFILE,
@@ -241,7 +247,9 @@ public class InstallCommand extends AbstractInstallCommand {
                 }
             }
 
-            provisioningAction.provision(provisioningConfig, channels, shadowRepositories);
+            final List<Channel> overrideChannels = buildOverrideChannels(shadowRepositories, channels);
+
+            provisioningAction.provisionWithChannels(provisioningConfig, channels, overrideChannels);
 
             console.println("");
             console.println(CliMessages.MESSAGES.installComplete(directory));
@@ -251,6 +259,14 @@ public class InstallCommand extends AbstractInstallCommand {
 
             return ReturnCodes.SUCCESS;
         }
+    }
+
+    private List<Channel> buildOverrideChannels(List<Repository> shadowRepositories, List<Channel> channels) throws ArgumentParsingException {
+        return OverrideBuilder
+                .from(channels)
+                .withRepositories(shadowRepositories)
+                .withManifestVersions(versions)
+                .build();
     }
 
     private void checkFileExists(URL resourceUrl, String argValue) throws ArgumentParsingException {

--- a/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/OverrideBuilder.java
+++ b/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/OverrideBuilder.java
@@ -1,0 +1,122 @@
+package org.wildfly.prospero.cli.commands;
+
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.wildfly.channel.Channel;
+import org.wildfly.channel.ChannelManifestCoordinate;
+import org.wildfly.channel.Repository;
+import org.wildfly.prospero.ProsperoLogger;
+import org.wildfly.prospero.cli.ArgumentParsingException;
+import org.wildfly.prospero.cli.CliMessages;
+
+
+/**
+ * Creates a list of channels with appropriate overrides. Currently, supports overrides manifest versions and
+ * repository definitions. If no overrides are defined, returns an empty list.
+ */
+class OverrideBuilder {
+
+    private final List<Channel> channels;
+    private List<Repository> shadowRepositories = Collections.emptyList();
+    private List<String> versions = Collections.emptyList();
+
+    OverrideBuilder(List<Channel> channels) {
+        this.channels = channels;
+    }
+
+    static OverrideBuilder from(List<Channel> channels) {
+        return new OverrideBuilder(channels);
+    }
+
+    List<Channel> build() throws ArgumentParsingException {
+        final Map<String, VersionOverride> channelsMap = new HashMap<>();
+        if (!versions.isEmpty()) {
+            for (String version : versions) {
+                final VersionOverride override = new VersionOverride(version);
+
+                if (channelsMap.containsKey(override.channelName)) {
+                    throw CliMessages.MESSAGES.duplicatedVersionOverride(override.channelName);
+                }
+                channelsMap.put(override.channelName, override);
+            }
+            final Set<String> existingChannelNames = channels.stream().map(Channel::getName).collect(Collectors.toSet());
+            for (String overrideKey : channelsMap.keySet()) {
+                if (!existingChannelNames.contains(overrideKey)) {
+                    throw CliMessages.MESSAGES.channelNotFoundException(overrideKey);
+                }
+            }
+
+            if (existingChannelNames.size() != channelsMap.size() || !existingChannelNames.containsAll(channelsMap.keySet())) {
+                throw CliMessages.MESSAGES.versionOverrideHasToApplyToAllChannels();
+            }
+        } else if (shadowRepositories.isEmpty()) {
+            // we don't need to alter the channels, can return an empty collection
+            return Collections.emptyList();
+        }
+
+
+        final List<Channel> list = new ArrayList<>();
+        for (Channel c : channels) {
+            // map the channel to version override
+            final VersionOverride version = channelsMap.get(c.getName());
+            Channel channel = overrideChannel(c, version);
+            list.add(channel);
+        }
+        return list;
+    }
+
+    OverrideBuilder withRepositories(List<Repository> shadowRepositories) {
+        this.shadowRepositories = shadowRepositories;
+        return this;
+    }
+
+    public OverrideBuilder withManifestVersions(List<String> versions) {
+        this.versions = versions;
+        return this;
+    }
+
+    private static class VersionOverride {
+        final String channelName;
+        final String version;
+
+        public VersionOverride(String version) throws ArgumentParsingException {
+            final String[] parts = version.split("::");
+            if (parts.length != 2) {
+                throw CliMessages.MESSAGES.invalidVersionOverrideString(version);
+            }
+            this.channelName = parts[0];
+            this.version = parts[1];
+        }
+    }
+
+    private Channel overrideChannel(Channel c, VersionOverride version) {
+        final Channel.Builder builder = new Channel.Builder(c);
+        if (version != null) {
+            if (c.getName().equals(version.channelName)) {
+                final ChannelManifestCoordinate coord = c.getManifestCoordinate();
+                if (coord.getUrl() != null) {
+                    try {
+                        builder.setManifestUrl(URI.create(version.version).toURL());
+                    } catch (MalformedURLException e) {
+                        throw ProsperoLogger.ROOT_LOGGER.invalidUrl(version.version, e);
+                    }
+                } else {
+                    builder.setManifestCoordinate(coord.getGroupId(), coord.getArtifactId(), version.version);
+                }
+            }
+        }
+        if (!shadowRepositories.isEmpty()) {
+            builder.setRepositories(shadowRepositories);
+        }
+
+        return builder.build();
+    }
+}

--- a/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/UpdateCommand.java
+++ b/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/UpdateCommand.java
@@ -349,10 +349,13 @@ public class UpdateCommand extends AbstractParentCommand {
         }
     }
 
-    @CommandLine.Command(name = "list-channels", sortOptions = false)
-    public static class ChannelListCommand extends AbstractMavenCommand {
+    @CommandLine.Command(name = CliConstants.Commands.LIST_CHANNELS, sortOptions = false)
+    public static class ListChannelsCommand extends AbstractMavenCommand {
 
-        public ChannelListCommand(CliConsole console, ActionFactory actionFactory) {
+        @CommandLine.Option(names = "--all")
+        boolean all;
+
+        public ListChannelsCommand(CliConsole console, ActionFactory actionFactory) {
             super(console, actionFactory);
         }
         @Override
@@ -367,7 +370,7 @@ public class UpdateCommand extends AbstractParentCommand {
                         RepositoryDefinition.from(temporaryRepositories), temporaryFiles);
                 console.println(CliMessages.MESSAGES.checkUpdatesHeader(installationDir));
                 try (UpdateAction updateAction = actionFactory.update(installationDir, mavenOptions, console, repositories)) {
-                    final ChannelsUpdateResult result = updateAction.findChannelUpdates();
+                    final ChannelsUpdateResult result = updateAction.findChannelUpdates(all);
                     new ChannelVersionChangesPrinter(console).printAvailableChannelChanges(result, installationDir.toString());
                 }
 
@@ -576,7 +579,7 @@ public class UpdateCommand extends AbstractParentCommand {
                     new UpdateCommand.ApplyCommand(console, actionFactory),
                     new UpdateCommand.PerformCommand(console, actionFactory),
                     new UpdateCommand.ListCommand(console, actionFactory),
-                    new UpdateCommand.ChannelListCommand(console, actionFactory),
+                    new ListChannelsCommand(console, actionFactory),
                     new SubscribeCommand(console, actionFactory))
         );
     }

--- a/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/UpdateCommand.java
+++ b/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/UpdateCommand.java
@@ -352,7 +352,7 @@ public class UpdateCommand extends AbstractParentCommand {
     @CommandLine.Command(name = CliConstants.Commands.LIST_CHANNELS, sortOptions = false)
     public static class ListChannelsCommand extends AbstractMavenCommand {
 
-        @CommandLine.Option(names = "--all")
+        @CommandLine.Option(names = CliConstants.ALL)
         boolean all;
 
         public ListChannelsCommand(CliConsole console, ActionFactory actionFactory) {

--- a/prospero-cli/src/main/java/org/wildfly/prospero/cli/printers/ChannelVersionChangesPrinter.java
+++ b/prospero-cli/src/main/java/org/wildfly/prospero/cli/printers/ChannelVersionChangesPrinter.java
@@ -4,10 +4,12 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 
+import org.wildfly.prospero.DistributionInfo;
 import org.wildfly.prospero.api.ChannelVersion;
 import org.wildfly.prospero.api.ChannelVersionChange;
 import org.wildfly.prospero.api.Console;
 import org.wildfly.prospero.cli.CliMessages;
+import org.wildfly.prospero.cli.commands.CliConstants;
 import org.wildfly.prospero.updates.ChannelsUpdateResult;
 import picocli.CommandLine;
 
@@ -53,27 +55,27 @@ public class ChannelVersionChangesPrinter {
         console.println(CliMessages.MESSAGES.unexpectedVersionsHeader(buildCommandString(spec) + versionArg));
     }
 
-    public void printAvailableChannelChanges(ChannelsUpdateResult result, String dir) {
+    public void printAvailableChannelChanges(ChannelsUpdateResult result, String serverDir) {
         if (!result.getUnsupportedChannels().isEmpty()) {
-            console.println("Some of the channels the server is subscribed to do not support the versioned manifests. The server has to be subscribed only to Maven channels to use this feature.");
+            console.println(CliMessages.MESSAGES.channelVersionListUnsupportedChannelType());
             return;
         }
 
         if (!result.hasUpdates()) {
-            console.println("All the server channels are at the latest versions.");
+            console.println(CliMessages.MESSAGES.noChannelVersionUpdates());
             return;
         }
 
         final StringBuilder versionArg = new StringBuilder();
-        console.println("Found new versions of channel manifests available:");
+        console.println(CliMessages.MESSAGES.channelVersionUpdateListHeader());
         for (String channelName : result.getUpdatedChannels()) {
             final Set<ChannelVersion> updatedVersion = result.getUpdatedVersion(channelName);
             if (!updatedVersion.isEmpty()) {
                 versionArg.append(channelName).append("::").append(updatedVersion.iterator().next().getPhysicalVersion());
 
-                console.println(" - channel-name: %s".formatted(channelName));
-                console.println("   current-version: %s".formatted(result.getOriginalVersions(channelName)));
-                console.println("   available-versions:");
+                console.println(" - %s: %s".formatted(CliMessages.MESSAGES.channelVersionUpdateListChannelName(), channelName));
+                console.println("   %s: %s".formatted(CliMessages.MESSAGES.channelVersionUpdateListCurrentVersion(), result.getOriginalVersions(channelName)));
+                console.println("   %s:".formatted(CliMessages.MESSAGES.channelVersionUpdateListAvailableVersions()));
                 for (ChannelVersion channelVersion : updatedVersion) {
                     console.println("   - %s(%s)".formatted(channelVersion.getPhysicalVersion(), channelVersion.getLogicalVersion()));
                 }
@@ -83,8 +85,11 @@ public class ChannelVersionChangesPrinter {
         }
 
         console.println("");
-        console.println("To perform the update to selected version use update operation with --version parameter like:");
-        console.println("  prospero update perform --dir " + dir + " --version " + versionArg.toString());
+
+        final String updateCmd = "  %s %s %s %s %s %s %s".formatted(
+                DistributionInfo.DIST_NAME, CliConstants.Commands.UPDATE, CliConstants.Commands.PERFORM,
+                CliConstants.DIR, serverDir, CliConstants.VERSION, versionArg.toString());
+        console.println(CliMessages.MESSAGES.channelVersionUpdateListUpdateCommandSuggestion(updateCmd));
     }
 
     private String buildCommandString(CommandLine.Model.CommandSpec spec) {

--- a/prospero-cli/src/main/java/org/wildfly/prospero/cli/printers/ChannelVersionChangesPrinter.java
+++ b/prospero-cli/src/main/java/org/wildfly/prospero/cli/printers/ChannelVersionChangesPrinter.java
@@ -1,10 +1,12 @@
 package org.wildfly.prospero.cli.printers;
 
 import java.util.Collection;
+import java.util.List;
 
 import org.wildfly.prospero.api.ChannelVersionChange;
 import org.wildfly.prospero.api.Console;
 import org.wildfly.prospero.cli.CliMessages;
+import picocli.CommandLine;
 
 public class ChannelVersionChangesPrinter {
 
@@ -34,5 +36,27 @@ public class ChannelVersionChangesPrinter {
             sb.append(System.lineSeparator());
         }
         console.println(sb.toString());
+    }
+
+    public void printUnexpectedDowngradesError(Collection<ChannelVersionChange> downgrades, CommandLine.Model.CommandSpec spec) {
+        final StringBuilder versionArg = new StringBuilder();
+        for (ChannelVersionChange downgrade : downgrades) {
+            versionArg.append("--version=")
+                    .append(downgrade.channelName())
+                    .append("::")
+                    .append(downgrade.newVersion().getPhysicalVersion())
+                    .append(" ");
+        }
+        console.println(CliMessages.MESSAGES.unexpectedVersionsHeader(buildCommandString(spec) + versionArg));
+    }
+
+    private String buildCommandString(CommandLine.Model.CommandSpec spec) {
+        final List<String> args = spec.commandLine().getParseResult().originalArgs();
+        final StringBuilder sb = new StringBuilder();
+
+        sb.append(spec.root().name()).append(" ");
+        args.forEach(a->sb.append(a).append(" "));
+
+        return sb.toString().trim();
     }
 }

--- a/prospero-cli/src/main/java/org/wildfly/prospero/cli/printers/ChannelVersionChangesPrinter.java
+++ b/prospero-cli/src/main/java/org/wildfly/prospero/cli/printers/ChannelVersionChangesPrinter.java
@@ -1,0 +1,38 @@
+package org.wildfly.prospero.cli.printers;
+
+import java.util.Collection;
+
+import org.wildfly.prospero.api.ChannelVersionChange;
+import org.wildfly.prospero.api.Console;
+import org.wildfly.prospero.cli.CliMessages;
+
+public class ChannelVersionChangesPrinter {
+
+    private final Console console;
+    private static final String INDENT = "  ";
+    private static final String ITEM_ELEM = "* ";
+
+
+    public ChannelVersionChangesPrinter(Console console) {
+        this.console = console;
+    }
+
+    public void printDowngrades(Collection<ChannelVersionChange> downgrades) {
+        console.println(CliMessages.MESSAGES.channelDowngradeWarningHeader());
+        final StringBuilder sb = new StringBuilder();
+        for (ChannelVersionChange downgrade : downgrades) {
+            sb.append(INDENT).append(ITEM_ELEM).append(downgrade.channelName()).append(": ");
+            sb.append(downgrade.oldVersion().getPhysicalVersion());
+            if (downgrade.oldVersion().getLogicalVersion() != null) {
+                sb.append(" (").append(downgrade.oldVersion().getLogicalVersion()).append(")");
+            }
+
+            sb.append("  ->  ").append(downgrade.newVersion().getPhysicalVersion());
+            if (downgrade.newVersion().getLogicalVersion() != null) {
+                sb.append(" (").append(downgrade.oldVersion().getLogicalVersion()).append(")");
+            }
+            sb.append(System.lineSeparator());
+        }
+        console.println(sb.toString());
+    }
+}

--- a/prospero-cli/src/main/java/org/wildfly/prospero/cli/printers/ChannelVersionChangesPrinter.java
+++ b/prospero-cli/src/main/java/org/wildfly/prospero/cli/printers/ChannelVersionChangesPrinter.java
@@ -69,18 +69,19 @@ public class ChannelVersionChangesPrinter {
         final StringBuilder versionArg = new StringBuilder();
         console.println(CliMessages.MESSAGES.channelVersionUpdateListHeader());
         for (String channelName : result.getUpdatedChannels()) {
-            final Set<ChannelVersion> updatedVersion = result.getUpdatedVersion(channelName);
-            if (!updatedVersion.isEmpty()) {
-                versionArg.append(channelName).append("::").append(updatedVersion.iterator().next().getPhysicalVersion());
+            final ChannelsUpdateResult.ChannelResult channelResult = result.getUpdatedVersion(channelName);
+            if (channelResult.getStatus() == ChannelsUpdateResult.Status.UpdatesFound) {
+                final Set<ChannelVersion> availableVersions = channelResult.getAvailableVersions();
+                versionArg.append(channelName).append("::").append(availableVersions.iterator().next().getPhysicalVersion());
 
                 console.println(" - %s: %s".formatted(CliMessages.MESSAGES.channelVersionUpdateListChannelName(), channelName));
-                console.println("   %s: %s".formatted(CliMessages.MESSAGES.channelVersionUpdateListCurrentVersion(), result.getOriginalVersions(channelName)));
+                console.println("   %s: %s".formatted(CliMessages.MESSAGES.channelVersionUpdateListCurrentVersion(), channelResult.getCurrentVersion()));
                 console.println("   %s:".formatted(CliMessages.MESSAGES.channelVersionUpdateListAvailableVersions()));
-                for (ChannelVersion channelVersion : updatedVersion) {
+                for (ChannelVersion channelVersion : availableVersions) {
                     console.println("   - %s(%s)".formatted(channelVersion.getPhysicalVersion(), channelVersion.getLogicalVersion()));
                 }
             } else {
-                versionArg.append(channelName).append("::").append(result.getOriginalVersions(channelName));
+                versionArg.append(channelName).append("::").append(channelResult.getCurrentVersion());
             }
         }
 

--- a/prospero-cli/src/main/java/org/wildfly/prospero/cli/printers/ChannelVersionChangesPrinter.java
+++ b/prospero-cli/src/main/java/org/wildfly/prospero/cli/printers/ChannelVersionChangesPrinter.java
@@ -78,7 +78,8 @@ public class ChannelVersionChangesPrinter {
                 console.println("   %s: %s".formatted(CliMessages.MESSAGES.channelVersionUpdateListCurrentVersion(), channelResult.getCurrentVersion()));
                 console.println("   %s:".formatted(CliMessages.MESSAGES.channelVersionUpdateListAvailableVersions()));
                 for (ChannelVersion channelVersion : availableVersions) {
-                    console.println("   - %s(%s)".formatted(channelVersion.getPhysicalVersion(), channelVersion.getLogicalVersion()));
+                    final String logicalVersion =  channelVersion.getLogicalVersion() == null ? "" : " (%s)".formatted(channelVersion.getLogicalVersion());
+                    console.println("   - %s%s".formatted(channelVersion.getPhysicalVersion(), logicalVersion));
                 }
             } else {
                 versionArg.append(channelName).append("::").append(channelResult.getCurrentVersion());

--- a/prospero-cli/src/main/resources/UsageMessages.properties
+++ b/prospero-cli/src/main/resources/UsageMessages.properties
@@ -317,6 +317,8 @@ prospero.update.subscribe.conflict.prompt.cancel=Quit without generating metadat
 prospero.update.subscribe.meta.exists=Path `%s` contains a server installation provisioned by the %s already.
 
 prospero.downgrade.warning.header=The update will downgrade following channels:
+prospero.downgrade.unexpected_versions=The update would introduce one or more unexpected channel downgrades.%n\
+If you want to perform the downgrade please use the `--version` parameter like:%n  %s
 
 prospero.history.no_updates=No changes found
 prospero.history.feature_pack.title=Feature Pack

--- a/prospero-cli/src/main/resources/UsageMessages.properties
+++ b/prospero-cli/src/main/resources/UsageMessages.properties
@@ -114,6 +114,10 @@ ${prospero.dist.name}.feature-pack.add.layers = Feature Pack layers selected for
 ${prospero.dist.name}.feature-pack.add.target-config = Server configuration file that the Feature Pack changes will be applied to. \
   If not specified, defaults to the @|bold standalone.xml|@.
 
+${prospero.dist.name}.update.list-channels.usage.header  = Lists the available versions of the channel manifests.
+${prospero.dist.name}.update.list-channels.usage.description = Lists the available versions of the channel manifests for each of the Maven channels that the server is subscribed to. \
+  The manifest versions can be used to apply specific updates to the server.
+${prospero.dist.name}.update.list-channels.all = List all the possible manifest versions including the downgrades.
 
 #
 # Parameter Groups Headings

--- a/prospero-cli/src/main/resources/UsageMessages.properties
+++ b/prospero-cli/src/main/resources/UsageMessages.properties
@@ -316,6 +316,8 @@ prospero.update.subscribe.conflict.prompt.continue=Copy metadata files.
 prospero.update.subscribe.conflict.prompt.cancel=Quit without generating metadata files.
 prospero.update.subscribe.meta.exists=Path `%s` contains a server installation provisioned by the %s already.
 
+prospero.downgrade.warning.header=The update will downgrade following channels:
+
 prospero.history.no_updates=No changes found
 prospero.history.feature_pack.title=Feature Pack
 prospero.history.configuration_model.title=configuration model

--- a/prospero-cli/src/main/resources/UsageMessages.properties
+++ b/prospero-cli/src/main/resources/UsageMessages.properties
@@ -181,6 +181,9 @@ repoUrl = Repository URL
 target-repository-url = Target repository to promote artifacts to.
 self = Update the installation of ${prospero.dist.name} tool, rather than the server installation.
 version = Prints the version of ${prospero.dist.name} and exits.
+${prospero.dist.name}.install.version.0 = Select a version of the channel manifest to update the server to.
+${prospero.dist.name}.install.version.1 = Each channel version has to be specified as a @|italic channel_name::version|@. Multiple channels can be separated by a comma.
+${prospero.dist.name}.install.version.2 = @|bold Note:|@ this command can be used to downgrade the server to a lower manifest version.
 yes = Performs the operation without asking for a confirmation.
 path = Path of the file to export to or import from.
 candidate-dir = Path of the server candidate created using the @|bold --update prepare|@ command.
@@ -368,6 +371,10 @@ prospero.general.error.unknown_command=Unknown command `%s`
 prospero.general.error.unknown_command.suggestion_multiple=Did you mean one of: %s?%n
 prospero.general.error.unknown_command.suggestion_single=Did you mean: %s?%n
 prospero.general.error.unknown_command.or=or
+prospero.general.error.version_overwrite.channel_not_found=The channel [%s] specified in the version overwrite does not exist in the current configuration. Please check the configuration and version value and try again.
+prospero.general.error.version_overwrite.duplicated=Version overwrite defines channel [%s] multiple times. Please make sure each channel is specified only once.
+prospero.general.error.version_overwrite.invalid_format=Version overwrite [%s] in not formatted correctly. It should consist of <channel_name>::<version>.
+prospero.general.error.version_overwrite.not_complete=The version overwrite argument needs to specify versions for all the channels used by the server.
 
 
 prospero.channels.custom.validation.exists=Custom repository `%s` already exist.

--- a/prospero-cli/src/main/resources/UsageMessages.properties
+++ b/prospero-cli/src/main/resources/UsageMessages.properties
@@ -322,9 +322,9 @@ If you want to perform the downgrade please use the `--version` parameter like:%
 prospero.update.channel-list.no_updates=All the server channels are at the latest versions.
 prospero.update.channel-list.unsupported_channel=Some of the channels the server is subscribed to do not support the versioned manifests. The server has to be subscribed only to Maven channels to use this feature.
 prospero.update.channel-list.updates_found.header=Found new versions of channel manifests available:
-prospero.update.channel-list.updates.channel_name=channel name:
-prospero.update.channel-list.updates.current_version=current version:
-prospero.update.channel-list.updates.available_versions=available versions:
+prospero.update.channel-list.updates.channel_name=channel name
+prospero.update.channel-list.updates.current_version=current version
+prospero.update.channel-list.updates.available_versions=available versions
 prospero.update.channel-list.updates.update_command_suggestion:To perform the update to selected version use update operation with --version parameter like:\n  %s
 
 prospero.history.no_updates=No changes found

--- a/prospero-cli/src/main/resources/UsageMessages.properties
+++ b/prospero-cli/src/main/resources/UsageMessages.properties
@@ -319,6 +319,13 @@ prospero.update.subscribe.meta.exists=Path `%s` contains a server installation p
 prospero.downgrade.warning.header=The update will downgrade following channels:
 prospero.downgrade.unexpected_versions=The update would introduce one or more unexpected channel downgrades.%n\
 If you want to perform the downgrade please use the `--version` parameter like:%n  %s
+prospero.update.channel-list.no_updates=All the server channels are at the latest versions.
+prospero.update.channel-list.unsupported_channel=Some of the channels the server is subscribed to do not support the versioned manifests. The server has to be subscribed only to Maven channels to use this feature.
+prospero.update.channel-list.updates_found.header=Found new versions of channel manifests available:
+prospero.update.channel-list.updates.channel_name=channel name:
+prospero.update.channel-list.updates.current_version=current version:
+prospero.update.channel-list.updates.available_versions=available versions:
+prospero.update.channel-list.updates.update_command_suggestion:To perform the update to selected version use update operation with --version parameter like:\n  %s
 
 prospero.history.no_updates=No changes found
 prospero.history.feature_pack.title=Feature Pack

--- a/prospero-cli/src/test/java/org/wildfly/prospero/cli/commands/InstallCommandTest.java
+++ b/prospero-cli/src/test/java/org/wildfly/prospero/cli/commands/InstallCommandTest.java
@@ -41,6 +41,7 @@ import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.wildfly.channel.Channel;
 import org.wildfly.channel.ChannelManifestCoordinate;
+import org.wildfly.channel.ChannelMapper;
 import org.wildfly.channel.InvalidChannelMetadataException;
 import org.wildfly.channel.Repository;
 import org.wildfly.prospero.ProsperoLogger;
@@ -166,7 +167,7 @@ public class InstallCommandTest extends AbstractMavenCommandTest {
                 CliConstants.FPL, "org.wildfly:wildfly-ee-galleon-pack",
                 CliConstants.CHANNELS, channelsFile.getAbsolutePath());
         assertEquals(ReturnCodes.SUCCESS, exitCode);
-        Mockito.verify(provisionAction).provision(configCaptor.capture(), channelCaptor.capture(), any());
+        Mockito.verify(provisionAction).provisionWithChannels(configCaptor.capture(), channelCaptor.capture(), any());
         assertThat(configCaptor.getValue().getFeaturePackDeps())
                 .map(fp->fp.getLocation().getProducerName())
                 .containsExactly("org.wildfly:wildfly-ee-galleon-pack::zip");
@@ -179,7 +180,7 @@ public class InstallCommandTest extends AbstractMavenCommandTest {
         commandLine.getErr();
 
         assertEquals(ReturnCodes.SUCCESS, exitCode);
-        Mockito.verify(provisionAction).provision(configCaptor.capture(), channelCaptor.capture(), any());
+        Mockito.verify(provisionAction).provisionWithChannels(configCaptor.capture(), channelCaptor.capture(), any());
         assertThat(configCaptor.getValue().getFeaturePackDeps())
                 .map(fp->fp.getLocation().getProducerName())
                 .containsExactly("org.wildfly.core:wildfly-core-galleon-pack::zip");
@@ -195,7 +196,7 @@ public class InstallCommandTest extends AbstractMavenCommandTest {
                 CliConstants.CHANNELS, channelsFile.getAbsolutePath());
 
         assertEquals(ReturnCodes.SUCCESS, exitCode);
-        Mockito.verify(provisionAction).provision(configCaptor.capture(), channelCaptor.capture(), any());
+        Mockito.verify(provisionAction).provisionWithChannels(configCaptor.capture(), channelCaptor.capture(), any());
         assertThat(configCaptor.getValue().getFeaturePackDeps())
                 .map(fp->fp.getLocation().getProducerName())
                 .containsExactly("org.wildfly.core:wildfly-core-galleon-pack::zip");
@@ -223,7 +224,7 @@ public class InstallCommandTest extends AbstractMavenCommandTest {
                 CliConstants.DEFINITION, provisionDefinitionFile.getAbsolutePath());
 
         assertEquals(ReturnCodes.SUCCESS, exitCode);
-        Mockito.verify(provisionAction).provision(configCaptor.capture(), channelCaptor.capture(), any());
+        Mockito.verify(provisionAction).provisionWithChannels(configCaptor.capture(), channelCaptor.capture(), any());
         assertThat(configCaptor.getValue().getFeaturePackDeps())
                 .map(fp->fp.getLocation().getProducerName())
                 .containsExactly("org.wildfly.core:wildfly-core-galleon-pack::zip");
@@ -275,7 +276,7 @@ public class InstallCommandTest extends AbstractMavenCommandTest {
                 CliConstants.FPL, "g:a");
 
         assertEquals(ReturnCodes.SUCCESS, exitCode);
-        Mockito.verify(provisionAction).provision(configCaptor.capture(), channelCaptor.capture(), any());
+        Mockito.verify(provisionAction).provisionWithChannels(configCaptor.capture(), channelCaptor.capture(), any());
         assertThat(channelCaptor.getValue().get(0).getRepositories()
                 .stream().map(Repository::getUrl).collect(Collectors.toList()))
                 .containsOnly(testURL);
@@ -297,9 +298,10 @@ public class InstallCommandTest extends AbstractMavenCommandTest {
                 CliConstants.FPL, "g:a");
 
         assertEquals(ReturnCodes.SUCCESS, exitCode);
-        final ArgumentCaptor<List<Repository>> listArgumentCaptor = ArgumentCaptor.forClass(List.class);
-        Mockito.verify(provisionAction).provision(configCaptor.capture(), channelCaptor.capture(), listArgumentCaptor.capture());
+        final ArgumentCaptor<List<Channel>> listArgumentCaptor = ArgumentCaptor.forClass(List.class);
+        Mockito.verify(provisionAction).provisionWithChannels(configCaptor.capture(), channelCaptor.capture(), listArgumentCaptor.capture());
         assertThat(listArgumentCaptor.getValue())
+                .flatMap(Channel::getRepositories)
                 .map(Repository::getUrl)
                 .contains(testURL);
     }
@@ -315,7 +317,7 @@ public class InstallCommandTest extends AbstractMavenCommandTest {
                 CliConstants.CHANNELS, channelsFile.getAbsolutePath(),
                 CliConstants.STABILITY_LEVEL, "default");
         assertEquals(ReturnCodes.SUCCESS, exitCode);
-        Mockito.verify(provisionAction).provision(configCaptor.capture(), any(), any());
+        Mockito.verify(provisionAction).provisionWithChannels(configCaptor.capture(), any(), any());
         assertThat(configCaptor.getValue().getOptions())
                 .contains(entry(Constants.STABILITY_LEVEL, "default"));
     }
@@ -363,7 +365,7 @@ public class InstallCommandTest extends AbstractMavenCommandTest {
                 CliConstants.CONFIG_STABILITY_LEVEL, "community",
                 CliConstants.PACKAGE_STABILITY_LEVEL, "experimental");
         assertEquals(ReturnCodes.SUCCESS, exitCode);
-        Mockito.verify(provisionAction).provision(configCaptor.capture(), any(), any());
+        Mockito.verify(provisionAction).provisionWithChannels(configCaptor.capture(), any(), any());
         assertThat(configCaptor.getValue().getOptions())
                 .contains(entry(Constants.PACKAGE_STABILITY_LEVEL, "experimental"),
                         entry(Constants.CONFIG_STABILITY_LEVEL, "community"));
@@ -430,7 +432,7 @@ public class InstallCommandTest extends AbstractMavenCommandTest {
                 CliConstants.FPL, "feature:pack");
 
         assertEquals(ReturnCodes.SUCCESS, exitCode);
-        Mockito.verify(provisionAction).provision(configCaptor.capture(), channelCaptor.capture(), any());
+        Mockito.verify(provisionAction).provisionWithChannels(configCaptor.capture(), channelCaptor.capture(), any());
         assertThat(channelCaptor.getValue())
                 // TODO: implement equals toHash in wildfly-channels objects and remove the toString mapping
                 .map(Channel::toString)
@@ -444,6 +446,138 @@ public class InstallCommandTest extends AbstractMavenCommandTest {
                                 .addRepository("repo1", testURL)
                                 .build().toString()
                 );
+    }
+
+    @Test
+    public void versionStringWithChannelNameAndVersionIsAppliedToAChannel() throws Exception {
+        int exitCode = commandLine.execute(CliConstants.Commands.INSTALL, CliConstants.DIR, "test",
+                CliConstants.PROFILE, "known-fpl",
+                CliConstants.VERSION, "wildfly-core::1.1.1");
+
+        assertEquals(ReturnCodes.SUCCESS, exitCode);
+        Mockito.verify(provisionAction).provisionWithChannels(any(), any(), channelCaptor.capture());
+
+        assertThat(channelCaptor.getValue())
+                .map(c->c.getManifestCoordinate())
+                .contains(new ChannelManifestCoordinate("org.wildfly.channels", "wildfly-core", "1.1.1"));
+    }
+
+    @Test
+    public void versionStringsHaveToOverrideAllChannels() throws Exception {
+        final Path channelFile = generateTwoChannelConfiguration();
+        int exitCode = commandLine.execute(CliConstants.Commands.INSTALL, CliConstants.DIR, "test",
+                CliConstants.PROFILE, "known-fpl",
+                CliConstants.CHANNELS, channelFile.toUri().toString(),
+                CliConstants.VERSION, "test-one::1.1.1");
+
+        assertEquals(ReturnCodes.INVALID_ARGUMENTS, exitCode);
+        assertThat(getErrorOutput())
+                .contains(CliMessages.MESSAGES.versionOverrideHasToApplyToAllChannels().getMessage());
+    }
+
+    @Test
+    public void versionArgumentWithNoSeparatorIsInvalid() {
+        int exitCode = commandLine.execute(CliConstants.Commands.INSTALL, CliConstants.DIR, "test",
+                CliConstants.PROFILE, "known-fpl",
+                CliConstants.VERSION, "1.1.1");
+
+        assertEquals(ReturnCodes.INVALID_ARGUMENTS, exitCode);
+        assertThat(getErrorOutput())
+                .contains(CliMessages.MESSAGES.invalidVersionOverrideString("1.1.1").getMessage());
+    }
+
+    @Test
+    public void versionStringNeedsToConsistOfChannelNameAndVersion() throws Exception {
+        int exitCode = commandLine.execute(CliConstants.Commands.INSTALL, CliConstants.DIR, "test",
+                CliConstants.PROFILE, "known-fpl",
+                CliConstants.VERSION, "wildfly-core::1.1.1");
+
+        assertEquals(ReturnCodes.SUCCESS, exitCode);
+        Mockito.verify(provisionAction).provisionWithChannels(any(), any(), channelCaptor.capture());
+
+        assertThat(channelCaptor.getValue())
+                .map(c->c.getManifestCoordinate())
+                .contains(new ChannelManifestCoordinate("org.wildfly.channels", "wildfly-core", "1.1.1"));
+    }
+
+    @Test
+    public void errorWhenVersionOverrideDoesNotMatchAnyChannels() throws Exception {
+        int exitCode = commandLine.execute(CliConstants.Commands.INSTALL, CliConstants.DIR, "test",
+                CliConstants.PROFILE, "known-fpl",
+                CliConstants.VERSION, "idontexist::1.1.1");
+
+        assertEquals(ReturnCodes.INVALID_ARGUMENTS, exitCode);
+        assertThat(getErrorOutput())
+                .contains(CliMessages.MESSAGES.channelNotFoundException("idontexist").getMessage());
+    }
+
+    @Test
+    public void multipleVersionOverrideAreApplied() throws Exception {
+        final Path config = generateTwoChannelConfiguration();
+
+        int exitCode = commandLine.execute(CliConstants.Commands.INSTALL, CliConstants.DIR, "test",
+                CliConstants.PROFILE, "known-fpl",
+                CliConstants.CHANNELS, config.toUri().toString(),
+                CliConstants.VERSION, "test-one::1.1.1",
+                CliConstants.VERSION, "test-two::2.2.2");
+
+        assertEquals(ReturnCodes.SUCCESS, exitCode);
+
+        Mockito.verify(provisionAction).provisionWithChannels(any(), any(), channelCaptor.capture());
+        assertThat(channelCaptor.getValue())
+                .map(c->c.getManifestCoordinate())
+                .contains(
+                        new ChannelManifestCoordinate("org.test", "test-one", "1.1.1"),
+                        new ChannelManifestCoordinate("org.test", "test-two", "2.2.2")
+                );
+    }
+
+    @Test
+    public void duplicateVersionOverrideIsAnError() throws Exception {
+        final Path config = generateTwoChannelConfiguration();
+
+        int exitCode = commandLine.execute(CliConstants.Commands.INSTALL, CliConstants.DIR, "test",
+                CliConstants.PROFILE, "known-fpl",
+                CliConstants.CHANNELS, config.toUri().toString(),
+                CliConstants.VERSION, "test-one::1.1.1",
+                CliConstants.VERSION, "test-one::1.1.2",
+                CliConstants.VERSION, "test-two::2.2.2");
+
+        assertEquals(ReturnCodes.INVALID_ARGUMENTS, exitCode);
+        assertThat(getErrorOutput())
+                .contains(CliMessages.MESSAGES.duplicatedVersionOverride("test-one").getMessage());
+    }
+
+    @Test
+    public void urlChannelIsOverrideByVersionArgument() throws Exception {
+        final Path channelFile = generateUrlChannelConfiguration();
+        int exitCode = commandLine.execute(CliConstants.Commands.INSTALL, CliConstants.DIR, "test",
+                CliConstants.PROFILE, "known-fpl",
+                CliConstants.CHANNELS, channelFile.toUri().toString(),
+                CliConstants.VERSION, "test-one::http://new.channel.com");
+
+        assertEquals(ReturnCodes.SUCCESS, exitCode);
+        Mockito.verify(provisionAction).provisionWithChannels(any(), any(), channelCaptor.capture());
+
+        assertThat(channelCaptor.getValue())
+                .map(c->c.getManifestCoordinate())
+                .contains(new ChannelManifestCoordinate(new URL("http://new.channel.com")));
+    }
+
+    @Test
+    public void urlChannelIsOverrideByVersionArgumentWithLocalFileUrl() throws Exception {
+        final Path channelFile = generateUrlChannelConfiguration();
+        int exitCode = commandLine.execute(CliConstants.Commands.INSTALL, CliConstants.DIR, "test",
+                CliConstants.PROFILE, "known-fpl",
+                CliConstants.CHANNELS, channelFile.toUri().toString(),
+                CliConstants.VERSION, "test-one::file:foo.yaml");
+
+        assertEquals(ReturnCodes.SUCCESS, exitCode);
+        Mockito.verify(provisionAction).provisionWithChannels(any(), any(), channelCaptor.capture());
+
+        assertThat(channelCaptor.getValue())
+                .map(c->c.getManifestCoordinate())
+                .contains(new ChannelManifestCoordinate(new URL("file:foo.yaml")));
     }
 
     @Override
@@ -464,5 +598,42 @@ public class InstallCommandTest extends AbstractMavenCommandTest {
                 new ChannelManifestCoordinate(groupId, test1),
                 null, null);
         return channel;
+    }
+
+    private Path generateTwoChannelConfiguration() throws IOException {
+        // build a list of two channels
+        final List<Channel> channels = List.of(
+                new Channel.Builder()
+                        .setName("test-one")
+                        .setManifestCoordinate("org.test", "test-one")
+                        .addRepository("repo", "http://repo.test")
+                        .build(),
+                new Channel.Builder()
+                        .setName("test-two")
+                        .setManifestCoordinate("org.test", "test-two")
+                        .addRepository("repo", "http://repo.test")
+                        .build()
+        );
+
+        // serialize the channels to a file and pass it to the CLI
+        final Path channelFile = temporaryFolder.newFile("channels.yaml").toPath();
+        Files.writeString(channelFile, ChannelMapper.toYaml(channels));
+        return channelFile;
+    }
+
+    private Path generateUrlChannelConfiguration() throws IOException {
+        // build a list of two channels
+        final List<Channel> channels = List.of(
+                new Channel.Builder()
+                        .setName("test-one")
+                        .setManifestUrl(new URL("http://channel.com"))
+                        .addRepository("repo", "http://repo.test")
+                        .build()
+        );
+
+        // serialize the channels to a file and pass it to the CLI
+        final Path channelFile = temporaryFolder.newFile("channels.yaml").toPath();
+        Files.writeString(channelFile, ChannelMapper.toYaml(channels));
+        return channelFile;
     }
 }

--- a/prospero-cli/src/test/java/org/wildfly/prospero/cli/commands/UpdateListChannelCommandTest.java
+++ b/prospero-cli/src/test/java/org/wildfly/prospero/cli/commands/UpdateListChannelCommandTest.java
@@ -51,7 +51,7 @@ public class UpdateListChannelCommandTest extends AbstractMavenCommandTest {
     @Before
     public void setUp() throws Exception {
         super.setUp();
-        when(actionFactory.update(any(), any(), any(), anyList())).thenReturn(updateAction);
+        when(actionFactory.update(any(), anyList(), any(), any())).thenReturn(updateAction);
         installationDir = tempFolder.newFolder().toPath();
 
         MetadataTestUtils.createInstallationMetadata(installationDir);
@@ -116,7 +116,7 @@ public class UpdateListChannelCommandTest extends AbstractMavenCommandTest {
 
     @Override
     protected MavenOptions getCapturedMavenOptions() throws Exception {
-        Mockito.verify(actionFactory).update(any(), mavenOptions.capture(), any(), any());
+        Mockito.verify(actionFactory).update(any(), anyList(), mavenOptions.capture(), any());
         return mavenOptions.getValue();
     }
 

--- a/prospero-cli/src/test/java/org/wildfly/prospero/cli/commands/UpdateListChannelCommandTest.java
+++ b/prospero-cli/src/test/java/org/wildfly/prospero/cli/commands/UpdateListChannelCommandTest.java
@@ -80,8 +80,10 @@ public class UpdateListChannelCommandTest extends AbstractMavenCommandTest {
 
     @Test
     public void unsupportedChannelType() throws Exception {
-        final ChannelsUpdateResult updates = new ChannelsUpdateResult();
-        updates.addUnsupportedChannel("test-channel");
+        final ChannelsUpdateResult updates = new ChannelsUpdateResult(
+                new ChannelsUpdateResult.ChannelResult(
+                        "test-channel",
+                        null));
         when(updateAction.findChannelUpdates(anyBoolean())).thenReturn(updates);
 
         int exitCode = commandLine.execute(getDefaultArguments());
@@ -93,10 +95,12 @@ public class UpdateListChannelCommandTest extends AbstractMavenCommandTest {
 
     @Test
     public void mavenChannelUpdateList() throws Exception {
-        final ChannelsUpdateResult updates = new ChannelsUpdateResult();
-        updates.addChannelVersions("test-channel", "1.0.0", List.of(new ChannelVersion.Builder()
-                        .setPhysicalVersion("1.0.1")
-                .build()));
+        final ChannelsUpdateResult updates = new ChannelsUpdateResult(
+                new ChannelsUpdateResult.ChannelResult(
+                        "test-channel",
+                        "1.0.0",
+                        List.of(new ChannelVersion.Builder().setPhysicalVersion("1.0.1").build()))
+        );
         when(updateAction.findChannelUpdates(anyBoolean())).thenReturn(updates);
 
         int exitCode = commandLine.execute(getDefaultArguments());
@@ -104,8 +108,8 @@ public class UpdateListChannelCommandTest extends AbstractMavenCommandTest {
         Assert.assertEquals(ReturnCodes.SUCCESS, exitCode);
         assertThat(getStandardOutput())
                 .contains(CliMessages.MESSAGES.channelVersionUpdateListHeader())
-                .contains(CliMessages.MESSAGES.channelVersionUpdateListChannelName() + " test-channel")
-                .contains(CliMessages.MESSAGES.channelVersionUpdateListCurrentVersion() + " 1.0.0")
+                .contains(CliMessages.MESSAGES.channelVersionUpdateListChannelName() + ": test-channel")
+                .contains(CliMessages.MESSAGES.channelVersionUpdateListCurrentVersion() + ": 1.0.0")
                 .contains(CliMessages.MESSAGES.channelVersionUpdateListAvailableVersions())
                 .contains("- 1.0.1");
     }

--- a/prospero-cli/src/test/java/org/wildfly/prospero/cli/commands/UpdateListChannelCommandTest.java
+++ b/prospero-cli/src/test/java/org/wildfly/prospero/cli/commands/UpdateListChannelCommandTest.java
@@ -1,0 +1,133 @@
+package org.wildfly.prospero.cli.commands;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.when;
+
+import java.nio.file.Path;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.wildfly.prospero.actions.UpdateAction;
+import org.wildfly.prospero.api.ChannelVersion;
+import org.wildfly.prospero.api.MavenOptions;
+import org.wildfly.prospero.cli.ActionFactory;
+import org.wildfly.prospero.cli.CliMessages;
+import org.wildfly.prospero.cli.ReturnCodes;
+import org.wildfly.prospero.test.MetadataTestUtils;
+import org.wildfly.prospero.updates.ChannelsUpdateResult;
+
+@RunWith(MockitoJUnitRunner.class)
+public class UpdateListChannelCommandTest extends AbstractMavenCommandTest {
+
+    public static final String A_PROSPERO_FP = UpdateCommand.PROSPERO_FP_GA + ":1.0.0";
+
+    @Mock
+    private UpdateAction updateAction;
+
+    @Mock
+    private ActionFactory actionFactory;
+
+    @Captor
+    private ArgumentCaptor<MavenOptions> mavenOptions;
+
+    @Rule
+    public TemporaryFolder tempFolder = new TemporaryFolder();
+
+    private Path installationDir;
+
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        when(actionFactory.update(any(), any(), any(), anyList())).thenReturn(updateAction);
+        installationDir = tempFolder.newFolder().toPath();
+
+        MetadataTestUtils.createInstallationMetadata(installationDir);
+        MetadataTestUtils.createGalleonProvisionedState(installationDir, A_PROSPERO_FP);
+    }
+
+    @Test
+    public void currentDirNotValidInstallation() {
+        int exitCode = commandLine.execute(CliConstants.Commands.UPDATE, CliConstants.Commands.LIST_CHANNELS);
+
+        Assert.assertEquals(ReturnCodes.INVALID_ARGUMENTS, exitCode);
+        assertThat(getErrorOutput())
+                .contains(CliMessages.MESSAGES.invalidInstallationDir(UpdateCommand.currentDir().toAbsolutePath()).getMessage());
+    }
+
+    @Test
+    public void noChannelChangesFound() throws Exception {
+        doLocalMock();
+
+        int exitCode = commandLine.execute(getDefaultArguments());
+
+        Assert.assertEquals(ReturnCodes.SUCCESS, exitCode);
+        assertThat(getStandardOutput())
+                .contains(CliMessages.MESSAGES.noChannelVersionUpdates());
+    }
+
+    @Test
+    public void unsupportedChannelType() throws Exception {
+        final ChannelsUpdateResult updates = new ChannelsUpdateResult();
+        updates.addUnsupportedChannel("test-channel");
+        when(updateAction.findChannelUpdates(anyBoolean())).thenReturn(updates);
+
+        int exitCode = commandLine.execute(getDefaultArguments());
+
+        Assert.assertEquals(ReturnCodes.SUCCESS, exitCode);
+        assertThat(getStandardOutput())
+                .contains(CliMessages.MESSAGES.channelVersionListUnsupportedChannelType());
+    }
+
+    @Test
+    public void mavenChannelUpdateList() throws Exception {
+        final ChannelsUpdateResult updates = new ChannelsUpdateResult();
+        updates.addChannelVersions("test-channel", "1.0.0", List.of(new ChannelVersion.Builder()
+                        .setPhysicalVersion("1.0.1")
+                .build()));
+        when(updateAction.findChannelUpdates(anyBoolean())).thenReturn(updates);
+
+        int exitCode = commandLine.execute(getDefaultArguments());
+
+        Assert.assertEquals(ReturnCodes.SUCCESS, exitCode);
+        assertThat(getStandardOutput())
+                .contains(CliMessages.MESSAGES.channelVersionUpdateListHeader())
+                .contains(CliMessages.MESSAGES.channelVersionUpdateListChannelName() + " test-channel")
+                .contains(CliMessages.MESSAGES.channelVersionUpdateListCurrentVersion() + " 1.0.0")
+                .contains(CliMessages.MESSAGES.channelVersionUpdateListAvailableVersions())
+                .contains("- 1.0.1");
+    }
+
+    @Override
+    protected MavenOptions getCapturedMavenOptions() throws Exception {
+        Mockito.verify(actionFactory).update(any(), mavenOptions.capture(), any(), any());
+        return mavenOptions.getValue();
+    }
+
+    @Override
+    protected String[] getDefaultArguments() {
+        return new String[] {CliConstants.Commands.UPDATE, CliConstants.Commands.LIST_CHANNELS, CliConstants.DIR, installationDir.toString()};
+    }
+
+    @Override
+    protected ActionFactory createActionFactory() {
+        return actionFactory;
+    }
+
+    @Override
+    protected void doLocalMock() throws Exception {
+        when(updateAction.findChannelUpdates(anyBoolean())).thenReturn(new ChannelsUpdateResult());
+    }
+}

--- a/prospero-cli/src/test/resources/prospero-installation-profiles.yaml
+++ b/prospero-cli/src/test/resources/prospero-installation-profiles.yaml
@@ -3,6 +3,7 @@
   galleonConfiguration: "classpath:galleon-provisioning.xml"
   channels:
   - schemaVersion: "2.0.0"
+    name: "wildfly-core"
     repositories:
       - id: "central"
         url: "https://repo1.maven.org/maven2/"

--- a/prospero-common/src/main/java/org/wildfly/prospero/ProsperoLogger.java
+++ b/prospero-common/src/main/java/org/wildfly/prospero/ProsperoLogger.java
@@ -403,4 +403,7 @@ public interface ProsperoLogger extends BasicLogger {
     @Message(id = 275, value = "The candidate at [%s] was not prepared for %s operation.")
     InvalidUpdateCandidateException wrongCandidateOperation(Path candidateServer, ApplyCandidateAction.Type operationType);
 
+    @Message(id = 276, value = "Unable to resolve version information for channel %s with coordinates %s:%s in repositories %s")
+    MetadataException unableToResolveChannelVersionInformation(String channelName, String groupId, String artifactId, String repos, @Cause Exception e);
+
 }

--- a/prospero-common/src/main/java/org/wildfly/prospero/VersionOverride.java
+++ b/prospero-common/src/main/java/org/wildfly/prospero/VersionOverride.java
@@ -1,0 +1,4 @@
+package org.wildfly.prospero;
+
+public record VersionOverride(String channelName, String version) {
+}

--- a/prospero-common/src/main/java/org/wildfly/prospero/actions/ProvisioningAction.java
+++ b/prospero-common/src/main/java/org/wildfly/prospero/actions/ProvisioningAction.java
@@ -110,6 +110,14 @@ public class ProvisioningAction {
      */
     public void provision(GalleonProvisioningConfig provisioningConfig, List<Channel> channels, List<Repository> overwriteRepositories)
             throws ProvisioningException, OperationException, MalformedURLException {
+
+        provisionWithChannels(provisioningConfig, channels, TemporaryRepositoriesHandler.overrideRepositories(channels, overwriteRepositories));
+    }
+
+    public void provisionWithChannels(GalleonProvisioningConfig provisioningConfig,
+                                      List<Channel> channels,
+                                      List<Channel> overrideChannels)
+            throws ProvisioningException, OperationException {
         ProsperoLogger.ROOT_LOGGER.startingProvision(installDir);
         channels = enforceChannelNames(channels);
 
@@ -119,7 +127,9 @@ public class ProvisioningAction {
         }
         final List<Channel> recordedChannels = new ArrayList<>(channels);
 
-        channels = TemporaryRepositoriesHandler.overrideRepositories(channels, overwriteRepositories);
+        if (!overrideChannels.isEmpty()) {
+            channels = overrideChannels;
+        }
 
         try (GalleonEnvironment galleonEnv = GalleonEnvironment
                 .builder(installDir, channels, mavenSessionManager, false)

--- a/prospero-common/src/main/java/org/wildfly/prospero/actions/UpdateAction.java
+++ b/prospero-common/src/main/java/org/wildfly/prospero/actions/UpdateAction.java
@@ -64,6 +64,7 @@ public class UpdateAction implements AutoCloseable {
     private final MavenOptions mavenOptions;
     private volatile ChannelUpdateFinder finder;
 
+    @Deprecated(forRemoval = true)
     public UpdateAction(Path installDir, MavenOptions mavenOptions, Console console, List<Repository> overrideRepositories)
             throws OperationException, ProvisioningException {
         this(installDir, addTemporaryRepositories(installDir, overrideRepositories), mavenOptions, console);

--- a/prospero-common/src/main/java/org/wildfly/prospero/actions/UpdateAction.java
+++ b/prospero-common/src/main/java/org/wildfly/prospero/actions/UpdateAction.java
@@ -156,7 +156,7 @@ public class UpdateAction implements AutoCloseable {
         try (GalleonEnvironment galleonEnv = getGalleonEnv(installDir);
              UpdateFinder updateFinder = new UpdateFinder(galleonEnv.getChannelSession())) {
 
-            final UpdateSet updates = updateFinder.findUpdates(metadata.getArtifacts());
+            final UpdateSet updates = updateFinder.findUpdates(metadata.getArtifacts(), metadata.getChannelVersions());
             ProsperoLogger.ROOT_LOGGER.updatesFound(updates.getArtifactUpdates().size());
             return updates;
         }

--- a/prospero-common/src/main/java/org/wildfly/prospero/api/ChannelVersion.java
+++ b/prospero-common/src/main/java/org/wildfly/prospero/api/ChannelVersion.java
@@ -1,0 +1,102 @@
+package org.wildfly.prospero.api;
+
+import java.util.Objects;
+
+public class ChannelVersion {
+
+    public enum Type {MAVEN, URL, OPEN};
+    private final String channelName;
+    private final Type type;
+    private final String location;
+    private final String physicalVersion;
+    private final String logicalVersion;
+
+    private ChannelVersion(Builder builder) {
+        this.channelName = builder.channelName;
+        this.type =builder.type;
+        this.location = builder.location;
+        this.physicalVersion = builder.physicalVersion;
+        this.logicalVersion = builder.logicalVersion;
+    }
+
+    public String getChannelName() {
+        return channelName;
+    }
+
+    public Type getType() {
+        return type;
+    }
+
+    public String getLocation() {
+        return location;
+    }
+
+    public String getPhysicalVersion() {
+        return physicalVersion;
+    }
+
+    public String getLogicalVersion() {
+        return logicalVersion;
+    }
+
+    @Override
+    public String toString() {
+        return "ChannelVersion{" +
+                "channelName='" + channelName + '\'' +
+                ", type=" + type +
+                ", location='" + location + '\'' +
+                ", physicalVersion='" + physicalVersion + '\'' +
+                ", logicalVersion='" + logicalVersion + '\'' +
+                '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ChannelVersion that = (ChannelVersion) o;
+        return Objects.equals(channelName, that.channelName) && type == that.type && Objects.equals(location, that.location) && Objects.equals(physicalVersion, that.physicalVersion) && Objects.equals(logicalVersion, that.logicalVersion);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(channelName, type, location, physicalVersion, logicalVersion);
+    }
+
+    public static class Builder {
+        private String channelName;
+        private Type type;
+        private String location;
+        private String physicalVersion;
+        private String logicalVersion;
+
+        public ChannelVersion build() {
+            return new ChannelVersion(this);
+        }
+
+        public Builder setChannelName(String channelName) {
+            this.channelName = channelName;
+            return this;
+        }
+
+        public Builder setType(Type type) {
+            this.type = type;
+            return this;
+        }
+
+        public Builder setLocation(String location) {
+            this.location = location;
+            return this;
+        }
+
+        public Builder setPhysicalVersion(String physicalVersion) {
+            this.physicalVersion = physicalVersion;
+            return this;
+        }
+
+        public Builder setLogicalVersion(String logicalVersion) {
+            this.logicalVersion = logicalVersion;
+            return this;
+        }
+    }
+}

--- a/prospero-common/src/main/java/org/wildfly/prospero/api/ChannelVersion.java
+++ b/prospero-common/src/main/java/org/wildfly/prospero/api/ChannelVersion.java
@@ -2,7 +2,9 @@ package org.wildfly.prospero.api;
 
 import java.util.Objects;
 
-public class ChannelVersion {
+import org.wildfly.channel.version.VersionMatcher;
+
+public class ChannelVersion implements Comparable<ChannelVersion> {
 
     public enum Type {MAVEN, URL, OPEN};
     private final String channelName;
@@ -61,6 +63,11 @@ public class ChannelVersion {
     @Override
     public int hashCode() {
         return Objects.hash(channelName, type, location, physicalVersion, logicalVersion);
+    }
+
+    @Override
+    public int compareTo(ChannelVersion o) {
+        return VersionMatcher.COMPARATOR.compare(this.physicalVersion, o.physicalVersion);
     }
 
     public static class Builder {

--- a/prospero-common/src/main/java/org/wildfly/prospero/api/ChannelVersionChange.java
+++ b/prospero-common/src/main/java/org/wildfly/prospero/api/ChannelVersionChange.java
@@ -1,0 +1,30 @@
+package org.wildfly.prospero.api;
+
+import org.wildfly.channel.version.VersionMatcher;
+
+public record ChannelVersionChange(String channelName, ChannelVersion oldVersion, ChannelVersion newVersion) {
+
+    /**
+     * Checks if the channel change represents a downgrade - i.e. attempt to install a lower version manifest.
+     *
+     * NOTE: the "downgrade" concept only makes sense for Maven backed channels. In all other channels this method always return "false"
+     * @return
+     */
+    public boolean isDowngrade() {
+        if (oldVersion != null && oldVersion.getPhysicalVersion() != null && oldVersion.getType() == ChannelVersion.Type.MAVEN &&
+                newVersion != null && newVersion.getPhysicalVersion() != null && newVersion.getType() == ChannelVersion.Type.MAVEN) {
+            return VersionMatcher.COMPARATOR.compare(oldVersion().getPhysicalVersion(), newVersion().getPhysicalVersion()) > 0;
+        } else {
+            return false;
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "ChannelVersionChange{" +
+                "channelName='" + channelName + '\'' +
+                ", oldVersion=" + oldVersion +
+                ", newVersion=" + newVersion +
+                '}';
+    }
+}

--- a/prospero-common/src/main/java/org/wildfly/prospero/api/ChannelVersionReader.java
+++ b/prospero-common/src/main/java/org/wildfly/prospero/api/ChannelVersionReader.java
@@ -1,0 +1,81 @@
+package org.wildfly.prospero.api;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.stream.Collectors;
+
+import org.wildfly.channel.Channel;
+import org.wildfly.channel.Repository;
+import org.wildfly.prospero.metadata.ManifestVersionRecord;
+
+/**
+ * Combines the information about currently installed versions of manifests per channel into {@link ChannelVersionReader}.
+ *
+ * The information is spread between installation-channels.yaml and manifest_version.yaml.
+ * The name of the channel with the location of the manifest is available in the installation-channels.yaml
+ * The versions of each manifest are in manifest_version.yaml
+ * The common element is the location of the manifest
+ */
+
+class ChannelVersionReader {
+
+    private final List<Channel> channels;
+    private final ManifestVersionRecord currentVersions;
+
+    ChannelVersionReader(List<Channel> channels, ManifestVersionRecord currentVersions) {
+        this.channels = channels;
+        this.currentVersions = currentVersions;
+    }
+
+    public List<ChannelVersion> getChannelVersions() {
+        final HashMap<String, ManifestVersionRecord.MavenManifest> recordedMaven = new HashMap<>();
+        final HashMap<String, ManifestVersionRecord.UrlManifest> recordedUrl = new HashMap<>();
+        final List<ChannelVersion> res = new ArrayList<>();
+        for (ManifestVersionRecord.MavenManifest mavenManifest : currentVersions.getMavenManifests()) {
+            final String key = mavenManifest.getGroupId() + ":" + mavenManifest.getArtifactId();
+            recordedMaven.put(key, mavenManifest);
+        }
+        for (ManifestVersionRecord.UrlManifest urlManifest : currentVersions.getUrlManifests()) {
+            final String key = urlManifest.getUrl();
+            recordedUrl.put(key, urlManifest);
+        }
+
+        for (Channel channel : channels) {
+            final String key;
+            final ChannelVersion.Builder builder = new ChannelVersion.Builder();
+            // TODO: this should be common with code in UpdateFinder
+            if (channel.getManifestCoordinate() == null) {
+                final String repos = channel.getRepositories().stream().map(Repository::getId).collect(Collectors.joining(","));
+                key = channel.getNoStreamStrategy().toString().toLowerCase(Locale.ROOT) + "@[" + repos + "]";
+                builder.setType(ChannelVersion.Type.OPEN);
+            } else if (channel.getManifestCoordinate().getUrl() != null) {
+                key = channel.getManifestCoordinate().getUrl().toExternalForm();
+                builder.setType(ChannelVersion.Type.URL);
+            } else {
+                key = channel.getManifestCoordinate().getGroupId() + ":" + channel.getManifestCoordinate().getArtifactId();
+                builder.setType(ChannelVersion.Type.MAVEN);
+            }
+            builder.setLocation(key)
+                    .setChannelName(channel.getName());
+
+            if (recordedMaven.containsKey(key)) {
+                final ManifestVersionRecord.MavenManifest record = recordedMaven.get(key);
+                res.add(builder
+                        .setPhysicalVersion(record.getVersion())
+                        .setLogicalVersion(record.getDescription())
+                        .build());
+            } else if (recordedUrl.containsKey(key)) {
+                final ManifestVersionRecord.UrlManifest record = recordedUrl.get(key);
+                res.add(builder
+                        .setPhysicalVersion(record.getHash())
+                        .setLogicalVersion(record.getDescription())
+                        .build());
+            } else {
+                res.add(builder.build());
+            }
+        }
+        return res;
+    }
+}

--- a/prospero-common/src/main/java/org/wildfly/prospero/api/InstallationMetadata.java
+++ b/prospero-common/src/main/java/org/wildfly/prospero/api/InstallationMetadata.java
@@ -24,6 +24,7 @@ import org.jboss.galleon.util.PathsUtils;
 import org.wildfly.channel.Channel;
 import org.wildfly.channel.ChannelManifest;
 import org.apache.commons.io.FileUtils;
+import org.wildfly.channel.ChannelMapper;
 import org.wildfly.prospero.ProsperoLogger;
 import org.wildfly.prospero.metadata.ManifestVersionRecord;
 import org.wildfly.prospero.api.exceptions.MetadataException;
@@ -436,5 +437,17 @@ public class InstallationMetadata implements AutoCloseable {
      */
     public GalleonProvisioningConfig getRecordedProvisioningConfig() {
         return provisioningConfig;
+    }
+
+    public List<ChannelVersion> getChannelVersions() throws MetadataException {
+        try {
+            final ChannelVersionReader reader = new ChannelVersionReader(
+                    ChannelMapper.fromString(Files.readString(channelsFile)),
+                    manifestVersion.orElse(new ManifestVersionRecord())
+            );
+            return reader.getChannelVersions();
+        } catch (IOException e) {
+            throw ProsperoLogger.ROOT_LOGGER.unableToParseConfiguration(channelsFile, e);
+        }
     }
 }

--- a/prospero-common/src/main/java/org/wildfly/prospero/galleon/CachedVersionResolver.java
+++ b/prospero-common/src/main/java/org/wildfly/prospero/galleon/CachedVersionResolver.java
@@ -152,8 +152,9 @@ public class CachedVersionResolver implements MavenVersionsResolver {
                     LOG.debugf("Last used version for manifest %s is %s.", a, version);
                 }
 
-                if (version == null) {
-                    // we can't use cache, just throw the resolution exception
+                // if version is empty - we're looking for a latest available manifest. we accept whatever we have in the cache
+                if (version == null || (!a.getVersion().isEmpty() && !version.equals(a.getVersion()))) {
+                    // we can't use cache, or we tried to resolve a different version of manifest - either way, just throw the resolution exception
                     throw e;
                 }
 

--- a/prospero-common/src/main/java/org/wildfly/prospero/updates/ChannelUpdateFinder.java
+++ b/prospero-common/src/main/java/org/wildfly/prospero/updates/ChannelUpdateFinder.java
@@ -1,9 +1,13 @@
 package org.wildfly.prospero.updates;
 
-import java.net.MalformedURLException;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
 
 import org.eclipse.aether.RepositorySystem;
 import org.eclipse.aether.RepositorySystemSession;
@@ -16,13 +20,19 @@ import org.eclipse.aether.resolution.ArtifactResult;
 import org.eclipse.aether.resolution.VersionRangeRequest;
 import org.eclipse.aether.resolution.VersionRangeResolutionException;
 import org.eclipse.aether.resolution.VersionRangeResult;
-import org.eclipse.aether.version.Version;
 import org.wildfly.channel.Channel;
 import org.wildfly.channel.ChannelManifest;
 import org.wildfly.channel.ChannelManifestCoordinate;
 import org.wildfly.channel.ChannelManifestMapper;
+import org.wildfly.prospero.ProsperoLogger;
 import org.wildfly.prospero.api.ChannelVersion;
+import org.wildfly.prospero.api.RepositoryUtils;
+import org.wildfly.prospero.api.exceptions.MetadataException;
 
+
+/**
+ * A Maven resolver to find manifest versions available in a given channel.
+ */
 public class ChannelUpdateFinder {
     private final RepositorySystemSession session;
     private final RepositorySystem system;
@@ -32,39 +42,109 @@ public class ChannelUpdateFinder {
         this.system = system;
     }
 
-    public Collection<ChannelVersion> findNewerVersions(Channel channel, ChannelVersion channelVersion, boolean allowDowngrades) throws VersionRangeResolutionException, ArtifactResolutionException, MalformedURLException {
-        // TODO: verify it's a maven manifest and that it has a version
+    /**
+     * Lists all manifests versions that can be found for the channel.
+     *
+     * NOTE: only Maven channels can be passed to this method. Any other channel will result in an exception to be thrown.
+     *
+     * @param channel - the channel to find the versions for
+     * @return - list of all the possible channel manifest versions
+     * @throws MetadataException - if unable to retrieve or parse the manifest information
+     */
+    public Collection<ChannelVersion> findAvailableChannelVersions(Channel channel)
+            throws MetadataException {
+        Objects.requireNonNull(channel);
 
+        return retrieveArtifactVersions(channel, null);
+    }
+
+    /**
+     * Lists manifests versions that can be found for the channel and are newer then {@code channelVersion}.
+     *
+     * NOTE: only Maven channels can be passed to this method. Any other channel will result in an exception to be thrown.
+     *
+     * @param channel - the channel to find the versions for
+     * @return - list of all the channel manifest versions newer then requested {@code channelVersion}
+     * @throws MetadataException - if unable to retrieve or parse the manifest information
+     */
+    public Collection<ChannelVersion> findNewerChannelVersions(Channel channel, String channelVersion)
+            throws MetadataException {
+        Objects.requireNonNull(channel);
+        Objects.requireNonNull(channelVersion);
+
+        return retrieveArtifactVersions(channel, channelVersion);
+    }
+
+    private ArrayList<ChannelVersion> retrieveArtifactVersions(Channel channel, String channelVersion) throws MetadataException {
+        if (channel.getManifestCoordinate() == null || channel.getManifestCoordinate().getMaven() == null) {
+            throw new RuntimeException("The channel %s needs to have a maven manifest to be able to retrieve channel updates.".formatted(channel.getName()));
+        }
+
+        final List<ArtifactResult> artifactResults = resolveArtifactsFromMaven(channel, toArtifact(channel, channelVersion));
+
+        return mapArtifactsToVersions(channel, artifactResults);
+    }
+
+    private static ArrayList<ChannelVersion> mapArtifactsToVersions(Channel channel, List<ArtifactResult> artifactResults) throws MetadataException {
+        final ArrayList<ChannelVersion> channelVersions = new ArrayList<>();
+        for (ArtifactResult artifactResult : artifactResults) {
+            channelVersions.add(new ChannelVersion.Builder()
+                    .setChannelName(channel.getName())
+                    .setPhysicalVersion(artifactResult.getArtifact().getVersion())
+                    .setLogicalVersion(readLogicalName(artifactResult))
+                    .build());
+        }
+        return channelVersions;
+    }
+
+    private List<ArtifactResult> resolveArtifactsFromMaven(Channel channel, Artifact artifact) throws MetadataException {
+        final List<RemoteRepository> repos = channel.getRepositories().stream()
+                .map(RepositoryUtils::toRemoteRepository)
+                .toList();
+        try {
+            final VersionRangeResult versionRangeResult = getMavenVersions(artifact, repos);
+
+            return downloadMavenArtifacts(versionRangeResult, artifact, repos);
+        } catch (VersionRangeResolutionException | ArtifactResolutionException e) {
+            throw ProsperoLogger.ROOT_LOGGER.unableToResolveChannelVersionInformation(channel.getName(),
+                    artifact.getGroupId(), artifact.getArtifactId(),
+                    repos.stream().map(RemoteRepository::getUrl).collect(Collectors.joining()), e);
+        }
+    }
+
+    private static String readLogicalName(ArtifactResult artifactResult) throws MetadataException {
+        final Path downloadedManifest = artifactResult.getArtifact().getFile().toPath();
+        try {
+            final ChannelManifest manifest = ChannelManifestMapper.fromString(Files.readString(downloadedManifest));
+            return manifest.getLogicalVersion();
+        } catch (IOException e) {
+            throw ProsperoLogger.ROOT_LOGGER.unableToReadFile(downloadedManifest, e);
+        }
+    }
+
+    private List<ArtifactResult> downloadMavenArtifacts(VersionRangeResult versionRangeResult, Artifact artifact, List<RemoteRepository> repos) throws ArtifactResolutionException {
+        final ArrayList<ArtifactRequest> requests = versionRangeResult.getVersions().stream()
+                .map(version -> new ArtifactRequest(artifact.setVersion(version.toString()), repos, null))
+                .collect(Collectors.toCollection(ArrayList::new));
+        return system.resolveArtifacts(session, requests);
+    }
+
+    private VersionRangeResult getMavenVersions(Artifact artifact, List<RemoteRepository> repos) throws VersionRangeResolutionException {
+        final VersionRangeRequest req = new VersionRangeRequest(artifact, repos, null);
+        return system.resolveVersionRange(session, req);
+    }
+
+    private static Artifact toArtifact(Channel channel, String channelVersion) {
         final ChannelManifestCoordinate coord = channel.getManifestCoordinate();
-        Artifact artifact = new DefaultArtifact(
+        return new DefaultArtifact(
                 coord.getGroupId(),
                 coord.getArtifactId(),
                 coord.getClassifier(),
                 coord.getExtension(),
-                "(" + (allowDowngrades ? "0" : channelVersion.getPhysicalVersion()) + ",)");
-        final List<RemoteRepository> repos = channel.getRepositories().stream()
-                .map(r -> new RemoteRepository.Builder(r.getId(), "default", r.getUrl()).build())
-                .toList();
-        VersionRangeRequest req = new VersionRangeRequest(artifact, repos, null);
-        final VersionRangeResult versionRangeResult = system.resolveVersionRange(session, req);
+                createVersionRange(channelVersion));
+    }
 
-        final ArrayList<ArtifactRequest> requests = new ArrayList<>();
-        for (Version version : versionRangeResult.getVersions()) {
-            requests.add(new ArtifactRequest(artifact.setVersion(version.toString()), repos, null));
-        }
-        final List<ArtifactResult> artifactResults = system.resolveArtifacts(session, requests);
-
-        final ArrayList<ChannelVersion> channelVersions = new ArrayList<>();
-        for (ArtifactResult artifactResult : artifactResults) {
-            final ChannelManifest manifest = ChannelManifestMapper.from(artifactResult.getArtifact().getFile().toURI().toURL());
-            final String logicalVersion = manifest.getLogicalVersion();
-            channelVersions.add(new ChannelVersion.Builder()
-                    .setChannelName(channel.getName())
-                    .setPhysicalVersion(artifactResult.getArtifact().getVersion())
-                    .setLogicalVersion(logicalVersion)
-                    .build());
-        }
-
-        return channelVersions;
+    private static String createVersionRange(String channelVersion) {
+        return "(" + (channelVersion == null ? "0" : channelVersion) + ",)";
     }
 }

--- a/prospero-common/src/main/java/org/wildfly/prospero/updates/ChannelUpdateFinder.java
+++ b/prospero-common/src/main/java/org/wildfly/prospero/updates/ChannelUpdateFinder.java
@@ -32,7 +32,7 @@ public class ChannelUpdateFinder {
         this.system = system;
     }
 
-    public Collection<ChannelVersion> findNewerVersions(Channel channel, ChannelVersion channelVersion) throws VersionRangeResolutionException, ArtifactResolutionException, MalformedURLException {
+    public Collection<ChannelVersion> findNewerVersions(Channel channel, ChannelVersion channelVersion, boolean allowDowngrades) throws VersionRangeResolutionException, ArtifactResolutionException, MalformedURLException {
         // TODO: verify it's a maven manifest and that it has a version
 
         final ChannelManifestCoordinate coord = channel.getManifestCoordinate();
@@ -41,7 +41,7 @@ public class ChannelUpdateFinder {
                 coord.getArtifactId(),
                 coord.getClassifier(),
                 coord.getExtension(),
-                "(" + channelVersion.getPhysicalVersion() + ",)");
+                "(" + (allowDowngrades ? "0" : channelVersion.getPhysicalVersion()) + ",)");
         final List<RemoteRepository> repos = channel.getRepositories().stream()
                 .map(r -> new RemoteRepository.Builder(r.getId(), "default", r.getUrl()).build())
                 .toList();

--- a/prospero-common/src/main/java/org/wildfly/prospero/updates/ChannelUpdateFinder.java
+++ b/prospero-common/src/main/java/org/wildfly/prospero/updates/ChannelUpdateFinder.java
@@ -1,0 +1,70 @@
+package org.wildfly.prospero.updates;
+
+import java.net.MalformedURLException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import org.eclipse.aether.RepositorySystem;
+import org.eclipse.aether.RepositorySystemSession;
+import org.eclipse.aether.artifact.Artifact;
+import org.eclipse.aether.artifact.DefaultArtifact;
+import org.eclipse.aether.repository.RemoteRepository;
+import org.eclipse.aether.resolution.ArtifactRequest;
+import org.eclipse.aether.resolution.ArtifactResolutionException;
+import org.eclipse.aether.resolution.ArtifactResult;
+import org.eclipse.aether.resolution.VersionRangeRequest;
+import org.eclipse.aether.resolution.VersionRangeResolutionException;
+import org.eclipse.aether.resolution.VersionRangeResult;
+import org.eclipse.aether.version.Version;
+import org.wildfly.channel.Channel;
+import org.wildfly.channel.ChannelManifest;
+import org.wildfly.channel.ChannelManifestCoordinate;
+import org.wildfly.channel.ChannelManifestMapper;
+import org.wildfly.prospero.api.ChannelVersion;
+
+public class ChannelUpdateFinder {
+    private final RepositorySystemSession session;
+    private final RepositorySystem system;
+
+    public ChannelUpdateFinder(RepositorySystem system, RepositorySystemSession session) {
+        this.session = session;
+        this.system = system;
+    }
+
+    public Collection<ChannelVersion> findNewerVersions(Channel channel, ChannelVersion channelVersion) throws VersionRangeResolutionException, ArtifactResolutionException, MalformedURLException {
+        // TODO: verify it's a maven manifest and that it has a version
+
+        final ChannelManifestCoordinate coord = channel.getManifestCoordinate();
+        Artifact artifact = new DefaultArtifact(
+                coord.getGroupId(),
+                coord.getArtifactId(),
+                coord.getClassifier(),
+                coord.getExtension(),
+                "(" + channelVersion.getPhysicalVersion() + ",)");
+        final List<RemoteRepository> repos = channel.getRepositories().stream()
+                .map(r -> new RemoteRepository.Builder(r.getId(), "default", r.getUrl()).build())
+                .toList();
+        VersionRangeRequest req = new VersionRangeRequest(artifact, repos, null);
+        final VersionRangeResult versionRangeResult = system.resolveVersionRange(session, req);
+
+        final ArrayList<ArtifactRequest> requests = new ArrayList<>();
+        for (Version version : versionRangeResult.getVersions()) {
+            requests.add(new ArtifactRequest(artifact.setVersion(version.toString()), repos, null));
+        }
+        final List<ArtifactResult> artifactResults = system.resolveArtifacts(session, requests);
+
+        final ArrayList<ChannelVersion> channelVersions = new ArrayList<>();
+        for (ArtifactResult artifactResult : artifactResults) {
+            final ChannelManifest manifest = ChannelManifestMapper.from(artifactResult.getArtifact().getFile().toURI().toURL());
+            final String logicalVersion = manifest.getLogicalVersion();
+            channelVersions.add(new ChannelVersion.Builder()
+                    .setChannelName(channel.getName())
+                    .setPhysicalVersion(artifactResult.getArtifact().getVersion())
+                    .setLogicalVersion(logicalVersion)
+                    .build());
+        }
+
+        return channelVersions;
+    }
+}

--- a/prospero-common/src/main/java/org/wildfly/prospero/updates/ChannelsUpdateResult.java
+++ b/prospero-common/src/main/java/org/wildfly/prospero/updates/ChannelsUpdateResult.java
@@ -1,48 +1,119 @@
 package org.wildfly.prospero.updates;
 
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.stream.Collectors;
 
 import org.wildfly.prospero.api.ChannelVersion;
 
+/**
+ * Collection of possible updates to the channels.
+ * Only Maven-based channels can have a versioned update, thus all other channels are marked as unsupported.
+ */
 public class ChannelsUpdateResult {
+    private final Map<String, ChannelResult> channelResultMap = new HashMap<>();
 
-    private final Map<String, Set<ChannelVersion>> channelVersions = new HashMap<>();
-    private final Map<String, String> currentVersions = new HashMap<>();
-    private final Set<String> unsupportedChannels = new HashSet<>();
-
-    public void addChannelVersions(String channelName, String originalVersion, Collection<ChannelVersion> versions) {
-        final Set<ChannelVersion> recorded = channelVersions.computeIfAbsent(channelName, (name)->new TreeSet<>());
-        recorded.addAll(versions);
-        currentVersions.put(channelName, originalVersion);
+    public ChannelsUpdateResult(ChannelResult... channelResults) {
+        this(Arrays.asList(channelResults));
     }
 
-    public void addUnsupportedChannel(String unsupportedChannel) {
-        unsupportedChannels.add(unsupportedChannel);
+    public ChannelsUpdateResult(List<ChannelResult> channelResults) {
+        for (ChannelResult channelResult : channelResults) {
+            if (channelResultMap.containsKey(channelResult.getChannelName())) {
+                throw new IllegalArgumentException("The results for channel " + channelResult.getChannelName() + " are listed twice.");
+            }
+
+            this.channelResultMap.put(channelResult.getChannelName(), channelResult);
+        }
     }
 
     public Set<String> getUpdatedChannels() {
-        return channelVersions.keySet();
+        return channelResultMap.keySet();
     }
 
-    public Set<ChannelVersion> getUpdatedVersion(String channel) {
-        return channelVersions.getOrDefault(channel, Collections.emptySet());
+    public ChannelResult getUpdatedVersion(String channel) {
+        return channelResultMap.get(channel);
     }
 
     public Set<String> getUnsupportedChannels() {
-        return unsupportedChannels;
-    }
-
-    public String getOriginalVersions(String channelName) {
-        return currentVersions.get(channelName);
+        return channelResultMap.values().stream()
+                .filter(r->r.getStatus() == Status.Unsupported)
+                .map(ChannelResult::getChannelName)
+                .collect(Collectors.toSet());
     }
 
     public boolean hasUpdates() {
-        return !this.channelVersions.values().stream().allMatch(Collection::isEmpty);
+        return channelResultMap.values().stream().anyMatch(r->r.getStatus() == Status.UpdatesFound);
+    }
+
+    public enum Status {
+        Unsupported, NoUpdates, UpdatesFound
+    }
+
+    /**
+     * Represents the possible versions a channel can be updated to.
+     *
+     * Since only Maven-based channels can have update versions, all other channels should have status set to Unsupported.
+     */
+    public static class ChannelResult {
+        private final Status status;
+        private final String channelName;
+        private final String currentVersion;
+        private final Set<ChannelVersion> availableVersions;
+
+        /**
+         * Create channel updates for a versioned channel record.
+         *
+         * @param channelName
+         * @param currentVersion
+         * @param availableVersions
+         */
+        public ChannelResult(String channelName, String currentVersion, Collection<ChannelVersion> availableVersions) {
+            Objects.requireNonNull(channelName);
+            Objects.requireNonNull(availableVersions);
+
+            this.channelName = channelName;
+            this.currentVersion = currentVersion;
+            this.availableVersions = new TreeSet<>(availableVersions);
+            this.status = availableVersions.isEmpty() ? Status.NoUpdates : Status.UpdatesFound;
+        }
+
+        /**
+         * Create unsupported channel versions record.
+         *
+         * @param channelName
+         * @param currentVersion
+         */
+        public ChannelResult(String channelName, String currentVersion) {
+            Objects.requireNonNull(channelName);
+
+            this.channelName = channelName;
+            this.status = Status.Unsupported;
+            this.currentVersion = currentVersion;
+            this.availableVersions = Collections.emptySet();
+        }
+
+        public Status getStatus() {
+            return status;
+        }
+
+        public String getCurrentVersion() {
+            return currentVersion;
+        }
+
+        public Set<ChannelVersion> getAvailableVersions() {
+            return availableVersions;
+        }
+
+        public String getChannelName() {
+            return channelName;
+        }
     }
 }

--- a/prospero-common/src/main/java/org/wildfly/prospero/updates/ChannelsUpdateResult.java
+++ b/prospero-common/src/main/java/org/wildfly/prospero/updates/ChannelsUpdateResult.java
@@ -1,0 +1,48 @@
+package org.wildfly.prospero.updates;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+
+import org.wildfly.prospero.api.ChannelVersion;
+
+public class ChannelsUpdateResult {
+
+    private final Map<String, Set<ChannelVersion>> channelVersions = new HashMap<>();
+    private final Map<String, String> currentVersions = new HashMap<>();
+    private final Set<String> unsupportedChannels = new HashSet<>();
+
+    public void addChannelVersions(String channelName, String originalVersion, Collection<ChannelVersion> versions) {
+        final Set<ChannelVersion> recorded = channelVersions.computeIfAbsent(channelName, (name)->new TreeSet<>());
+        recorded.addAll(versions);
+        currentVersions.put(channelName, originalVersion);
+    }
+
+    public void addUnsupportedChannel(String unsupportedChannel) {
+        unsupportedChannels.add(unsupportedChannel);
+    }
+
+    public Set<String> getUpdatedChannels() {
+        return channelVersions.keySet();
+    }
+
+    public Set<ChannelVersion> getUpdatedVersion(String channel) {
+        return channelVersions.getOrDefault(channel, Collections.emptySet());
+    }
+
+    public Set<String> getUnsupportedChannels() {
+        return unsupportedChannels;
+    }
+
+    public String getOriginalVersions(String channelName) {
+        return currentVersions.get(channelName);
+    }
+
+    public boolean hasUpdates() {
+        return !this.channelVersions.values().stream().allMatch(Collection::isEmpty);
+    }
+}

--- a/prospero-common/src/main/java/org/wildfly/prospero/updates/UpdateFinder.java
+++ b/prospero-common/src/main/java/org/wildfly/prospero/updates/UpdateFinder.java
@@ -19,14 +19,30 @@ package org.wildfly.prospero.updates;
 
 import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.artifact.DefaultArtifact;
+import org.jboss.galleon.util.HashUtils;
+import org.wildfly.channel.Channel;
 import org.wildfly.channel.ChannelSession;
+import org.wildfly.channel.Repository;
+import org.wildfly.channel.RuntimeChannel;
 import org.wildfly.channel.UnresolvedMavenArtifactException;
 import org.wildfly.channel.VersionResult;
+import org.wildfly.prospero.ProsperoLogger;
 import org.wildfly.prospero.api.ArtifactChange;
+import org.wildfly.prospero.api.ChannelVersion;
+import org.wildfly.prospero.api.ChannelVersionChange;
 import org.wildfly.prospero.api.exceptions.ArtifactResolutionException;
+import org.wildfly.prospero.api.exceptions.MetadataException;
 
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.URL;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
@@ -40,13 +56,22 @@ public class UpdateFinder implements AutoCloseable {
 
     private final ChannelSession channelSession;
     private final ExecutorService executorService;
-
     public UpdateFinder(ChannelSession channelSession) {
         this.channelSession = channelSession;
         this.executorService = Executors.newWorkStealingPool(UPDATES_SEARCH_PARALLELISM);
     }
 
+    @Deprecated(forRemoval = true)
     public UpdateSet findUpdates(List<Artifact> artifacts) throws ArtifactResolutionException {
+        try {
+            return findUpdates(artifacts, Collections.emptyList());
+        } catch (MetadataException e) {
+            // need to wrap this exception so the method signature is not changed
+            throw new RuntimeException(e);
+        }
+    }
+
+    public UpdateSet findUpdates(List<Artifact> artifacts, List<ChannelVersion> channelVersions) throws ArtifactResolutionException, MetadataException {
         // use parallel executor to speed up the artifact resolution
         List<CompletableFuture<Optional<ArtifactChange>>> allPackages = new ArrayList<>();
         for (Artifact artifact : artifacts) {
@@ -77,11 +102,17 @@ public class UpdateFinder implements AutoCloseable {
                 .flatMap(Optional::stream)
                 .collect(Collectors.toList());
 
-        return new UpdateSet(updates);
+        List<ChannelVersionChange> channelVersionChanges = findChannelVersions(channelVersions);
+
+        return new UpdateSet(updates, channelVersionChanges);
     }
 
-    private Optional<ArtifactChange> findUpdates(Artifact artifact) throws ArtifactResolutionException {
+    @Override
+    public void close() {
+        this.executorService.shutdown();
+    }
 
+    private Optional<ArtifactChange> findUpdates(Artifact artifact) {
         final String latestVersion;
         final Optional<String> channelName;
         try {
@@ -93,6 +124,7 @@ public class UpdateFinder implements AutoCloseable {
         } catch (UnresolvedMavenArtifactException e) {
             return Optional.of(ArtifactChange.removed(artifact));
         }
+
         final Artifact latest = new DefaultArtifact(artifact.getGroupId(), artifact.getArtifactId(), artifact.getExtension(), latestVersion);
 
         if (latestVersion == null || latest.getVersion().equals(artifact.getVersion())) {
@@ -102,9 +134,87 @@ public class UpdateFinder implements AutoCloseable {
         }
     }
 
-    @Override
-    public void close() {
-        this.executorService.shutdown();
+    private List<ChannelVersionChange> findChannelVersions(List<ChannelVersion> currentVersions) throws MetadataException {
+
+        final List<ChannelVersionChange> res = new ArrayList<>();
+        final List<RuntimeChannel> runtimeChannels = channelSession.getRuntimeChannels();
+
+        final HashMap<String, ChannelVersion> oldManifests = new HashMap<>();
+        // match the channels by name
+        currentVersions.forEach(v -> oldManifests.put(v.getChannelName(), v));
+
+        // name :: channel version info
+        final HashMap<String, ChannelVersion> newManifests = new HashMap<>();
+        // match the channels by name
+        for (RuntimeChannel c : runtimeChannels) {
+            final String location;
+            final Channel channelDefinition = c.getChannelDefinition();
+            if (channelDefinition.getManifestCoordinate() == null) {
+                final String repos = channelDefinition.getRepositories().stream().map(Repository::getId).collect(Collectors.joining(","));
+                location = channelDefinition.getNoStreamStrategy().toString().toLowerCase(Locale.ROOT) + "@[" + repos + "]";
+            } else if (channelDefinition.getManifestCoordinate().getUrl() != null) {
+                location = channelDefinition.getManifestCoordinate().getUrl().toExternalForm();
+            } else {
+                location = channelDefinition.getManifestCoordinate().getGroupId() + ":" + channelDefinition.getManifestCoordinate().getArtifactId();
+            }
+
+            final String physicalVersion;
+            final ChannelVersion.Type type;
+            if (channelDefinition.getManifestCoordinate() == null) {
+                physicalVersion = null;
+                type = ChannelVersion.Type.OPEN;
+            } else if (channelDefinition.getManifestCoordinate().getUrl() != null) {
+                try {
+                    physicalVersion = HashUtils.hash(read(channelDefinition.getManifestCoordinate().getUrl()));
+                } catch (IOException e) {
+                    throw ProsperoLogger.ROOT_LOGGER.unableToDownloadFile(e);
+                }
+                type = ChannelVersion.Type.URL;
+            } else {
+                physicalVersion = channelDefinition.getManifestCoordinate().getVersion();
+                type = ChannelVersion.Type.MAVEN;
+            }
+
+
+            final ChannelVersion cv = new ChannelVersion.Builder()
+                    .setChannelName(channelDefinition.getName())
+                    .setLocation(location)
+                    .setLogicalVersion(c.getChannelManifest().getLogicalVersion())
+                    .setPhysicalVersion(physicalVersion)
+                    .setType(type)
+                    .build();
+
+            newManifests.put(channelDefinition.getName(), cv);
+        }
+
+        // handle changed and removed channels
+        for (String channelName: oldManifests.keySet()) {
+            final ChannelVersion oldVersion = oldManifests.get(channelName);
+            final ChannelVersion newVersion = newManifests.get(channelName);
+
+            res.add(new ChannelVersionChange(channelName, oldVersion, newVersion));
+        }
+
+        // add versions were a channel was added since history
+        for (String channelName: newManifests.keySet()) {
+            if (oldManifests.containsKey(channelName)) {
+                // skip, we've already handled those
+                continue;
+            }
+
+            final ChannelVersion newVersion = newManifests.get(channelName);
+
+            res.add(new ChannelVersionChange(channelName, null, newVersion));
+        }
+
+        return res;
     }
 
+    private static String read(URL url) throws IOException {
+        try(InputStream inputStream = url.openStream();
+            OutputStream outputStream = new ByteArrayOutputStream()) {
+            inputStream.transferTo(outputStream);
+            return outputStream.toString();
+        }
+    }
 }

--- a/prospero-common/src/main/java/org/wildfly/prospero/updates/UpdateSet.java
+++ b/prospero-common/src/main/java/org/wildfly/prospero/updates/UpdateSet.java
@@ -18,6 +18,7 @@
 package org.wildfly.prospero.updates;
 
 import org.wildfly.prospero.api.ArtifactChange;
+import org.wildfly.prospero.api.ChannelVersionChange;
 
 import java.util.Collections;
 import java.util.List;
@@ -26,9 +27,15 @@ public class UpdateSet {
 
     public static final UpdateSet EMPTY = new UpdateSet(Collections.emptyList());
     private final List<ArtifactChange> artifactUpdates;
+    private List<ChannelVersionChange> channelChanges;
 
     public UpdateSet(List<ArtifactChange> updates) {
+        this(updates, Collections.emptyList());
+    }
+
+    public UpdateSet(List<ArtifactChange> updates, List<ChannelVersionChange> channelChanges) {
         this.artifactUpdates = updates;
+        this.channelChanges = channelChanges;
     }
 
     public List<ArtifactChange> getArtifactUpdates() {
@@ -37,5 +44,9 @@ public class UpdateSet {
 
     public boolean isEmpty() {
         return artifactUpdates.isEmpty();
+    }
+
+    public List<ChannelVersionChange> getChannelVersionChanges() {
+        return channelChanges;
     }
 }

--- a/prospero-common/src/test/java/org/wildfly/prospero/api/ChannelVersionReaderTest.java
+++ b/prospero-common/src/test/java/org/wildfly/prospero/api/ChannelVersionReaderTest.java
@@ -1,0 +1,117 @@
+package org.wildfly.prospero.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.URL;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.Test;
+import org.wildfly.channel.Channel;
+import org.wildfly.prospero.metadata.ManifestVersionRecord;
+
+public class ChannelVersionReaderTest {
+
+    @Test
+    public void noRecordedVersionsReturnsInfoWithoutVersion() throws Exception {
+        final ChannelVersionReader reader = new ChannelVersionReader(
+                List.of(
+                        new Channel.Builder()
+                                .setName("test-channel")
+                                .setManifestCoordinate("org", "test")
+                                .build()
+                ),
+                new ManifestVersionRecord());
+
+        assertThat(reader.getChannelVersions())
+                .contains(new ChannelVersion.Builder()
+                        .setChannelName("test-channel")
+                        .setLocation("org:test")
+                        .setType(ChannelVersion.Type.MAVEN)
+                        .build());
+    }
+
+    @Test
+    public void matchingMavenChannel() throws Exception {
+        final ChannelVersionReader reader = new ChannelVersionReader(
+                List.of(
+                        new Channel.Builder()
+                                .setName("test-channel")
+                                .setManifestCoordinate("org", "test")
+                                .build()
+                ),
+                new ManifestVersionRecord(
+                        "1.0.0",
+                        List.of(
+                                new ManifestVersionRecord.MavenManifest("org", "test", "1.0.0", "Update 0")
+                        ),
+                        Collections.emptyList(),
+                        Collections.emptyList()
+                        ));
+
+        assertThat(reader.getChannelVersions())
+                .contains(new ChannelVersion.Builder()
+                        .setChannelName("test-channel")
+                        .setLocation("org:test")
+                        .setPhysicalVersion("1.0.0")
+                        .setLogicalVersion("Update 0")
+                        .setType(ChannelVersion.Type.MAVEN)
+                        .build());
+    }
+
+    @Test
+    public void matchingUrlChannel() throws Exception {
+        final ChannelVersionReader reader = new ChannelVersionReader(
+                List.of(
+                        new Channel.Builder()
+                                .setName("test-channel")
+                                .setManifestUrl(new URL("http://test.te"))
+                                .build()
+                ),
+                new ManifestVersionRecord(
+                        "1.0.0",
+                        Collections.emptyList(),
+                        List.of(
+                                new ManifestVersionRecord.UrlManifest("http://test.te", "abcd", "Update 0")
+                        ),
+                        Collections.emptyList()
+                ));
+
+        assertThat(reader.getChannelVersions())
+                .contains(new ChannelVersion.Builder()
+                        .setChannelName("test-channel")
+                        .setLocation("http://test.te")
+                        .setPhysicalVersion("abcd")
+                        .setLogicalVersion("Update 0")
+                        .setType(ChannelVersion.Type.URL)
+                        .build());
+    }
+
+    @Test
+    public void matchingOpenChannel() throws Exception {
+        final ChannelVersionReader reader = new ChannelVersionReader(
+                List.of(
+                        new Channel.Builder()
+                                .setName("test-channel")
+                                .addRepository("test-repo", "http://test.te")
+                                .setResolveStrategy(Channel.NoStreamStrategy.LATEST)
+                                .build()
+                ),
+                new ManifestVersionRecord(
+                        "1.0.0",
+                        Collections.emptyList(),
+                        Collections.emptyList(),
+                        List.of(
+                                new ManifestVersionRecord.NoManifest(List.of("test-repo"), "latest")
+                        )
+                ));
+
+        assertThat(reader.getChannelVersions())
+                .contains(new ChannelVersion.Builder()
+                        .setChannelName("test-channel")
+                        .setType(ChannelVersion.Type.OPEN)
+                        .setLocation("latest@[test-repo]")
+                        .build());
+    }
+
+}

--- a/prospero-common/src/test/java/org/wildfly/prospero/galleon/CachedVersionResolverTest.java
+++ b/prospero-common/src/test/java/org/wildfly/prospero/galleon/CachedVersionResolverTest.java
@@ -286,4 +286,16 @@ public class CachedVersionResolverTest {
                 new ChannelManifestCoordinate("org.test", "manifest-two"))))
                 .containsExactly(testFileOne.toURI().toURL(), testFileTwo.toURI().toURL());
     }
+
+    @Test
+    public void testResolveChannelMetadata_ManifestVersionDoesNotMatchCache() throws Exception {
+        final ArtifactTransferException resolutionException = new ArtifactTransferException("",
+                Set.of(new ArtifactCoordinate("org.test", "manifest-one", ChannelManifest.EXTENSION, ChannelManifest.CLASSIFIER, "1.2.4")),
+                Collections.emptySet());
+        when(mockResolver.resolveChannelMetadata(any())).thenThrow(resolutionException);
+        when(manifestVersionProvider.apply(any())).thenReturn("1.2.3");
+
+        assertThatThrownBy(()->resolver.resolveChannelMetadata(List.of(new ChannelMetadataCoordinate("org.test", "manifest-one", ChannelManifest.CLASSIFIER, ChannelManifest.EXTENSION))))
+                .isEqualTo(resolutionException);
+    }
 }

--- a/prospero-common/src/test/java/org/wildfly/prospero/updates/ChannelUpdateFinderTest.java
+++ b/prospero-common/src/test/java/org/wildfly/prospero/updates/ChannelUpdateFinderTest.java
@@ -19,7 +19,8 @@ public class ChannelUpdateFinderTest {
                         .setName("test-channel")
                         .setManifestCoordinate("org.wildfly.channels", "wildfly-ee")
                         .addRepository("central", "https://repo1.maven.org/maven2/")
-                        .build(), new ChannelVersion.Builder().setChannelName("test-channel").setPhysicalVersion("35.0.0.Final").build());
+                        .build(), new ChannelVersion.Builder().setChannelName("test-channel").setPhysicalVersion("35.0.0.Final").build(),
+                        false);
 
         for (ChannelVersion newerVersion : newerVersions) {
             System.out.println(newerVersion);

--- a/prospero-common/src/test/java/org/wildfly/prospero/updates/ChannelUpdateFinderTest.java
+++ b/prospero-common/src/test/java/org/wildfly/prospero/updates/ChannelUpdateFinderTest.java
@@ -1,0 +1,29 @@
+package org.wildfly.prospero.updates;
+
+import java.util.Collection;
+
+import org.eclipse.aether.RepositorySystem;
+import org.junit.Test;
+import org.wildfly.channel.Channel;
+import org.wildfly.prospero.api.ChannelVersion;
+import org.wildfly.prospero.wfchannel.MavenSessionManager;
+
+public class ChannelUpdateFinderTest {
+
+    @Test
+    public void listUpdatesOfManifest() throws Exception {
+        final MavenSessionManager msm = new MavenSessionManager();
+        final RepositorySystem repositorySystem = msm.newRepositorySystem();
+        final Collection<ChannelVersion> newerVersions = new ChannelUpdateFinder(repositorySystem, msm.newRepositorySystemSession(repositorySystem))
+                .findNewerVersions(new Channel.Builder()
+                        .setName("test-channel")
+                        .setManifestCoordinate("org.wildfly.channels", "wildfly-ee")
+                        .addRepository("central", "https://repo1.maven.org/maven2/")
+                        .build(), new ChannelVersion.Builder().setChannelName("test-channel").setPhysicalVersion("35.0.0.Final").build());
+
+        for (ChannelVersion newerVersion : newerVersions) {
+            System.out.println(newerVersion);
+        }
+    }
+
+}

--- a/prospero-common/src/test/java/org/wildfly/prospero/updates/ChannelUpdateFinderTest.java
+++ b/prospero-common/src/test/java/org/wildfly/prospero/updates/ChannelUpdateFinderTest.java
@@ -1,30 +1,135 @@
 package org.wildfly.prospero.updates;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+import java.io.File;
+import java.net.URI;
+import java.nio.file.Files;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
 
 import org.eclipse.aether.RepositorySystem;
+import org.eclipse.aether.RepositorySystemSession;
+import org.eclipse.aether.artifact.DefaultArtifact;
+import org.eclipse.aether.resolution.ArtifactResult;
+import org.eclipse.aether.resolution.VersionRangeRequest;
+import org.eclipse.aether.resolution.VersionRangeResult;
+import org.eclipse.aether.util.version.GenericVersionScheme;
+import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.wildfly.channel.Channel;
+import org.wildfly.channel.ChannelManifest;
+import org.wildfly.channel.ChannelManifestMapper;
 import org.wildfly.prospero.api.ChannelVersion;
-import org.wildfly.prospero.wfchannel.MavenSessionManager;
 
+@RunWith(MockitoJUnitRunner.class)
 public class ChannelUpdateFinderTest {
 
+    private final GenericVersionScheme versionScheme = new GenericVersionScheme();
+    @Mock
+    private RepositorySystem system;
+
+    @Mock
+    private RepositorySystemSession session;
+
+    @Captor
+    private ArgumentCaptor<VersionRangeRequest> rangeRequests;
+
+    @Rule
+    public TemporaryFolder temp = new TemporaryFolder();
+    private ChannelUpdateFinder channelUpdateFinder;
+
+    @Before
+    public void setUp() throws Exception {
+        channelUpdateFinder = new ChannelUpdateFinder(system, session);
+    }
+
     @Test
-    public void listUpdatesOfManifest() throws Exception {
-        final MavenSessionManager msm = new MavenSessionManager();
-        final RepositorySystem repositorySystem = msm.newRepositorySystem();
-        final Collection<ChannelVersion> newerVersions = new ChannelUpdateFinder(repositorySystem, msm.newRepositorySystemSession(repositorySystem))
-                .findNewerVersions(new Channel.Builder()
+    public void listNewerUpdatesOfManifest() throws Exception {
+        final VersionRangeResult rangeRes = Mockito.mock(VersionRangeResult.class);
+        when(rangeRes.getVersions()).thenReturn(List.of(versionScheme.parseVersion("1.0.1")));
+        final ArtifactResult artifactRes = Mockito.mock(ArtifactResult.class);
+        final File file = temp.newFile();
+        Files.writeString(file.toPath(), ChannelManifestMapper.toYaml(new ChannelManifest.Builder().build()));
+        when(artifactRes.getArtifact()).thenReturn(new DefaultArtifact("org.wildfly.channels", "wildfly-ee", "manifest", "yaml", "1.0.1", null, file));
+        when(system.resolveVersionRange(eq(session), rangeRequests.capture())).thenReturn(rangeRes);
+        when(system.resolveArtifacts(eq(session), any())).thenReturn(List.of(artifactRes));
+        final Collection<ChannelVersion> versions = channelUpdateFinder
+                .findNewerChannelVersions(new Channel.Builder()
                         .setName("test-channel")
                         .setManifestCoordinate("org.wildfly.channels", "wildfly-ee")
                         .addRepository("central", "https://repo1.maven.org/maven2/")
-                        .build(), new ChannelVersion.Builder().setChannelName("test-channel").setPhysicalVersion("35.0.0.Final").build(),
-                        false);
+                        .build(),
+                        "1.0.0");
 
-        for (ChannelVersion newerVersion : newerVersions) {
-            System.out.println(newerVersion);
-        }
+        assertThat(versions)
+                .containsExactly(new ChannelVersion.Builder().setChannelName("test-channel").setPhysicalVersion("1.0.1").build());
+        assertThat(rangeRequests.getValue().getArtifact().getVersion())
+                .isEqualTo("(1.0.0,)");
+    }
+
+    @Test
+    public void listAllUpdatesOfManifest() throws Exception {
+        final VersionRangeResult rangeRes = Mockito.mock(VersionRangeResult.class);
+        when(rangeRes.getVersions()).thenReturn(List.of(versionScheme.parseVersion("1.0.0"), versionScheme.parseVersion("1.0.1")));
+        final ArtifactResult artifactRes = Mockito.mock(ArtifactResult.class);
+        final File file = temp.newFile();
+        Files.writeString(file.toPath(), ChannelManifestMapper.toYaml(new ChannelManifest.Builder().build()));
+        when(artifactRes.getArtifact()).thenReturn(new DefaultArtifact("org.wildfly.channels", "wildfly-ee", "manifest", "yaml", "1.0.1", null, file));
+        when(system.resolveVersionRange(eq(session), rangeRequests.capture())).thenReturn(rangeRes);
+        when(system.resolveArtifacts(eq(session), any())).thenReturn(List.of(artifactRes));
+        final Collection<ChannelVersion> versions = channelUpdateFinder
+                .findAvailableChannelVersions(new Channel.Builder()
+                                .setName("test-channel")
+                                .setManifestCoordinate("org.wildfly.channels", "wildfly-ee")
+                                .addRepository("central", "https://repo1.maven.org/maven2/")
+                                .build());
+
+        assertThat(versions)
+                .containsExactly(new ChannelVersion.Builder().setChannelName("test-channel").setPhysicalVersion("1.0.1").build());
+        assertThat(rangeRequests.getValue().getArtifact().getVersion())
+                .isEqualTo("(0,)");
+    }
+
+    @Test
+    public void noUpdatesFoundReturnsAnEmptyList() throws Exception {
+        final VersionRangeResult rangeRes = Mockito.mock(VersionRangeResult.class);
+        when(rangeRes.getVersions()).thenReturn(Collections.emptyList());
+        when(system.resolveVersionRange(eq(session), rangeRequests.capture())).thenReturn(rangeRes);
+        final Collection<ChannelVersion> versions = channelUpdateFinder
+                .findNewerChannelVersions(new Channel.Builder()
+                                .setName("test-channel")
+                                .setManifestCoordinate("org.wildfly.channels", "wildfly-ee")
+                                .addRepository("central", "https://repo1.maven.org/maven2/")
+                                .build(),
+                        "1.0.0");
+
+        assertThat(versions)
+                .isEmpty();
+    }
+
+    @Test
+    public void nonMavenManifestThrowsException() {
+        assertThatThrownBy(()-> channelUpdateFinder
+                .findNewerChannelVersions(new Channel.Builder()
+                                .setName("test-channel")
+                                .setManifestUrl(URI.create("file:test-manifest.yaml").toURL())
+                                .addRepository("central", "https://repo1.maven.org/maven2/")
+                                .build(),
+                        "1.0.0"))
+                .hasMessageContaining("The channel test-channel needs to have a maven manifest to be able to retrieve channel updates.");
     }
 
 }

--- a/prospero-common/src/test/java/org/wildfly/prospero/updates/UpdateFinderTest.java
+++ b/prospero-common/src/test/java/org/wildfly/prospero/updates/UpdateFinderTest.java
@@ -19,22 +19,33 @@ package org.wildfly.prospero.updates;
 
 import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.artifact.DefaultArtifact;
+import org.jboss.galleon.util.HashUtils;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.wildfly.channel.ArtifactTransferException;
+import org.wildfly.channel.Channel;
+import org.wildfly.channel.ChannelManifest;
+import org.wildfly.channel.ChannelManifestMapper;
 import org.wildfly.channel.ChannelSession;
+import org.wildfly.channel.RuntimeChannel;
 import org.wildfly.channel.VersionResult;
 import org.wildfly.prospero.api.ArtifactChange;
+import org.wildfly.prospero.api.ChannelVersion;
+import org.wildfly.prospero.api.ChannelVersionChange;
 
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
-import org.jboss.galleon.api.Provisioning;
 
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.when;
 
 @SuppressWarnings("OptionalGetWithoutIsPresent")
@@ -43,8 +54,9 @@ public class UpdateFinderTest {
 
     @Mock
     ChannelSession channelSession;
-    @Mock
-    Provisioning provMgr;
+
+    @Rule
+    public TemporaryFolder tempFolder = new TemporaryFolder();
 
     @Test
     public void testDowngradeIsPossible() throws Exception {
@@ -55,7 +67,7 @@ public class UpdateFinderTest {
         final List<Artifact> artifacts = Arrays.asList(
                 new DefaultArtifact("org.foo", "bar", "jar", "1.0.1")
                 );
-        final UpdateSet updates = finder.findUpdates(artifacts);
+        final UpdateSet updates = finder.findUpdates(artifacts, Collections.emptyList());
 
         assertEquals(1, updates.getArtifactUpdates().size());
         final ArtifactChange actualChange = updates.getArtifactUpdates().get(0);
@@ -74,7 +86,7 @@ public class UpdateFinderTest {
         final List<Artifact> artifacts = Arrays.asList(
                 new DefaultArtifact("org.foo", "bar", "jar", "1.0.0")
         );
-        final UpdateSet updates = finder.findUpdates(artifacts);
+        final UpdateSet updates = finder.findUpdates(artifacts, Collections.emptyList());
 
         assertEquals(0, updates.getArtifactUpdates().size());
     }
@@ -88,7 +100,7 @@ public class UpdateFinderTest {
         final List<Artifact> artifacts = Arrays.asList(
                 new DefaultArtifact("org.foo", "bar", "jar", "1.0.0")
         );
-        final UpdateSet updates = finder.findUpdates(artifacts);
+        final UpdateSet updates = finder.findUpdates(artifacts, Collections.emptyList());
 
         assertEquals(1, updates.getArtifactUpdates().size());
         assertEquals("org.foo:bar", updates.getArtifactUpdates().get(0).getArtifactName());
@@ -105,7 +117,7 @@ public class UpdateFinderTest {
         final List<Artifact> artifacts = Arrays.asList(
                 new DefaultArtifact("org.foo", "bar", "jar", "1.0.0")
         );
-        final UpdateSet updates = finder.findUpdates(artifacts);
+        final UpdateSet updates = finder.findUpdates(artifacts, Collections.emptyList());
 
         assertEquals(1, updates.getArtifactUpdates().size());
         assertEquals("org.foo:bar", updates.getArtifactUpdates().get(0).getArtifactName());
@@ -122,7 +134,7 @@ public class UpdateFinderTest {
         final List<Artifact> artifacts = Arrays.asList(
                 new DefaultArtifact("org.foo", "bar", "jar", "1.0.1")
         );
-        final UpdateSet updates = finder.findUpdates(artifacts);
+        final UpdateSet updates = finder.findUpdates(artifacts, Collections.emptyList());
 
         assertEquals(1, updates.getArtifactUpdates().size());
         final ArtifactChange actualUpdate = updates.getArtifactUpdates().get(0);
@@ -130,5 +142,197 @@ public class UpdateFinderTest {
         assertEquals("1.0.0", actualUpdate.getNewVersion().get());
         assertEquals("1.0.1", actualUpdate.getOldVersion().get());
         assertEquals("test-channel", actualUpdate.getChannelName().orElse(null));
+    }
+
+    @Test
+    public void listChannelVersionChangesWithMavenChannel() throws Exception {
+        final ChannelManifest.Builder manifestBuilder = new ChannelManifest.Builder();
+        manifestBuilder.setLogicalVersion("Update 1");
+        when(channelSession.getRuntimeChannels())
+                .thenReturn(List.of(new RuntimeChannel(
+                        new Channel.Builder()
+                                .setName("test-channel")
+                                .setManifestCoordinate("t", "c", "1.0.1")
+                                .build(),
+                        manifestBuilder
+                                .build(),
+                        null
+                )));
+        List<ChannelVersion> currentVersions = List.of(new ChannelVersion.Builder()
+                .setChannelName("test-channel")
+                .setPhysicalVersion("1.0.0")
+                .setType(ChannelVersion.Type.MAVEN)
+                .setLocation("t:c")
+                .setLogicalVersion("Update 0")
+                .build());
+        UpdateFinder finder = new UpdateFinder(channelSession);
+        final List<Artifact> artifacts = Collections.emptyList();
+        final UpdateSet updates = finder.findUpdates(artifacts, currentVersions);
+
+        assertThat(updates.getChannelVersionChanges())
+                .contains(new ChannelVersionChange("test-channel",
+                        new ChannelVersion.Builder()
+                                .setChannelName("test-channel")
+                                .setLocation("t:c")
+                                .setPhysicalVersion("1.0.0")
+                                .setLogicalVersion( "Update 0")
+                                .setType(ChannelVersion.Type.MAVEN)
+                                .build(),
+                        new ChannelVersion.Builder()
+                                .setChannelName("test-channel")
+                                .setLocation("t:c")
+                                .setPhysicalVersion("1.0.1")
+                                .setLogicalVersion( "Update 1")
+                                .setType(ChannelVersion.Type.MAVEN)
+                                .build()
+                ));
+    }
+
+    @Test
+    public void listChannelVersionChangesWithUrlChannel() throws Exception {
+        final ChannelManifest.Builder manifestBuilder = new ChannelManifest.Builder();
+        manifestBuilder.setLogicalVersion("Update 1");
+
+        final Path manifestTwo = tempFolder.newFile("test-manifest").toPath();
+        final String manifestUrl = manifestTwo.toUri().toURL().toExternalForm();
+        Files.writeString(manifestTwo, ChannelManifestMapper.toYaml(manifestBuilder.build()));
+        final String hash = HashUtils.hash(Files.readString(manifestTwo));
+
+        when(channelSession.getRuntimeChannels())
+                .thenReturn(List.of(new RuntimeChannel(
+                        new Channel.Builder()
+                                .setName("test-channel")
+                                .setManifestUrl(manifestTwo.toUri().toURL())
+                                .build(),
+                        manifestBuilder
+                                .build(),
+                        null
+                )));
+        List<ChannelVersion> currentVersions = List.of(new ChannelVersion.Builder()
+                        .setChannelName("test-channel")
+                        .setPhysicalVersion("abcd")
+                        .setType(ChannelVersion.Type.URL)
+                        .setLocation(manifestUrl)
+                        .setLogicalVersion("Update 0")
+                .build());
+        UpdateFinder finder = new UpdateFinder(channelSession);
+        final List<Artifact> artifacts = Collections.emptyList();
+        final UpdateSet updates = finder.findUpdates(artifacts, currentVersions);
+
+        assertThat(updates.getChannelVersionChanges())
+                .contains(new ChannelVersionChange("test-channel",
+                        new ChannelVersion.Builder()
+                                .setChannelName("test-channel")
+                                .setLocation(manifestUrl)
+                                .setPhysicalVersion("abcd")
+                                .setLogicalVersion("Update 0")
+                                .setType(ChannelVersion.Type.URL)
+                                .build(),
+                        new ChannelVersion.Builder()
+                                .setChannelName("test-channel")
+                                .setLocation(manifestUrl)
+                                .setPhysicalVersion(hash)
+                                .setLogicalVersion("Update 1")
+                                .setType(ChannelVersion.Type.URL)
+                                .build())
+                );
+    }
+
+    @Test
+    public void listChannelVersionChangesOpenChannel() throws Exception {
+        when(channelSession.getRuntimeChannels())
+                .thenReturn(List.of(new RuntimeChannel(
+                        new Channel.Builder()
+                                .setName("test-channel")
+                                .setResolveStrategy(Channel.NoStreamStrategy.LATEST)
+                                .addRepository("central", "http://repo")
+                                .build(),
+                        new ChannelManifest.Builder()
+                                .build(),
+                        null
+                )));
+        List<ChannelVersion> currentVersions = List.of(new ChannelVersion.Builder()
+                .setChannelName("test-channel")
+                .setType(ChannelVersion.Type.OPEN)
+                .setLocation("latest@[central]")
+                .build());
+        UpdateFinder finder = new UpdateFinder(channelSession);
+        final List<Artifact> artifacts = Collections.emptyList();
+        final UpdateSet updates = finder.findUpdates(artifacts, currentVersions);
+
+        assertThat(updates.getChannelVersionChanges())
+                .contains(new ChannelVersionChange("test-channel",
+                        new ChannelVersion.Builder()
+                                .setChannelName("test-channel")
+                                .setType(ChannelVersion.Type.OPEN)
+                                .setLocation("latest@[central]")
+                                .build(),
+                        new ChannelVersion.Builder()
+                                .setChannelName("test-channel")
+                                .setType(ChannelVersion.Type.OPEN)
+                                .setLocation("latest@[central]")
+                                .build())
+                );
+    }
+
+    @Test
+    public void listChannelVersionChangesWithMavenChannelNoHistory() throws Exception {
+        final ChannelManifest.Builder manifestBuilder = new ChannelManifest.Builder();
+        manifestBuilder.setLogicalVersion("Update 1");
+        when(channelSession.getRuntimeChannels())
+                .thenReturn(List.of(new RuntimeChannel(
+                        new Channel.Builder()
+                                .setName("test-channel")
+                                .setManifestCoordinate("t", "c", "1.0.1")
+                                .build(),
+                        manifestBuilder
+                                .build(),
+                        null
+                )));
+        UpdateFinder finder = new UpdateFinder(channelSession);
+        final List<Artifact> artifacts = Collections.emptyList();
+        final UpdateSet updates = finder.findUpdates(artifacts, Collections.emptyList());
+
+        assertThat(updates.getChannelVersionChanges())
+                .contains(new ChannelVersionChange("test-channel",
+                        null,
+                        new ChannelVersion.Builder()
+                                .setChannelName("test-channel")
+                                .setLocation("t:c")
+                                .setPhysicalVersion("1.0.1")
+                                .setLogicalVersion( "Update 1")
+                                .setType(ChannelVersion.Type.MAVEN)
+                                .build()
+                ));
+    }
+
+    @Test
+    public void listChannelVersionChangesWithMavenChannelRemoved() throws Exception {
+        final ChannelManifest.Builder manifestBuilder = new ChannelManifest.Builder();
+        manifestBuilder.setLogicalVersion("Update 1");
+        when(channelSession.getRuntimeChannels())
+                .thenReturn(Collections.emptyList());
+        UpdateFinder finder = new UpdateFinder(channelSession);
+        final List<Artifact> artifacts = Collections.emptyList();
+        List<ChannelVersion> currentVersions = List.of(new ChannelVersion.Builder()
+                .setChannelName("test-channel")
+                .setPhysicalVersion("1.0.0")
+                .setType(ChannelVersion.Type.MAVEN)
+                .setLocation("t:c")
+                .setLogicalVersion("Update 0")
+                .build());
+        final UpdateSet updates = finder.findUpdates(artifacts, currentVersions);
+
+        assertThat(updates.getChannelVersionChanges())
+                .contains(new ChannelVersionChange("test-channel",
+                        new ChannelVersion.Builder()
+                                .setChannelName("test-channel")
+                                .setLocation("t:c")
+                                .setPhysicalVersion("1.0.0")
+                                .setLogicalVersion( "Update 0")
+                                .setType(ChannelVersion.Type.MAVEN)
+                                .build(),
+                        null
+                ));
     }
 }


### PR DESCRIPTION
Fixes #754

- **Add version overwrite to install command**
- **Add support for version overrides in update process**
- **Support prepare/apply**
- **Detect and warn about channel downgrade in an update**
- **Reject implicit downgrade**
- **Initial list-channels command impl**
- **Finish channel-list operation**
- **Clean up ChannelsUpdateResult**
- **Finish list-channels command**
- **Add version parameter to update list operation**
- **Fail the cached manifest resolution is the requested version doesn't match**
- **Deprecate old UpdateAction constructor**
