### PR TITLE
[JBEAP-30585] - JBoss EAP 8 Update Deletes 'log' Directory Symlink, Causing Startup Failure

### DIFF
--- a/prospero-common/src/main/java/org/wildfly/prospero/actions/ApplyCandidateAction.java
+++ b/prospero-common/src/main/java/org/wildfly/prospero/actions/ApplyCandidateAction.java
@@ -663,6 +663,7 @@ public class ApplyCandidateAction {
 
         // Delete the files in the installation that are not present in the update and not added by the user
         // We need to skip .glnew and .glold.
+        // JBEAP-30585: We need to keep the Symbolic files
         Files.walkFileTree(installationDir, new SimpleFileVisitor<Path>() {
             @Override
             public FileVisitResult visitFile(Path file, BasicFileAttributes attrs)
@@ -670,7 +671,7 @@ public class ApplyCandidateAction {
                 Path relative = installationDir.relativize(file);
                 Path updateFile = updateDir.resolve(relative);
                 final String fsDiffKey = getFsDiffKey(relative, false);
-                if (isNotAddedOrModified(fsDiffKey, fsDiff) && fileNotPresent(updateFile)) {
+                if (isNotAddedOrModified(fsDiffKey, fsDiff) && fileNotPresent(updateFile) && !Files.isSymbolicLink(file)) {
                     if (ProsperoLogger.ROOT_LOGGER.isDebugEnabled()) {
                         ProsperoLogger.ROOT_LOGGER.debug("Deleting the file " + relative + " that doesn't exist in the update");
                     }

--- a/prospero-common/src/test/java/org/wildfly/prospero/actions/ApplyCandidateActionTest.java
+++ b/prospero-common/src/test/java/org/wildfly/prospero/actions/ApplyCandidateActionTest.java
@@ -109,6 +109,34 @@ public class ApplyCandidateActionTest {
         assertThat(conflicts).isEmpty();
     }
 
+    public void testUpdateWithSymlink() throws Exception {
+        final DirState expectedState = dirBuilder
+                .addFile("prod1/p1.txt", "p1 1.0.1")
+                .addDir("log")
+                .addDir("testlog")
+                .build();
+
+        // build test packages
+        createSimpleFeaturePacks();
+
+        // install base and update. perform apply-update
+        install(installationPath, FPL_100);
+
+        //creating SymbolicLink
+        Path symlinkPath = Files.createDirectory(installationPath.resolve("testlog"));
+        Path logPath = installationPath.resolve("log");
+        Files.createSymbolicLink(logPath, symlinkPath);
+
+        prepareUpdate(updatePath, installationPath, FPL_101);
+        final List<FileConflict> conflicts = new ApplyCandidateAction(installationPath, updatePath).applyUpdate(ApplyCandidateAction.Type.UPDATE);
+
+        // verify
+        expectedState.assertState(installationPath);
+        assertThat(conflicts).isEmpty();
+        assertTrue(Files.exists(logPath));
+        assertTrue(Files.isSymbolicLink(logPath));
+    }
+
     @Test
     public void testUpdateWithUserChanges() throws Exception {
         final DirState expectedState = dirBuilder


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/JBEAP-30585
Upstream PR: #927