### PR TITLE
JBEAP-29587 Fix InstallCommand to handle zipped repositories

### DIFF
--- a/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/AbstractInstallCommand.java
+++ b/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/AbstractInstallCommand.java
@@ -21,10 +21,14 @@ import org.eclipse.aether.DefaultRepositorySystemSession;
 import org.eclipse.aether.RepositorySystem;
 import org.jboss.galleon.ProvisioningException;
 import org.wildfly.channel.Channel;
+import org.wildfly.channel.Repository;
 import org.wildfly.channel.maven.VersionResolverFactory;
 import org.wildfly.prospero.api.MavenOptions;
 import org.wildfly.prospero.api.ProvisioningDefinition;
+import org.wildfly.prospero.api.RepositoryUtils;
+import org.wildfly.prospero.api.TemporaryFilesManager;
 import org.wildfly.prospero.api.exceptions.ChannelDefinitionException;
+import org.wildfly.prospero.api.exceptions.InvalidRepositoryArchiveException;
 import org.wildfly.prospero.api.exceptions.MetadataException;
 import org.wildfly.prospero.api.exceptions.NoChannelException;
 import org.wildfly.prospero.cli.ActionFactory;
@@ -100,13 +104,16 @@ public abstract class AbstractInstallCommand extends AbstractCommand {
         return mavenOptions.build();
     }
 
-    protected ProvisioningDefinition buildDefinition() throws MetadataException, NoChannelException, ArgumentParsingException {
+    protected ProvisioningDefinition buildDefinition(TemporaryFilesManager temporaryFiles)
+            throws ArgumentParsingException, InvalidRepositoryArchiveException, NoChannelException, MetadataException {
+        final List<Repository> repositories = RepositoryUtils.unzipArchives(
+                RepositoryDefinition.from(remoteRepositories), temporaryFiles);
         return ProvisioningDefinition.builder()
                 .setFpl(featurePackOrDefinition.fpl.orElse(null))
                 .setProfile(featurePackOrDefinition.profile.orElse(null))
                 .setManifest(manifestCoordinate.orElse(null))
                 .setChannelCoordinates(channelCoordinates)
-                .setOverrideRepositories(RepositoryDefinition.from(remoteRepositories))
+                .setOverrideRepositories(repositories)
                 .setDefinitionFile(featurePackOrDefinition.definition.map(Path::toUri).orElse(null))
                 .build();
     }

--- a/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/CloneCommand.java
+++ b/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/CloneCommand.java
@@ -143,7 +143,7 @@ public class CloneCommand extends AbstractCommand {
             }
             console.println("");
 
-            try (TemporaryFilesManager temporaryFiles = TemporaryFilesManager.getInstance()) {
+            try (TemporaryFilesManager temporaryFiles = TemporaryFilesManager.newInstance()) {
                 List<Repository> repositories = RepositoryDefinition.from(remoteRepositories);
                 actionFactory
                         .restoreAction(installationDirectory, mavenOptions.build(), console)

--- a/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/FeaturesCommand.java
+++ b/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/FeaturesCommand.java
@@ -87,7 +87,7 @@ public class FeaturesCommand extends AbstractParentCommand {
 
             final MavenOptions mavenOptions = parseMavenOptions();
 
-            try (TemporaryFilesManager temporaryFiles = TemporaryFilesManager.getInstance()) {
+            try (TemporaryFilesManager temporaryFiles = TemporaryFilesManager.newInstance()) {
                 final List<Repository> repositories = RepositoryUtils.unzipArchives(
                         RepositoryDefinition.from(temporaryRepositories), temporaryFiles);
 
@@ -138,7 +138,7 @@ public class FeaturesCommand extends AbstractParentCommand {
                 }
 
                 if (accepted) {
-                    try (TemporaryFilesManager temporaryFilesManager = TemporaryFilesManager.getInstance()) {
+                    try (TemporaryFilesManager temporaryFilesManager = TemporaryFilesManager.newInstance()) {
                         final Path candidate = temporaryFilesManager.createTempDirectory("prospero-fp-candidate");
                         final ConfigId configId = parseConfigName(config.orElse(null));
                         if (layers.isEmpty()) {

--- a/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/InstallCommand.java
+++ b/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/InstallCommand.java
@@ -145,11 +145,11 @@ public class InstallCommand extends AbstractInstallCommand {
 
         verifyTargetDirectoryIsEmpty(directory);
 
-        final ProvisioningDefinition provisioningDefinition = buildDefinition();
-        final MavenOptions mavenOptions = getMavenOptions();
-        final ProvisioningConfig provisioningConfig = provisioningDefinition.toProvisioningConfig();
-        final List<Channel> channels = resolveChannels(provisioningDefinition, mavenOptions);
-        try (TemporaryFilesManager temporaryFiles = TemporaryFilesManager.getInstance()) {
+        try (TemporaryFilesManager temporaryFiles = TemporaryFilesManager.newInstance()) {
+            final ProvisioningDefinition provisioningDefinition = buildDefinition(temporaryFiles);
+            final MavenOptions mavenOptions = getMavenOptions();
+            final ProvisioningConfig provisioningConfig = provisioningDefinition.toProvisioningConfig();
+            final List<Channel> channels = resolveChannels(provisioningDefinition, mavenOptions);
             List<Repository> repositories = RepositoryDefinition.from(this.shadowRepositories);
             final List<Repository> shadowRepositories = RepositoryUtils.unzipArchives(repositories, temporaryFiles);
 

--- a/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/PrintLicensesCommand.java
+++ b/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/PrintLicensesCommand.java
@@ -17,12 +17,12 @@
 
 package org.wildfly.prospero.cli.commands;
 
-import org.apache.commons.io.FileUtils;
 import org.jboss.galleon.config.ProvisioningConfig;
 import org.wildfly.channel.Channel;
 import org.wildfly.prospero.actions.ProvisioningAction;
 import org.wildfly.prospero.api.MavenOptions;
 import org.wildfly.prospero.api.ProvisioningDefinition;
+import org.wildfly.prospero.api.TemporaryFilesManager;
 import org.wildfly.prospero.cli.ActionFactory;
 import org.wildfly.prospero.cli.CliConsole;
 import org.wildfly.prospero.cli.CliMessages;
@@ -31,7 +31,6 @@ import org.wildfly.prospero.cli.ReturnCodes;
 import org.wildfly.prospero.licenses.License;
 import picocli.CommandLine;
 
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 
@@ -48,9 +47,9 @@ public class PrintLicensesCommand extends AbstractInstallCommand {
     @Override
     public Integer call() throws Exception {
 
-        final Path tempDirectory = Files.createTempDirectory("tmp-installer");
-        try {
-            final ProvisioningDefinition provisioningDefinition = buildDefinition();
+        try (TemporaryFilesManager temporaryFiles = TemporaryFilesManager.newInstance()) {
+            final Path tempDirectory = temporaryFiles.createTempDirectory("tmp-installer");
+            final ProvisioningDefinition provisioningDefinition = buildDefinition(temporaryFiles);
             final MavenOptions mavenOptions = getMavenOptions();
             final ProvisioningConfig provisioningConfig = provisioningDefinition.toProvisioningConfig();
             final List<Channel> channels = resolveChannels(provisioningDefinition, mavenOptions);
@@ -69,8 +68,6 @@ public class PrintLicensesCommand extends AbstractInstallCommand {
                 console.println(CliMessages.MESSAGES.noAgreementsNeeded());
             }
             return ReturnCodes.SUCCESS;
-        } finally {
-            FileUtils.deleteQuietly(tempDirectory.toFile());
         }
     }
 }

--- a/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/RevertCommand.java
+++ b/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/RevertCommand.java
@@ -102,7 +102,7 @@ public class RevertCommand extends AbstractParentCommand {
             final MavenOptions mavenOptions = parseMavenOptions();
 
             final List<Repository> repositories = RepositoryDefinition.from(temporaryRepositories);
-            try (TemporaryFilesManager temporaryFiles = TemporaryFilesManager.getInstance()) {
+            try (TemporaryFilesManager temporaryFiles = TemporaryFilesManager.newInstance()) {
                 final List<Repository> overrideRepositories = RepositoryUtils.unzipArchives(repositories, temporaryFiles);
 
                 InstallationHistoryAction historyAction = actionFactory.history(installationDirectory, console);
@@ -190,7 +190,7 @@ public class RevertCommand extends AbstractParentCommand {
             final Path installationDirectory = determineInstallationDirectory(directory);
             final MavenOptions mavenOptions = parseMavenOptions();
 
-            try(TemporaryFilesManager temporaryFiles = TemporaryFilesManager.getInstance()) {
+            try(TemporaryFilesManager temporaryFiles = TemporaryFilesManager.newInstance()) {
                 final List<Repository> repositories = RepositoryDefinition.from(temporaryRepositories);
                 final List<Repository> overrideRepositories = RepositoryUtils.unzipArchives(repositories, temporaryFiles);
 

--- a/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/UpdateCommand.java
+++ b/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/UpdateCommand.java
@@ -90,7 +90,7 @@ public class UpdateCommand extends AbstractParentCommand {
             }
 
             final MavenOptions mavenOptions = parseMavenOptions();
-            try (TemporaryFilesManager temporaryFiles = TemporaryFilesManager.getInstance()) {
+            try (TemporaryFilesManager temporaryFiles = TemporaryFilesManager.newInstance()) {
                 final List<Repository> repositories = RepositoryUtils.unzipArchives(
                         RepositoryDefinition.from(temporaryRepositories), temporaryFiles);
 
@@ -163,7 +163,7 @@ public class UpdateCommand extends AbstractParentCommand {
             final Path installationDir = determineInstallationDirectory(directory);
 
             final MavenOptions mavenOptions = parseMavenOptions();
-            try (TemporaryFilesManager temporaryFiles = TemporaryFilesManager.getInstance()) {
+            try (TemporaryFilesManager temporaryFiles = TemporaryFilesManager.newInstance()) {
                 final List<Repository> repositories = RepositoryUtils.unzipArchives(
                         RepositoryDefinition.from(temporaryRepositories), temporaryFiles);
 
@@ -270,7 +270,7 @@ public class UpdateCommand extends AbstractParentCommand {
 
             final MavenOptions mavenOptions = parseMavenOptions();
 
-            try (TemporaryFilesManager temporaryFiles = TemporaryFilesManager.getInstance()) {
+            try (TemporaryFilesManager temporaryFiles = TemporaryFilesManager.newInstance()) {
                 final List<Repository> repositories = RepositoryUtils.unzipArchives(
                         RepositoryDefinition.from(temporaryRepositories), temporaryFiles);
                 console.println(CliMessages.MESSAGES.checkUpdatesHeader(installationDir));

--- a/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/channel/ChannelAddCommand.java
+++ b/prospero-cli/src/main/java/org/wildfly/prospero/cli/commands/channel/ChannelAddCommand.java
@@ -64,7 +64,7 @@ public class ChannelAddCommand extends AbstractCommand {
 
         ChannelManifestCoordinate manifest = ArtifactUtils.manifestCoordFromString(gavUrlOrPath);
 
-        try (TemporaryFilesManager temporaryFiles = TemporaryFilesManager.getInstance()) {
+        try (TemporaryFilesManager temporaryFiles = TemporaryFilesManager.newInstance()) {
             final List<Repository> repositories = RepositoryUtils.unzipArchives(RepositoryDefinition.from(repositoryDefs), temporaryFiles);
 
             Channel channel = new Channel(channelName, null, null, repositories, manifest, null, null);

--- a/prospero-cli/src/main/resources/UsageMessages.properties
+++ b/prospero-cli/src/main/resources/UsageMessages.properties
@@ -317,7 +317,7 @@ prospero.general.error.resolve.streams.header=Required artifact streams are not 
 prospero.general.validation.conflicting_options=Only one of %s and %s can be set.
 prospero.general.validation.local_repo.not_directory=Repository path `%s` is a file not a directory.
 prospero.general.validation.repo_format=Repository definition [%s] is invalid. The definition format should be [id::url] or [url].
-prospero.general.validation.file_path.not_exists=The provided path [%s] doesn't exist or is not accessible. The local repository has to an existing, readable folder.
+prospero.general.validation.file_path.not_exists=The provided path [%s] doesn't exist or is not accessible. The local repository has to be an existing, readable folder.
 prospero.general.validation.file_path.invalid=The given file path [%s] is invalid.
 
 prospero.general.error.missing_file=Required file at `%s` cannot be opened.

--- a/prospero-cli/src/test/java/org/wildfly/prospero/cli/RepositoryDefinitionTest.java
+++ b/prospero-cli/src/test/java/org/wildfly/prospero/cli/RepositoryDefinitionTest.java
@@ -206,8 +206,8 @@ public class RepositoryDefinitionTest {
 
         // On Linux following is interpreted as relative path, on Windows it's an absolute path
         if (SystemUtils.IS_OS_WINDOWS) {
-            assertThat(RepositoryDefinition.parseRepositoryLocation("a:foo/bar", false)) // interpreted as local relative path
-                    .isEqualTo("file:/A:/foo/bar");
+            assertThat(RepositoryDefinition.parseRepositoryLocation("c:foo/bar", false)) // interpreted as local relative path
+                    .isEqualTo("file:/C:/foo/bar");
         } else {
             assertThat(RepositoryDefinition.parseRepositoryLocation("a:foo/bar", false)) // interpreted as local relative path
                     .isEqualTo("file:" + cwdPath + "a:foo/bar");

--- a/prospero-cli/src/test/java/org/wildfly/prospero/cli/RepositoryDefinitionTest.java
+++ b/prospero-cli/src/test/java/org/wildfly/prospero/cli/RepositoryDefinitionTest.java
@@ -169,7 +169,7 @@ public class RepositoryDefinitionTest {
     public void testNonExistingFile() throws Exception {
         Assertions.assertThatThrownBy(() -> from(List.of("idontexist")))
                 .hasMessageContaining(String.format(
-                        "The provided path [%s] doesn't exist or is not accessible. The local repository has to an existing, readable folder.",
+                        "The provided path [%s] doesn't exist or is not accessible. The local repository has to be an existing, readable folder.",
                         Path.of("idontexist").toAbsolutePath()));
     }
 
@@ -177,7 +177,7 @@ public class RepositoryDefinitionTest {
     public void testNonExistingFileUri() throws Exception {
         Assertions.assertThatThrownBy(() -> from(List.of("file:idontexist")))
                 .hasMessageContaining(String.format(
-                        "The provided path [%s] doesn't exist or is not accessible. The local repository has to an existing, readable folder.",
+                        "The provided path [%s] doesn't exist or is not accessible. The local repository has to be an existing, readable folder.",
                         Path.of("idontexist").toAbsolutePath()));
     }
 

--- a/prospero-common/src/main/java/org/wildfly/prospero/api/TemporaryFilesManager.java
+++ b/prospero-common/src/main/java/org/wildfly/prospero/api/TemporaryFilesManager.java
@@ -36,7 +36,7 @@ public class TemporaryFilesManager implements AutoCloseable {
 
     }
 
-    public static TemporaryFilesManager getInstance() {
+    public static TemporaryFilesManager newInstance() {
         return new TemporaryFilesManager();
     }
 

--- a/prospero-common/src/test/java/org/wildfly/prospero/api/RepositoryUtilsTest.java
+++ b/prospero-common/src/test/java/org/wildfly/prospero/api/RepositoryUtilsTest.java
@@ -180,6 +180,6 @@ public class RepositoryUtilsTest {
     }
 
     private static List<Repository> applyOverride(List<Repository> overrideRepositories) throws InvalidRepositoryArchiveException {
-        return RepositoryUtils.unzipArchives(overrideRepositories, TemporaryFilesManager.getInstance());
+        return RepositoryUtils.unzipArchives(overrideRepositories, TemporaryFilesManager.newInstance());
     }
 }


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/JBEAP-29587
Upstream issue: https://issues.redhat.com/browse/JBEAP-29588
Upstream PR: https://github.com/wildfly-extras/prospero/pull/916

* In the install command, the unpacking functionality is only applied on the shadowRepositories field, but not on the remoteRepositories field.
* Rename TemporaryFilesManager.getInstance() to TemporaryFilesManager.newInstance(), because the method really always creates a new instance, and doesn't handle an existing instance in any way.
